### PR TITLE
fix: add git to Docker image and improve missing-git error message

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN VERSION=$(git describe --always --tags) && \
 
 ### Create image ###
 FROM alpine:3
+RUN apk add --no-cache git
 WORKDIR /usr/bin
 COPY --from=builder /go/src/app/oasdiff .
 ENTRYPOINT ["/usr/bin/oasdiff"]

--- a/load/load.go
+++ b/load/load.go
@@ -36,7 +36,7 @@ func loadFromGitRevision(loader *openapi3.Loader, gitRef string) (*openapi3.T, e
 		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
 			return nil, fmt.Errorf("failed to load spec from git revision %q: %s", gitRef, strings.TrimSpace(string(exitErr.Stderr)))
 		}
-		return nil, fmt.Errorf("failed to load spec from git revision %q: %w", gitRef, err)
+		return nil, fmt.Errorf("failed to load spec from git revision %q (is git installed and in PATH?): %w", gitRef, err)
 	}
 
 	specPath := gitRef[strings.Index(gitRef, ":")+1:]

--- a/load/spec_info_git_test.go
+++ b/load/spec_info_git_test.go
@@ -85,5 +85,5 @@ func TestLoadInfo_GitRevisionNotFound(t *testing.T) {
 func TestLoadInfo_GitRevisionNoGit(t *testing.T) {
 	t.Setenv("PATH", t.TempDir()) // remove git from PATH
 	_, err := load.NewSpecInfo(openapi3.NewLoader(), load.NewSource("HEAD:openapi.yaml"))
-	require.ErrorContains(t, err, "failed to load spec from git revision")
+	require.ErrorContains(t, err, "is git installed and in PATH?")
 }


### PR DESCRIPTION
## Summary

- Adds `git` to the Alpine Docker image — required for git revision syntax (`origin/main:openapi.yaml`) introduced in #799
- Improves the error message when `git` is not in `PATH` from a raw `exec` error to `is git installed and in PATH?`

## Why

The oasdiff-action `pr-comment` now passes `origin/main:openapi.yaml` directly to the oasdiff binary, which calls `git show` internally. The Docker container had no `git`, causing:
```
failed to load spec from git revision "origin/main:simple.yaml": exec: "git": executable file not found in $PATH
```

Since the action Dockerfiles are all `FROM tufin/oasdiff:stable`, adding `git` to the base image fixes the action without any changes to oasdiff-action itself.

## Test plan

- [ ] Docker image builds successfully
- [ ] `TestLoadInfo_GitRevisionNoGit` passes with the improved error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)