### PR TITLE
Fix maxItems detection for array parameters (issue #760)

### DIFF
--- a/checker/check_request_parameters_max_items_updated.go
+++ b/checker/check_request_parameters_max_items_updated.go
@@ -24,10 +24,17 @@ func RequestParameterMaxItemsUpdatedCheck(diffReport *diff.Diff, operationsSourc
 			}
 			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
 				for paramName, paramDiff := range paramDiffs {
-					if paramDiff.SchemaDiff == nil || paramDiff.SchemaDiff.ItemsDiff == nil {
+					if paramDiff.SchemaDiff == nil {
 						continue
 					}
-					maxItemsDiff := paramDiff.SchemaDiff.ItemsDiff.MaxItemsDiff
+
+					// Check for maxItems on the parameter schema itself (for array parameters)
+					maxItemsDiff := paramDiff.SchemaDiff.MaxItemsDiff
+					if maxItemsDiff == nil && paramDiff.SchemaDiff.ItemsDiff != nil {
+						// Fallback: check for maxItems on the items schema (legacy behavior)
+						maxItemsDiff = paramDiff.SchemaDiff.ItemsDiff.MaxItemsDiff
+					}
+
 					if maxItemsDiff == nil {
 						continue
 					}

--- a/checker/check_request_parameters_max_items_updated_test.go
+++ b/checker/check_request_parameters_max_items_updated_test.go
@@ -94,3 +94,25 @@ func TestBreaking_RequestParameterMaxItemsWithFlatten(t *testing.T) {
 		OperationId: "createOneGroup",
 	}, errs[0])
 }
+
+// BC: decreasing maxItems on array parameter schema itself (issue #760)
+func TestRequestParameterArrayMaxItemsDecreased(t *testing.T) {
+	s1, err := open("../data/checker/request_parameter_array_max_items_base.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/checker/request_parameter_array_max_items_revision.yaml")
+	require.NoError(t, err)
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestParameterMaxItemsUpdatedCheck), d, osm, checker.ERR)
+	require.Len(t, errs, 1)
+	require.Equal(t, checker.ApiChange{
+		Id:          checker.RequestParameterMaxItemsDecreasedId,
+		Args:        []any{"query", "ids", uint64(50), uint64(10)},
+		Level:       checker.ERR,
+		Operation:   "GET",
+		Path:        "/test",
+		Source:      load.NewSource("../data/checker/request_parameter_array_max_items_revision.yaml"),
+		OperationId: "testOperation",
+	}, errs[0])
+}

--- a/data/checker/request_parameter_array_max_items_base.yaml
+++ b/data/checker/request_parameter_array_max_items_base.yaml
@@ -1,0 +1,19 @@
+openapi: 3.0.3
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /test:
+    get:
+      operationId: testOperation
+      parameters:
+        - name: ids
+          in: query
+          schema:
+            type: array
+            maxItems: 50
+            items:
+              type: string
+      responses:
+        '200':
+          description: OK

--- a/data/checker/request_parameter_array_max_items_revision.yaml
+++ b/data/checker/request_parameter_array_max_items_revision.yaml
@@ -1,0 +1,19 @@
+openapi: 3.0.3
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /test:
+    get:
+      operationId: testOperation
+      parameters:
+        - name: ids
+          in: query
+          schema:
+            type: array
+            maxItems: 10
+            items:
+              type: string
+      responses:
+        '200':
+          description: OK


### PR DESCRIPTION
## Summary
Fixes #760 - The `oasdiff breaking` command was not detecting when `maxItems` is decreased on array query parameters because the checker was looking in the wrong location in the schema structure.

## Problem
When `maxItems` is set directly on an array parameter schema (the correct location per OpenAPI spec), the checker failed to detect changes. For example:

```yaml
parameters:
  - name: ids
    in: query
    schema:
      type: array
      maxItems: 50  # <-- maxItems here (on the array schema)
      items:
        type: string
```

When `maxItems` changed from 50 to 10, `oasdiff diff` would report it, but `oasdiff breaking` would not flag it as a breaking change.

## Root Cause
The checker was only looking for `maxItems` in `paramDiff.SchemaDiff.ItemsDiff.MaxItemsDiff` (on the items schema) but not in `paramDiff.SchemaDiff.MaxItemsDiff` (on the parameter schema itself).

This worked for a legacy pattern where `maxItems` was incorrectly placed on the items schema, but failed for the correct OpenAPI specification pattern.

## Solution
Updated `RequestParameterMaxItemsUpdatedCheck` to check both locations:
1. **First**: Check `maxItems` on the parameter schema itself (correct per spec)
2. **Fallback**: Check `maxItems` on the items schema (for backward compatibility)

## Changes
- **checker/check_request_parameters_max_items_updated.go**: Updated logic to check both locations
- **checker/check_request_parameters_max_items_updated_test.go**: Added `TestRequestParameterArrayMaxItemsDecreased`
- **data/checker/request_parameter_array_max_items_*.yaml**: Added test fixtures

## Testing
- ✅ New test `TestRequestParameterArrayMaxItemsDecreased` passes
- ✅ All existing maxItems tests pass
- ✅ Full checker test suite passes

## Test plan
- [x] Run maxItems tests: `go test github.com/oasdiff/oasdiff/checker -run ".*MaxItems" -v`
- [x] Run full checker suite: `go test github.com/oasdiff/oasdiff/checker`
- [x] Verify the fix resolves issue #760 scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)