### PR TITLE
fix: resolve $ref chains via git show when loading from git revision specs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	cloud.google.com/go v0.123.0
 	github.com/TwiN/go-color v1.4.1
-	github.com/oasdiff/kin-openapi v0.136.11
+	github.com/oasdiff/kin-openapi v0.136.12
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
@@ -50,5 +50,3 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/wI2L/jsondiff v0.7.1
 )
-
-replace github.com/oasdiff/kin-openapi => ../kin-openapi

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	cloud.google.com/go v0.123.0
 	github.com/TwiN/go-color v1.4.1
-	github.com/oasdiff/kin-openapi v0.136.12
+	github.com/oasdiff/kin-openapi v0.136.13
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1

--- a/go.mod
+++ b/go.mod
@@ -50,3 +50,5 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/wI2L/jsondiff v0.7.1
 )
+
+replace github.com/oasdiff/kin-openapi => ../kin-openapi

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/mailru/easyjson v0.9.2 h1:dX8U45hQsZpxd80nLvDGihsQ/OxlvTkVUXH2r/8cb2M
 github.com/mailru/easyjson v0.9.2/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
-github.com/oasdiff/kin-openapi v0.136.11 h1:+d0zvraX62uP25Itr7psz0mWMSWBGBDkOxhFby+GtM4=
-github.com/oasdiff/kin-openapi v0.136.11/go.mod h1:E7LUU2UyOHENK+Mhu7stMOtUA41LJRp5sFAW+L1Ier4=
+github.com/oasdiff/kin-openapi v0.136.12 h1:QZRMxruhwfksr9cZ8w1xVf600kInC8DzA1La+GqYYBw=
+github.com/oasdiff/kin-openapi v0.136.12/go.mod h1:E7LUU2UyOHENK+Mhu7stMOtUA41LJRp5sFAW+L1Ier4=
 github.com/oasdiff/yaml v0.0.9 h1:zQOvd2UKoozsSsAknnWoDJlSK4lC0mpmjfDsfqNwX48=
 github.com/oasdiff/yaml v0.0.9/go.mod h1:8lvhgJG4xiKPj3HN5lDow4jZHPlx1i7dIwzkdAo6oAM=
 github.com/oasdiff/yaml3 v0.0.9 h1:rWPrKccrdUm8J0F3sGuU+fuh9+1K/RdJlWF7O/9yw2g=

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/mailru/easyjson v0.9.2 h1:dX8U45hQsZpxd80nLvDGihsQ/OxlvTkVUXH2r/8cb2M
 github.com/mailru/easyjson v0.9.2/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
-github.com/oasdiff/kin-openapi v0.136.12 h1:QZRMxruhwfksr9cZ8w1xVf600kInC8DzA1La+GqYYBw=
-github.com/oasdiff/kin-openapi v0.136.12/go.mod h1:E7LUU2UyOHENK+Mhu7stMOtUA41LJRp5sFAW+L1Ier4=
+github.com/oasdiff/kin-openapi v0.136.13 h1:OBNKf96rrA4jdrwVsFwCP/rwN2xTKcBL192tYSkueb8=
+github.com/oasdiff/kin-openapi v0.136.13/go.mod h1:E7LUU2UyOHENK+Mhu7stMOtUA41LJRp5sFAW+L1Ier4=
 github.com/oasdiff/yaml v0.0.9 h1:zQOvd2UKoozsSsAknnWoDJlSK4lC0mpmjfDsfqNwX48=
 github.com/oasdiff/yaml v0.0.9/go.mod h1:8lvhgJG4xiKPj3HN5lDow4jZHPlx1i7dIwzkdAo6oAM=
 github.com/oasdiff/yaml3 v0.0.9 h1:rWPrKccrdUm8J0F3sGuU+fuh9+1K/RdJlWF7O/9yw2g=

--- a/load/load.go
+++ b/load/load.go
@@ -39,13 +39,6 @@ func loadFromGitRevision(loader *openapi3.Loader, gitRef string) (*openapi3.T, e
 		return nil, fmt.Errorf("failed to load spec from git revision %q: %w", gitRef, err)
 	}
 
-	// We must set IsExternalRefsAllowed=true so kin-openapi doesn't reject relative $refs
-	// (which look like external refs) before calling our ReadFromURIFunc.
-	// The original value is captured and enforced inside ReadFromURIFunc so that
-	// non-git refs (e.g. HTTP/HTTPS) still respect the caller's --allow-external-refs setting.
-	externalRefsAllowed := loader.IsExternalRefsAllowed
-	loader.IsExternalRefsAllowed = true
-
 	// gitPrefix is the "revision:" part of gitRef (e.g. "HEAD:", "origin/main:").
 	// When a spec lives at the repo root (no "/" in gitRef after the ":"), Go's URL
 	// resolution strips the prefix from relative $refs — e.g. "HEAD:openapi.yaml" +
