### PR TITLE
chore: upgrade actions/checkout from v4 to v6

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install Go
       uses: actions/setup-go@v5

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     
-      - name: Check Out Repo 
-        uses: actions/checkout@v4
+      - name: Check Out Repo
+        uses: actions/checkout@v6
 
       - name: Extract Metadata
         id: meta

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
 
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - uses: actions/setup-go@v5
       with:

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -11,7 +11,7 @@ jobs:
     name: check-links
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         config-file: '.github/workflows/mlc_config.json'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
         with:
           go-version: '1.25'

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # See: https://goreleaser.com/ci/actions/
 


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` from v4 to v6 across all GitHub Actions workflow files
- Applies to: claude.yml, codeql-analysis.yml, docker.yml, go.yml, links.yml, lint.yml, release_build.yml

## Test plan
- [ ] Verify CI workflows run successfully with the new action version

🤖 Generated with [Claude Code](https://claude.com/claude-code)