### PR TITLE
chore: remove tap from homebrew install instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,6 @@ go install github.com/oasdiff/oasdiff@latest
 
 ### Install on macOS with Brew
 ```bash
-brew tap oasdiff/homebrew-oasdiff
 brew install oasdiff
 ```
 


### PR DESCRIPTION
oasdiff has been moved to homebrew formulae. 
See https://formulae.brew.sh/formula/oasdiff