@@ -55,6 +48,9 @@ func loadFromGitRevision(loader *openapi3.Loader, gitRef string) (*openapi3.T, e
 
 	// Install a ReadFromURIFunc so relative $refs inside a git-revision spec are also
 	// fetched via "git show" rather than opened as literal file paths.
+	// kin-openapi calls this function before checking IsExternalRefsAllowed, so the
+	// caller's --allow-external-refs setting is still enforced for non-git refs via
+	// DefaultReadFromURI.
 	loader.ReadFromURIFunc = func(loader *openapi3.Loader, location *url.URL) ([]byte, error) {
 		p := filepath.FromSlash(location.Path)
 		if isGitRevision(p) {
@@ -64,9 +60,6 @@ func loadFromGitRevision(loader *openapi3.Loader, gitRef string) (*openapi3.T, e
 		// root and Go URL resolution drops the "revision:" prefix. Restore it.
 		if location.Scheme == "" && location.Host == "" {
 			return gitShow(gitPrefix + p)
-		}
-		if !externalRefsAllowed {
-			return nil, fmt.Errorf("external references not allowed: %s", location)
 		}
 		return openapi3.DefaultReadFromURI(loader, location)
 	}

--- a/load/load.go
+++ b/load/load.go
@@ -29,14 +29,27 @@ func from(loader *openapi3.Loader, source *Source) (*openapi3.T, error) {
 // loadFromGitRevision loads an OpenAPI spec from a git revision reference (e.g. "origin/main:openapi.yaml").
 // It runs "git show <ref>" to obtain the content and loads it via LoadFromDataWithPath so that
 // relative $refs are resolved against the spec's path.
+//
+// Relative $refs (e.g. "./schemas/pet.yaml") are resolved by kin-openapi into paths like
+// "origin/main:multi-file/schemas/pet.yaml". We install a ReadFromURIFunc so the loader
+// recognises that pattern and reads referenced files via "git show" too.
 func loadFromGitRevision(loader *openapi3.Loader, gitRef string) (*openapi3.T, error) {
-	out, err := exec.Command("git", "show", gitRef).Output()
+	out, err := gitShow(gitRef)
 	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
-			return nil, fmt.Errorf("failed to load spec from git revision %q: %s", gitRef, strings.TrimSpace(string(exitErr.Stderr)))
+		return nil, fmt.Errorf("failed to load spec from git revision %q: %w", gitRef, err)
+	}
+
+	// Allow external refs: they are resolved via "git show" (no network), so this is safe.
+	loader.IsExternalRefsAllowed = true
+
+	// Install a ReadFromURIFunc so relative $refs inside a git-revision spec are also
+	// fetched via "git show" rather than opened as literal file paths.
+	loader.ReadFromURIFunc = func(loader *openapi3.Loader, location *url.URL) ([]byte, error) {
+		p := filepath.FromSlash(location.Path)
+		if isGitRevision(p) {
+			return gitShow(p)
 		}
-		return nil, fmt.Errorf("failed to load spec from git revision %q (is git installed and in PATH?): %w", gitRef, err)
+		return openapi3.DefaultReadFromURI(loader, location)
 	}
 
 	// Use the full gitRef as the URL path so each revision gets a unique cache key in the
@@ -45,6 +58,19 @@ func loadFromGitRevision(loader *openapi3.Loader, gitRef string) (*openapi3.T, e
 	// the loader would return the cached base spec for the revision.
 	u := &url.URL{Path: filepath.ToSlash(gitRef)}
 	return loader.LoadFromDataWithPath(out, u)
+}
+
+// gitShow runs "git show <ref>" and returns its stdout, or a descriptive error.
+func gitShow(ref string) ([]byte, error) {
+	out, err := exec.Command("git", "show", ref).Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+			return nil, fmt.Errorf("%s", strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return nil, fmt.Errorf("is git installed and in PATH?: %w", err)
+	}
+	return out, nil
 }
 
 func getURL(rawURL string) (*url.URL, error) {

--- a/load/load.go
+++ b/load/load.go
@@ -39,8 +39,19 @@ func loadFromGitRevision(loader *openapi3.Loader, gitRef string) (*openapi3.T, e
 		return nil, fmt.Errorf("failed to load spec from git revision %q: %w", gitRef, err)
 	}
 
-	// Allow external refs: they are resolved via "git show" (no network), so this is safe.
+	// We must set IsExternalRefsAllowed=true so kin-openapi doesn't reject relative $refs
+	// (which look like external refs) before calling our ReadFromURIFunc.
+	// The original value is captured and enforced inside ReadFromURIFunc so that
+	// non-git refs (e.g. HTTP/HTTPS) still respect the caller's --allow-external-refs setting.
+	externalRefsAllowed := loader.IsExternalRefsAllowed
 	loader.IsExternalRefsAllowed = true
+
+	// gitPrefix is the "revision:" part of gitRef (e.g. "HEAD:", "origin/main:").
+	// When a spec lives at the repo root (no "/" in gitRef after the ":"), Go's URL
+	// resolution strips the prefix from relative $refs — e.g. "HEAD:openapi.yaml" +
+	// "./schemas/pet.yaml" → "schemas/pet.yaml" instead of "HEAD:schemas/pet.yaml".
+	// We capture the prefix here so we can restore it in ReadFromURIFunc.
+	gitPrefix := gitRef[:strings.Index(gitRef, ":")+1]
 
 	// Install a ReadFromURIFunc so relative $refs inside a git-revision spec are also
 	// fetched via "git show" rather than opened as literal file paths.
@@ -48,6 +59,14 @@ func loadFromGitRevision(loader *openapi3.Loader, gitRef string) (*openapi3.T, e
 		p := filepath.FromSlash(location.Path)
 		if isGitRevision(p) {
 			return gitShow(p)
+		}
+		// Relative path without the git prefix — happens when the spec is at the repo
+		// root and Go URL resolution drops the "revision:" prefix. Restore it.
+		if location.Scheme == "" && location.Host == "" {
+			return gitShow(gitPrefix + p)
+		}
+		if !externalRefsAllowed {
+			return nil, fmt.Errorf("external references not allowed: %s", location)
 		}
 		return openapi3.DefaultReadFromURI(loader, location)
 	}

--- a/load/spec_info_git_test.go
+++ b/load/spec_info_git_test.go
@@ -142,3 +142,65 @@ func TestLoadInfo_GitRevisionNoGit(t *testing.T) {
 	_, err := load.NewSpecInfo(openapi3.NewLoader(), load.NewSource("HEAD:openapi.yaml"))
 	require.ErrorContains(t, err, "is git installed and in PATH?")
 }
+
+// TestLoadInfo_GitRevisionWithExternalRef verifies that $ref chains are resolved via
+// "git show" when loading from a git revision, not opened as literal file paths.
+func TestLoadInfo_GitRevisionWithExternalRef(t *testing.T) {
+	dir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(out))
+	}
+
+	run("git", "init")
+	run("git", "config", "user.email", "test@test.com")
+	run("git", "config", "user.name", "Test")
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "schemas"), 0755))
+
+	topLevel := `openapi: "3.0.0"
+info:
+  title: Test
+  version: "1.0"
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/pet.yaml"
+`
+	petSchema := `type: object
+required:
+  - id
+properties:
+  id:
+    type: integer
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "openapi.yaml"), []byte(topLevel), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "schemas", "pet.yaml"), []byte(petSchema), 0644))
+
+	run("git", "add", ".")
+	run("git", "commit", "-m", "add multi-file spec")
+
+	oldDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	defer os.Chdir(oldDir) //nolint:errcheck
+
+	specInfo, err := load.NewSpecInfo(openapi3.NewLoader(), load.NewSource("HEAD:openapi.yaml"))
+	require.NoError(t, err)
+	require.Equal(t, "1.0", specInfo.GetVersion())
+
+	// Verify the $ref was resolved — the pet schema should have the "id" property
+	schema := specInfo.Spec.Paths.Value("/pets").Get.Responses.Value("200").Value.Content["application/json"].Schema.Value
+	require.NotNil(t, schema.Properties["id"], "id property from $ref chain should be resolved")
+}


### PR DESCRIPTION
## Problem

When loading a spec like \`origin/main:multi-file/openapi.yaml\` that contains \`\$ref: \"./schemas/pet.yaml\"\`, kin-openapi resolves the relative ref to \`origin/main:multi-file/schemas/pet.yaml\` and then tries to \`open()\` it as a literal file path — which fails:

\`\`\`
open origin/main:multi-file/schemas/pet.yaml: no such file or directory
\`\`\`

A secondary problem: the original fix set \`loader.IsExternalRefsAllowed = true\` unconditionally to allow \`ReadFromURIFunc\` to be called at all, which overrode the user's \`--allow-external-refs\` flag and bypassed SSRF protection for HTTP/HTTPS refs.

## Fix

**In kin-openapi** ([getkin/kin-openapi#1146](https://github.com/getkin/kin-openapi/pull/1146), now in [oasdiff/kin-openapi v0.136.13](https://github.com/oasdiff/kin-openapi/releases/tag/v0.136.13)):
- \`ReadFromURIFunc\` is now called before the \`IsExternalRefsAllowed\` check, so custom loaders no longer need to set \`IsExternalRefsAllowed=true\` as a workaround. The function itself is responsible for enforcing access policy.

**In oasdiff** \`loadFromGitRevision\`:
1. Install \`loader.ReadFromURIFunc\` that recognises git revision paths (containing \`:\` but not \`://\`) and reads them via \`git show\`
2. Handle the repo-root edge case: when the spec is at the repo root (e.g. \`HEAD:openapi.yaml\`), Go's URL resolution strips the \`HEAD:\` prefix from relative \`\$ref\`s — the git prefix is captured and restored inside \`ReadFromURIFunc\`
3. Non-git external refs (HTTP/HTTPS) fall through to \`DefaultReadFromURI\`, which still enforces \`IsExternalRefsAllowed\` — so the user's \`--allow-external-refs\` flag is respected

## Test

\`TestLoadInfo_GitRevisionWithExternalRef\` creates a real git repo with a multi-file spec and verifies the \`\$ref\` chain is fully resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)