### PR TITLE
Migrate from gopkg.in/yaml.v3 to go.yaml.in/yaml/v3

### DIFF
--- a/checker/generator/tree.go
+++ b/checker/generator/tree.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type ChangeTree struct {

--- a/diff/example_test.go
+++ b/diff/example_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func ExampleGet() {

--- a/formatters/format_yaml.go
+++ b/formatters/format_yaml.go
@@ -7,7 +7,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/diff"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type YAMLFormatter struct {

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/yargevad/filepathx v1.0.0
 	github.com/yuin/goldmark v1.7.16
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -33,9 +33,9 @@ require (
 	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect
 	github.com/woodsbury/decimal128 v1.3.0 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (

--- a/internal/run_test.go
+++ b/internal/run_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/oasdiff/oasdiff/formatters"
 	"github.com/oasdiff/oasdiff/internal"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func cmdToArgs(cmd string) []string {


### PR DESCRIPTION
## Summary
- Replace archived `gopkg.in/yaml.v3` with maintained `go.yaml.in/yaml/v3` in all 4 direct usages
- The new module is maintained by the official YAML org and is API-compatible

Closes #768

## Test plan
- [x] All tests pass
- [x] Build succeeds
- [x] `go mod tidy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)