### PR TITLE
feat: support git revision syntax for spec paths

### DIFF
--- a/docs/GIT-REVISION.md
+++ b/docs/GIT-REVISION.md
@@ -1,0 +1,71 @@
+# Loading Specs from Git Revisions
+
+oasdiff can load OpenAPI specs directly from any git revision using the standard `<ref>:<path>` syntax — no extra flags, no temp files, no manual `git show` steps.
+
+## Syntax
+
+```
+<git-ref>:<path-to-spec>
+```
+
+Examples:
+
+| Expression | Meaning |
+|---|---|
+| `HEAD:openapi.yaml` | Spec at `openapi.yaml` in the current commit |
+| `HEAD~1:openapi.yaml` | Spec one commit before the current HEAD |
+| `origin/main:openapi.yaml` | Spec at `openapi.yaml` on the remote `main` branch |
+| `v2.3.0:api/openapi.yaml` | Spec at `api/openapi.yaml` at tag `v2.3.0` |
+| `abc1234:openapi.yaml` | Spec at a specific commit SHA |
+
+## Usage
+
+Compare the current working-tree spec against the version on `origin/main`:
+
+```bash
+oasdiff breaking origin/main:openapi.yaml openapi.yaml
+```
+
+Compare across two tags:
+
+```bash
+oasdiff changelog v1.0.0:openapi.yaml v2.0.0:openapi.yaml
+```
+
+Compare yesterday's `HEAD` against today's:
+
+```bash
+oasdiff diff HEAD~1:openapi.yaml HEAD:openapi.yaml
+```
+
+## How it works
+
+oasdiff detects the `<ref>:<path>` pattern and runs `git show <ref>:<path>` internally to retrieve the spec content. Relative `$ref`s in the spec are resolved against the spec's path, matching the behaviour of loading from a local file.
+
+The command must be run from within the git repository that contains the spec.
+
+## GitHub Actions
+
+Git revision syntax is particularly useful in CI/CD. The following workflow detects breaking changes between the base branch and the PR branch without needing a separate checkout step or temp files:
+
+```yaml
+name: API breaking changes
+
+on:
+  pull_request:
+
+jobs:
+  oasdiff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0          # full history needed for git refs
+
+      - uses: oasdiff/oasdiff-action/breaking@v0.0.30
+        with:
+          base: 'origin/${{ github.base_ref }}:openapi.yaml'
+          revision: 'HEAD:openapi.yaml'
+```
+
+> **Note:** `fetch-depth: 0` is required. The default shallow clone used by `actions/checkout` does not contain the history or remote refs that git revision syntax relies on.

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,7 +60,7 @@ docker run --rm -t tufin/oasdiff changelog https://raw.githubusercontent.com/oas
 - Generate comprehensive [diff](DIFF.md) reports including all aspects of [OpenAPI Specification](https://swagger.io/specification/): paths, operations, parameters, request bodies, responses, schemas, enums, callbacks, security etc.
 - Output reports in YAML, JSON, Text, Markdown, HTML, JUnit XML or the [github actions annotation format](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-warning-message)
 - [Customize HTML and Markdown changelog reports](USAGE_EXAMPLES.md#openapi-changelog-with-custom-template)
-- Compare local specs or remote specs over http/s
+- Compare specs from local files, http/s URLs, or [git revisions](GIT-REVISION.md)
 - Compare specs in YAML or JSON format
 - [Compare two collections of specs](COMPOSED.md)
 - [Deprecate APIs and Parameters](DEPRECATION.md)

--- a/load/load.go
+++ b/load/load.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -28,9 +27,9 @@ func from(loader *openapi3.Loader, source *Source) (*openapi3.T, error) {
 }
 
 // loadFromGitRevision loads an OpenAPI spec from a git revision reference (e.g. "origin/main:openapi.yaml").
-// It runs "git show <ref>" to obtain the content, writes it to a temp file in the same directory as
-// the spec path (so that relative $refs resolve correctly), and loads from that temp file.
-func loadFromGitRevision(loader Loader, gitRef string) (*openapi3.T, error) {
+// It runs "git show <ref>" to obtain the content and loads it via LoadFromDataWithPath so that
+// relative $refs are resolved against the spec's path.
+func loadFromGitRevision(loader *openapi3.Loader, gitRef string) (*openapi3.T, error) {
 	out, err := exec.Command("git", "show", gitRef).Output()
 	if err != nil {
 		var exitErr *exec.ExitError
@@ -41,19 +40,8 @@ func loadFromGitRevision(loader Loader, gitRef string) (*openapi3.T, error) {
 	}
 
 	specPath := gitRef[strings.Index(gitRef, ":")+1:]
-	tmpFile, err := os.CreateTemp(filepath.Dir(specPath), "oasdiff-*.yaml")
-	if err != nil {
-		return nil, fmt.Errorf("failed to create temp file for git revision %q: %w", gitRef, err)
-	}
-	defer os.Remove(tmpFile.Name())
-
-	if _, err = tmpFile.Write(out); err != nil {
-		tmpFile.Close()
-		return nil, fmt.Errorf("failed to write temp file for git revision %q: %w", gitRef, err)
-	}
-	tmpFile.Close()
-
-	return loader.LoadFromFile(tmpFile.Name())
+	u := &url.URL{Path: filepath.ToSlash(specPath)}
+	return loader.LoadFromDataWithPath(out, u)
 }
 
 func getURL(rawURL string) (*url.URL, error) {

--- a/load/load.go
+++ b/load/load.go
@@ -1,8 +1,13 @@
 package load
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
 )
@@ -15,9 +20,40 @@ func from(loader *openapi3.Loader, source *Source) (*openapi3.T, error) {
 		return loader.LoadFromStdin()
 	case SourceTypeURL:
 		return loader.LoadFromURI(source.Uri)
+	case SourceTypeGitRevision:
+		return loadFromGitRevision(loader, source.Path)
 	default:
 		return loader.LoadFromFile(source.Path)
 	}
+}
+
+// loadFromGitRevision loads an OpenAPI spec from a git revision reference (e.g. "origin/main:openapi.yaml").
+// It runs "git show <ref>" to obtain the content, writes it to a temp file in the same directory as
+// the spec path (so that relative $refs resolve correctly), and loads from that temp file.
+func loadFromGitRevision(loader Loader, gitRef string) (*openapi3.T, error) {
+	out, err := exec.Command("git", "show", gitRef).Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+			return nil, fmt.Errorf("failed to load spec from git revision %q: %s", gitRef, strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return nil, fmt.Errorf("failed to load spec from git revision %q: %w", gitRef, err)
+	}
+
+	specPath := gitRef[strings.Index(gitRef, ":")+1:]
+	tmpFile, err := os.CreateTemp(filepath.Dir(specPath), "oasdiff-*.yaml")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp file for git revision %q: %w", gitRef, err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err = tmpFile.Write(out); err != nil {
+		tmpFile.Close()
+		return nil, fmt.Errorf("failed to write temp file for git revision %q: %w", gitRef, err)
+	}
+	tmpFile.Close()
+
+	return loader.LoadFromFile(tmpFile.Name())
 }
 
 func getURL(rawURL string) (*url.URL, error) {

--- a/load/source.go
+++ b/load/source.go
@@ -3,6 +3,7 @@ package load
 import (
 	"fmt"
 	"net/url"
+	"strings"
 )
 
 type SourceType int
@@ -11,6 +12,7 @@ const (
 	SourceTypeStdin SourceType = iota
 	SourceTypeURL
 	SourceTypeFile
+	SourceTypeGitRevision
 )
 
 type Source struct {
@@ -41,6 +43,13 @@ func NewSource(path string) *Source {
 		}
 	}
 
+	if isGitRevision(path) {
+		return &Source{
+			Path: path,
+			Type: SourceTypeGitRevision,
+		}
+	}
+
 	uri, err := getURL(path)
 	if err == nil {
 		return &Source{
@@ -54,6 +63,20 @@ func NewSource(path string) *Source {
 		Path: path,
 		Type: SourceTypeFile,
 	}
+}
+
+// isGitRevision returns true if path looks like a git revision spec (e.g. "origin/main:openapi.yaml" or "HEAD~1:spec.yaml").
+// It excludes URLs (contain "://") and Windows drive letters (single uppercase letter before ":").
+func isGitRevision(path string) bool {
+	idx := strings.Index(path, ":")
+	if idx < 0 || strings.Contains(path, "://") {
+		return false
+	}
+	// Single uppercase letter before colon = Windows drive letter (C:, D:, …)
+	if idx == 1 && path[0] >= 'A' && path[0] <= 'Z' {
+		return false
+	}
+	return true
 }
 
 func (source *Source) String() string {
@@ -73,4 +96,8 @@ func (source *Source) IsStdin() bool {
 
 func (source *Source) IsFile() bool {
 	return source.Type == SourceTypeFile
+}
+
+func (source *Source) IsGitRevision() bool {
+	return source.Type == SourceTypeGitRevision
 }

--- a/load/source_test.go
+++ b/load/source_test.go
@@ -26,3 +26,17 @@ func TestSource_OutStdin(t *testing.T) {
 func TestSource_Out(t *testing.T) {
 	require.Equal(t, `"http://twitter.com"`, load.NewSource("http://twitter.com").Out())
 }
+
+func TestSource_IsGitRevision(t *testing.T) {
+	require.True(t, load.NewSource("origin/main:openapi.yaml").IsGitRevision())
+	require.True(t, load.NewSource("HEAD~1:spec.yaml").IsGitRevision())
+	require.True(t, load.NewSource("HEAD:dir/spec.yaml").IsGitRevision())
+}
+
+func TestSource_IsNotGitRevision(t *testing.T) {
+	require.False(t, load.NewSource("openapi.yaml").IsGitRevision())
+	require.False(t, load.NewSource("-").IsGitRevision())
+	require.False(t, load.NewSource("http://example.com/spec.yaml").IsGitRevision())
+	require.False(t, load.NewSource("https://example.com/spec.yaml").IsGitRevision())
+	require.False(t, load.NewSource(`C:\path\spec.yaml`).IsGitRevision())
+}

--- a/load/spec_info_git_test.go
+++ b/load/spec_info_git_test.go
@@ -1,0 +1,82 @@
+//go:build unix
+
+package load_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/oasdiff/oasdiff/load"
+	"github.com/stretchr/testify/require"
+)
+
+const minimalSpec = `openapi: "3.0.0"
+info:
+  title: Test
+  version: "1.0"
+paths: {}
+`
+
+// TestLoadInfo_GitRevision creates a real git repo, commits a spec, and verifies
+// that NewSpecInfo can load it via git revision syntax (e.g. "HEAD:openapi.yaml").
+func TestLoadInfo_GitRevision(t *testing.T) {
+	dir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(out))
+	}
+
+	run("git", "init")
+	run("git", "config", "user.email", "test@test.com")
+	run("git", "config", "user.name", "Test")
+
+	specPath := filepath.Join(dir, "openapi.yaml")
+	require.NoError(t, os.WriteFile(specPath, []byte(minimalSpec), 0644))
+
+	run("git", "add", "openapi.yaml")
+	run("git", "commit", "-m", "add spec")
+
+	oldDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	defer os.Chdir(oldDir) //nolint:errcheck
+
+	specInfo, err := load.NewSpecInfo(MockLoader{}, load.NewSource("HEAD:openapi.yaml"))
+	require.NoError(t, err)
+	require.Equal(t, "1.0", specInfo.GetVersion())
+}
+
+func TestLoadInfo_GitRevisionNotFound(t *testing.T) {
+	dir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(out))
+	}
+
+	run("git", "init")
+	run("git", "config", "user.email", "test@test.com")
+	run("git", "config", "user.name", "Test")
+
+	specPath := filepath.Join(dir, "openapi.yaml")
+	require.NoError(t, os.WriteFile(specPath, []byte(minimalSpec), 0644))
+	run("git", "add", "openapi.yaml")
+	run("git", "commit", "-m", "add spec")
+
+	oldDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	defer os.Chdir(oldDir) //nolint:errcheck
+
+	_, err = load.NewSpecInfo(MockLoader{}, load.NewSource("HEAD:nonexistent.yaml"))
+	require.ErrorContains(t, err, "failed to load spec from git revision")
+}

--- a/load/spec_info_git_test.go
+++ b/load/spec_info_git_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/load"
 	"github.com/stretchr/testify/require"
 )
@@ -47,7 +48,7 @@ func TestLoadInfo_GitRevision(t *testing.T) {
 	require.NoError(t, os.Chdir(dir))
 	defer os.Chdir(oldDir) //nolint:errcheck
 
-	specInfo, err := load.NewSpecInfo(MockLoader{}, load.NewSource("HEAD:openapi.yaml"))
+	specInfo, err := load.NewSpecInfo(openapi3.NewLoader(), load.NewSource("HEAD:openapi.yaml"))
 	require.NoError(t, err)
 	require.Equal(t, "1.0", specInfo.GetVersion())
 }
@@ -77,6 +78,6 @@ func TestLoadInfo_GitRevisionNotFound(t *testing.T) {
 	require.NoError(t, os.Chdir(dir))
 	defer os.Chdir(oldDir) //nolint:errcheck
 
-	_, err = load.NewSpecInfo(MockLoader{}, load.NewSource("HEAD:nonexistent.yaml"))
+	_, err = load.NewSpecInfo(openapi3.NewLoader(), load.NewSource("HEAD:nonexistent.yaml"))
 	require.ErrorContains(t, err, "failed to load spec from git revision")
 }

--- a/load/spec_info_git_test.go
+++ b/load/spec_info_git_test.go
@@ -81,3 +81,9 @@ func TestLoadInfo_GitRevisionNotFound(t *testing.T) {
 	_, err = load.NewSpecInfo(openapi3.NewLoader(), load.NewSource("HEAD:nonexistent.yaml"))
 	require.ErrorContains(t, err, "failed to load spec from git revision")
 }
+
+func TestLoadInfo_GitRevisionNoGit(t *testing.T) {
+	t.Setenv("PATH", t.TempDir()) // remove git from PATH
+	_, err := load.NewSpecInfo(openapi3.NewLoader(), load.NewSource("HEAD:openapi.yaml"))
+	require.ErrorContains(t, err, "failed to load spec from git revision")
+}


### PR DESCRIPTION
## Summary

- Adds `SourceTypeGitRevision` to the `load` package so that paths like `origin/main:openapi.yaml` or `HEAD~1:spec.yaml` are recognised natively
- `NewSource()` detects the `<ref>:<path>` pattern — excluded URLs (`://`) and Windows drive letters (single uppercase letter before `:`)
- `loadFromGitRevision()` runs `git show <ref>:<path>` and loads the output via `LoadFromDataWithPath`, passing the spec path as the URL so that relative `$ref`s resolve correctly — no temp file needed
- Clear error messages include the git stderr when the ref or path doesn't exist

## Motivation

Previously, using oasdiff in GitHub Actions required an extra manual step:

```yaml
- run: git show origin/${{ github.base_ref }}:openapi.yaml > /tmp/base.yaml
- uses: oasdiff/oasdiff-action/pr-comment@v0.0.30
  with:
    base: /tmp/base.yaml
    revision: openapi.yaml
```

After this change, the workflow collapses to:

```yaml
- uses: oasdiff/oasdiff-action/breaking@v0.0.30
  with:
    base: 'origin/${{ github.base_ref }}:openapi.yaml'
    revision: 'HEAD:openapi.yaml'
```

## Test plan

- [ ] `TestSource_IsGitRevision` — detection of valid git revision patterns
- [ ] `TestSource_IsNotGitRevision` — non-git paths (files, URLs, Windows drive letters) are not misclassified
- [ ] `TestLoadInfo_GitRevision` — end-to-end: real git repo, committed spec, loaded via `HEAD:openapi.yaml`
- [ ] `TestLoadInfo_GitRevisionNotFound` — clear error when ref or path doesn't exist
- [ ] Full `./load/...` test suite passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)