### PR TITLE
fix: use full git ref as URL path to avoid loader cache collision

### DIFF
--- a/load/load.go
+++ b/load/load.go
@@ -39,8 +39,11 @@ func loadFromGitRevision(loader *openapi3.Loader, gitRef string) (*openapi3.T, e
 		return nil, fmt.Errorf("failed to load spec from git revision %q (is git installed and in PATH?): %w", gitRef, err)
 	}
 
-	specPath := gitRef[strings.Index(gitRef, ":")+1:]
-	u := &url.URL{Path: filepath.ToSlash(specPath)}
+	// Use the full gitRef as the URL path so each revision gets a unique cache key in the
+	// loader's visitedDocuments map (e.g. "origin/main:openapi.yaml" vs "HEAD:openapi.yaml").
+	// Using only the file portion would cause both refs to share the key "openapi.yaml" and
+	// the loader would return the cached base spec for the revision.
+	u := &url.URL{Path: filepath.ToSlash(gitRef)}
 	return loader.LoadFromDataWithPath(out, u)
 }
 

--- a/load/spec_info_git_test.go
+++ b/load/spec_info_git_test.go
@@ -82,6 +82,61 @@ func TestLoadInfo_GitRevisionNotFound(t *testing.T) {
 	require.ErrorContains(t, err, "failed to load spec from git revision")
 }
 
+// TestLoadInfo_TwoGitRevisionsSharedLoader verifies that loading two different git revisions
+// of the same file with the same loader returns distinct specs.
+// This guards against the openapi3 loader's visitedDocuments cache returning the cached
+// first spec for the second load when both refs resolve to the same file path.
+func TestLoadInfo_TwoGitRevisionsSharedLoader(t *testing.T) {
+	dir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(out))
+	}
+
+	run("git", "init")
+	run("git", "config", "user.email", "test@test.com")
+	run("git", "config", "user.name", "Test")
+
+	specV1 := `openapi: "3.0.0"
+info:
+  title: Test
+  version: "1.0"
+paths: {}
+`
+	specV2 := `openapi: "3.0.0"
+info:
+  title: Test
+  version: "2.0"
+paths: {}
+`
+	specPath := filepath.Join(dir, "openapi.yaml")
+	require.NoError(t, os.WriteFile(specPath, []byte(specV1), 0644))
+	run("git", "add", "openapi.yaml")
+	run("git", "commit", "-m", "v1")
+
+	require.NoError(t, os.WriteFile(specPath, []byte(specV2), 0644))
+	run("git", "add", "openapi.yaml")
+	run("git", "commit", "-m", "v2")
+
+	oldDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	defer os.Chdir(oldDir) //nolint:errcheck
+
+	loader := openapi3.NewLoader()
+	s1, err := load.NewSpecInfo(loader, load.NewSource("HEAD~1:openapi.yaml"))
+	require.NoError(t, err)
+	s2, err := load.NewSpecInfo(loader, load.NewSource("HEAD:openapi.yaml"))
+	require.NoError(t, err)
+
+	require.Equal(t, "1.0", s1.GetVersion(), "base spec should be v1")
+	require.Equal(t, "2.0", s2.GetVersion(), "revision spec should be v2")
+}
+
 func TestLoadInfo_GitRevisionNoGit(t *testing.T) {
 	t.Setenv("PATH", t.TempDir()) // remove git from PATH
 	_, err := load.NewSpecInfo(openapi3.NewLoader(), load.NewSource("HEAD:openapi.yaml"))


### PR DESCRIPTION
## Summary

- When loading two git revisions of the same file (e.g. `origin/main:openapi.yaml` and `HEAD:openapi.yaml`) with a shared `openapi3.Loader`, both calls produced the same URL cache key (`"openapi.yaml"`), causing the loader to return the cached base spec for the revision — resulting in empty `changelog`/`diff` output
- Fix by using the full git ref (e.g. `"origin/main:openapi.yaml"`) as the URL path, so each revision gets a unique key in `visitedDocuments`
- Adds a regression test that loads two revisions of the same filename with a shared loader and asserts they contain distinct content

## Test plan

- [ ] `go test ./load/... -run TestLoadInfo_TwoGitRevisionsSharedLoader` passes
- [ ] Reverting the fix causes the new test to fail (verified locally)
- [ ] Full `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)