### PR TITLE
Fix false positive diff when exploded param name matches property name

### DIFF
--- a/data/explode-params/issue-767.yml
+++ b/data/explode-params/issue-767.yml
@@ -1,0 +1,21 @@
+openapi: 3.0.3
+paths:
+    /test:
+        parameters:
+            - $ref: '#/components/parameters/QueryParam'
+
+components:
+    parameters:
+        QueryParam:
+            name: query
+            in: query
+            required: false
+            explode: true
+            schema:
+                $ref: '#/components/schemas/QuerySchema'
+    schemas:
+        QuerySchema:
+            type: object
+            properties:
+                query:
+                    type: string

--- a/diff/parameters_diff_by_location.go
+++ b/diff/parameters_diff_by_location.go
@@ -376,6 +376,12 @@ func matchExplodedWithSimple(config *Config, state *state, simpleParams, explode
 				continue
 			}
 
+			// Skip if this parameter is itself an exploded object parameter
+			// We only want to match truly simple parameters with exploded parameters
+			if isExplodedObjectParam(simpleParam) {
+				continue
+			}
+
 			// Only match simple parameters that are in query or cookie locations
 			// to ensure both simple and exploded params are in compatible locations
 			if !isQueryOrCookieParam(simpleParam) {

--- a/diff/parameters_diff_by_location_test.go
+++ b/diff/parameters_diff_by_location_test.go
@@ -155,6 +155,30 @@ func TestParameterStyleDefaults(t *testing.T) {
 
 }
 
+// TestIssue767_ExplodedParamWithSameNameProperty tests that an exploded object parameter
+// is not mistakenly matched with a property inside its own schema.
+// Regression test for issue #767 where a parameter named "query" with a property named "query"
+// inside its schema was incorrectly matched as semantically equivalent to itself.
+func TestIssue767_ExplodedParamWithSameNameProperty(t *testing.T) {
+	loader := openapi3.NewLoader()
+
+	// Load the same spec twice - should result in no diff
+	s1, err := load.NewSpecInfo(loader, load.NewSource("../data/explode-params/issue-767.yml"))
+	require.NoError(t, err)
+
+	s2, err := load.NewSpecInfo(loader, load.NewSource("../data/explode-params/issue-767.yml"))
+	require.NoError(t, err)
+
+	// Get the diff
+	d, _, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+
+	// The key assertion: identical specs should have no diff
+	// Before the fix, this incorrectly reported modifications because the "query" parameter
+	// was matched with its own "query" property
+	require.Nil(t, d, "Identical specs should result in no diff")
+}
+
 // TestExplodedParameterLocationMatching tests that parameters with the same name
 // but different locations (In field) are NOT matched by exploded parameter logic.
 // This test verifies the location check at parameters_diff_by_location.go:304


### PR DESCRIPTION
## Summary
Fixes #767 - Resolves a bug where comparing identical OpenAPI specs incorrectly reported differences when an exploded object parameter's name matched a property name within its own schema.

## Problem
When running `oasdiff diff` on identical files, the tool incorrectly reported modifications in cases where:
- A parameter has an exploded object schema (e.g., `explode: true`)
- The parameter name matches a property name within that parameter's schema
- Example: A parameter named `query` containing a schema with a property also named `query`

This caused false positive diffs showing type changes and deleted properties that didn't actually exist.

## Root Cause
The exploded parameter semantic equivalence matching logic (introduced in PR #744) was checking if a parameter's name matched properties in exploded object schemas. However, it didn't exclude the case where the parameter being checked was itself an exploded object parameter, leading it to match against properties in its own schema.

## Solution
Added a check in `matchExplodedWithSimple()` to skip parameters that are themselves exploded object parameters when searching for simple parameters to match with exploded parameters. This ensures we only match truly simple parameters with exploded parameters, not exploded parameters with themselves.

## Changes
- **diff/parameters_diff_by_location.go**: Added check to filter out exploded object parameters from the "simple" parameter list before matching
- **diff/parameters_diff_by_location_test.go**: Added regression test `TestIssue767_ExplodedParamWithSameNameProperty`
- **data/explode-params/issue-767.yml**: Added test fixture demonstrating the bug scenario

## Testing
- ✅ New regression test passes
- ✅ All existing tests pass
- ✅ Verified fix resolves the issue: `oasdiff diff test.yml test.yml` now correctly returns no diff

## Test plan
- [x] Run full test suite: `go test ./...`
- [x] Verify regression test: `go test ./diff/... -run TestIssue767`
- [x] Manual verification with issue-767.yml fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)