### PR TITLE
feat: add --exclude-extensions flag to exclude specific extension names

### DIFF
--- a/diff/config.go
+++ b/diff/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	PathStripPrefixBase     string
 	PathStripPrefixRevision string
 	ExcludeElements         utils.StringSet
+	ExcludeExtensions       utils.StringSet
 	IncludePathParams       bool
 }
 
@@ -40,12 +41,18 @@ func GetExcludeDiffOptions() []string {
 // NewConfig returns a default configuration
 func NewConfig() *Config {
 	return &Config{
-		ExcludeElements: utils.StringSet{},
+		ExcludeElements:   utils.StringSet{},
+		ExcludeExtensions: utils.StringSet{},
 	}
 }
 
 func (config *Config) WithExcludeElements(excludeElements []string) *Config {
 	config.ExcludeElements = utils.StringList(excludeElements).ToStringSet()
+	return config
+}
+
+func (config *Config) WithExcludeExtensions(excludeExtensions []string) *Config {
+	config.ExcludeExtensions = utils.StringList(excludeExtensions).ToStringSet()
 	return config
 }
 
@@ -71,6 +78,11 @@ func (config *Config) IsExcludeSummary() bool {
 
 func (config *Config) IsExcludeExtensions() bool {
 	return config.ExcludeElements.Contains(ExcludeExtensionsOption)
+}
+
+// IsExcludedExtension checks if a specific extension name should be excluded from diff
+func (config *Config) IsExcludedExtension(name string) bool {
+	return config.ExcludeExtensions.Contains(name)
 }
 
 const (

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -872,6 +872,37 @@ func TestDiff_ExtensionsExcluded(t *testing.T) {
 	require.Empty(t, d)
 }
 
+func TestDiff_ExtensionsExcludeSpecificName(t *testing.T) {
+	loader := openapi3.NewLoader()
+
+	s1, err := load.NewSpecInfo(loader, load.NewSource("../data/extensions/base.yaml"))
+	require.NoError(t, err)
+
+	s2, err := load.NewSpecInfo(loader, load.NewSource("../data/extensions/revision.yaml"))
+	require.NoError(t, err)
+
+	// Exclude the specific extension that has changes
+	d, _, err := diff.GetWithOperationsSourcesMap(diff.NewConfig().WithExcludeExtensions([]string{"x-amazon-apigateway-integration"}), s1, s2)
+	require.NoError(t, err)
+	require.Empty(t, d)
+}
+
+func TestDiff_ExtensionsExcludeUnrelatedName(t *testing.T) {
+	loader := openapi3.NewLoader()
+
+	s1, err := load.NewSpecInfo(loader, load.NewSource("../data/extensions/base.yaml"))
+	require.NoError(t, err)
+
+	s2, err := load.NewSpecInfo(loader, load.NewSource("../data/extensions/revision.yaml"))
+	require.NoError(t, err)
+
+	// Exclude a different extension name - should still show the diff for x-amazon-apigateway-integration
+	d, _, err := diff.GetWithOperationsSourcesMap(diff.NewConfig().WithExcludeExtensions([]string{"x-unrelated"}), s1, s2)
+	require.NoError(t, err)
+	dd := d.PathsDiff.Modified["/example/callback"].OperationsDiff.Modified["POST"].ExtensionsDiff.Modified["x-amazon-apigateway-integration"]
+	require.Len(t, dd, 2)
+}
+
 func TestDiff_ExtensionsInvalid(t *testing.T) {
 	s1, err := load.NewSpecInfo(openapi3.NewLoader(), load.NewSource("../data/extensions/base.yaml"))
 	require.NoError(t, err)

--- a/diff/extensions_diff.go
+++ b/diff/extensions_diff.go
@@ -13,7 +13,11 @@ func getExtensionsDiff(config *Config, extensions1, extensions2 map[string]any) 
 		return nil, nil
 	}
 
-	diff, err := getExtensionsDiffInternal(extensions1, extensions2)
+	// Filter out excluded extension names
+	filtered1 := filterExtensions(extensions1, config)
+	filtered2 := filterExtensions(extensions2, config)
+
+	diff, err := getExtensionsDiffInternal(filtered1, filtered2)
 	if err != nil {
 		return nil, err
 	}
@@ -27,4 +31,19 @@ func getExtensionsDiff(config *Config, extensions1, extensions2 map[string]any) 
 
 func getExtensionsDiffInternal(extensions1, extensions2 map[string]any) (*InterfaceMapDiff, error) {
 	return getInterfaceMapDiff(extensions1, extensions2)
+}
+
+// filterExtensions returns a copy of the extensions map with excluded extensions removed
+func filterExtensions(extensions map[string]any, config *Config) map[string]any {
+	if len(config.ExcludeExtensions) == 0 {
+		return extensions
+	}
+
+	filtered := make(map[string]any)
+	for name, value := range extensions {
+		if !config.IsExcludedExtension(name) {
+			filtered[name] = value
+		}
+	}
+	return filtered
 }

--- a/docs/DIFF.md
+++ b/docs/DIFF.md
@@ -83,7 +83,7 @@ endpoints:
                           path: /uri
 ```
 
-### Excluding Specific Kinds of Changes 
+### Excluding Specific Kinds of Changes
 You can use the `--exclude-elements` flag with to exclude one or more of the following:
 - Use `--exclude-elements examples` to exclude [Examples](https://swagger.io/specification/#example-object)
 - Use `--exclude-elements extensions` to exclude [Extensions](https://swagger.io/specification/#specification-extensions)
@@ -96,6 +96,17 @@ For example, this diff excludes descriptions and examples:
 ```
 oasdiff diff data/openapi-test1.yaml data/openapi-test3.yaml --exclude-elements description,examples -f text
 ```
+
+### Excluding Specific Extension Names
+If you want to exclude specific [OpenAPI extensions](https://swagger.io/docs/specification/openapi-extensions/) by name while keeping others, use the `--exclude-extensions` flag.
+This is different from `--exclude-elements extensions` which excludes ALL extensions.
+
+For example, to exclude only `x-internal` and `x-ignore` extensions while keeping all others:
+```
+oasdiff diff base.yaml revision.yaml --exclude-extensions x-internal,x-ignore
+```
+
+This is useful when you have extensions that are only used internally or for tooling purposes (e.g., `x-codegen-ignore`, `x-internal`) and you don't want changes to these extensions to appear in the diff.
 
 ### Additional Options
 - [Merging AllOf Schemas](ALLOF.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,6 +70,7 @@ docker run --rm -t tufin/oasdiff changelog https://raw.githubusercontent.com/oas
 - [Path prefix modification](PATH-PREFIX.md)
 - [Path parameter renaming](PATH-PARAM-RENAME.md)
 - [Exclude certain kinds of changes](DIFF.md#excluding-specific-kinds-of-changes)
+- [Exclude specific extension names](DIFF.md#excluding-specific-extension-names)
 - [Track changes to OpenAPI Extensions](DIFF.md#openapi-extensions)
 - [Filter endpoints](FILTERING-ENDPOINTS.md)
 - [Extend breaking changes with custom checks](CUSTOMIZING-CHECKS.md)

--- a/examples/oasdiff.yaml
+++ b/examples/oasdiff.yaml
@@ -3,9 +3,9 @@
 # Place in the directory where the command is run
 format: json
 color: never
-attributes: 
+attributes:
 - x-beta
-- x-extension-test 
+- x-extension-test
 composed: false
 flatten-allof: true
 err-ignore: ignore-err-example.txt
@@ -14,3 +14,8 @@ fail-on: ERR
 level: INFO
 exclude-elements:
 - endpoints
+# exclude-extensions allows excluding specific extension names from diff
+# (unlike exclude-elements extensions which excludes ALL extensions)
+# exclude-extensions:
+# - x-internal
+# - x-codegen-ignore

--- a/internal/cmd_flags.go
+++ b/internal/cmd_flags.go
@@ -20,6 +20,7 @@ func addCommonDiffFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().Bool("flatten-allof", false, "merge subschemas under allOf before diff")
 	cmd.PersistentFlags().Bool("flatten-params", false, "merge common parameters at path level with operation parameters")
 	cmd.PersistentFlags().Bool("case-insensitive-headers", false, "case-insensitive header name comparison")
+	cmd.PersistentFlags().StringSlice("exclude-extensions", nil, "OpenAPI Extension names to exclude from diff (e.g., x-internal)")
 
 	addHiddenFlattenFlag(cmd)
 	addHiddenCircularDepFlag(cmd)

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -19,7 +19,9 @@ func NewFlags() *Flags {
 }
 
 func (flags *Flags) toConfig() *diff.Config {
-	config := diff.NewConfig().WithExcludeElements(flags.getExcludeElements())
+	config := diff.NewConfig().
+		WithExcludeElements(flags.getExcludeElements()).
+		WithExcludeExtensions(flags.getExcludeExtensions())
 	config.MatchPath = flags.v.GetString("match-path")
 	config.UnmatchPath = flags.v.GetString("unmatch-path")
 	config.FilterExtension = flags.v.GetString("filter-extension")
@@ -114,6 +116,10 @@ func (flags *Flags) getSeverityLevelsFile() string {
 
 func (flags *Flags) getExcludeElements() []string {
 	return fixViperStringSlice(flags.v.GetStringSlice("exclude-elements"))
+}
+
+func (flags *Flags) getExcludeExtensions() []string {
+	return fixViperStringSlice(flags.v.GetStringSlice("exclude-extensions"))
 }
 
 func (flags *Flags) setBase(source *load.Source) {

--- a/internal/run_test.go
+++ b/internal/run_test.go
@@ -368,6 +368,18 @@ func Test_JsonWithExcludeElements(t *testing.T) {
 	require.Zero(t, internal.Run(cmdToArgs("oasdiff diff --format json --exclude-elements=description,title,summary ../data/description/spec1.yml ../data/description/spec2.yml --fail-on-diff"), io.Discard, io.Discard))
 }
 
+// Test_ExcludeExtensions tests the --exclude-extensions flag (issue #765)
+func Test_ExcludeExtensions(t *testing.T) {
+	// With --exclude-extensions flag, the x-amazon-apigateway-integration changes should be excluded
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff diff ../data/extensions/base.yaml ../data/extensions/revision.yaml --exclude-extensions x-amazon-apigateway-integration --fail-on-diff"), io.Discard, io.Discard))
+}
+
+// Test_ExcludeExtensionsMultiple tests excluding multiple extension names
+func Test_ExcludeExtensionsMultiple(t *testing.T) {
+	// Should work with comma-separated values
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff diff ../data/extensions/base.yaml ../data/extensions/revision.yaml --exclude-extensions x-amazon-apigateway-integration,x-other-extension --fail-on-diff"), io.Discard, io.Discard))
+}
+
 func Test_EmptyComponentsOmitted(t *testing.T) {
 	var stdout bytes.Buffer
 	require.Zero(t, internal.Run(cmdToArgs("oasdiff diff ../data/version/base.yaml ../data/version/revision.yaml -f json"), &stdout, io.Discard))

--- a/internal/viper.go
+++ b/internal/viper.go
@@ -97,6 +97,7 @@ type Config struct {
 	FailOnDiff             bool     `mapstructure:"fail-on-diff"`
 	SeverityLevels         string   `mapstructure:"severity-levels"`
 	ExcludeElements        []string `mapstructure:"exclude-elements"`
+	ExcludeExtensions      []string `mapstructure:"exclude-extensions"`
 	Severity               []string `mapstructure:"severity"`
 	Tags                   []string `mapstructure:"tags"`
 	MatchPath              string   `mapstructure:"match-path"`


### PR DESCRIPTION
## Summary
- Adds new `--exclude-extensions` CLI flag to exclude specific OpenAPI extension names from diff
- Unlike `--exclude-elements extensions` which excludes ALL extensions, this provides fine-grained control
- Supports multiple extensions via comma separation or repeated flag usage
- Also works via config file (`oasdiff.yaml`)

Closes #765

## Usage
```bash
# Exclude specific extension
oasdiff diff base.yaml revision.yaml --exclude-extensions x-internal

# Exclude multiple extensions
oasdiff diff base.yaml revision.yaml --exclude-extensions x-internal,x-ignore
```

Config file:
```yaml
exclude-extensions:
  - x-internal
  - x-ignore
```

## Test plan
- [x] Added unit tests for exclude-extensions in diff package
- [x] Added CLI integration tests in internal package
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)