### PR TITLE
Fix invalid comparison operator

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -127,7 +127,7 @@ main() {
     exit 1
   fi
 
-  if [ "$os" == "darwin" ]; then
+  if [ "$os" = "darwin" ]; then
     machine="all"
   else
     machine=$(get_machine)


### PR DESCRIPTION
When running the installation script in a POSIX-compliant shell without bashisms (like `dash` on Alpine Linux), the shell reports an error:

```
sh: 130: [: linux: unexpected operator
```

The issue lies in the `==` operator, which only exists in Bash, ksh, and some other shells, but is not valid POSIX. This PR fixes the issue by using `=`.

See also https://www.shellcheck.net/wiki/SC3014