### PR TITLE
fix: show meaningful messages for empty breaking/changelog results

### DIFF
--- a/formatters/format_html.go
+++ b/formatters/format_html.go
@@ -57,7 +57,7 @@ func (f HTMLFormatter) RenderChangelog(changes checker.Changes, opts RenderOpts,
 		tmpl = template.Must(template.New("changelog").Funcs(HtmlTemplateFuncs()).Parse(changelogHtml))
 	}
 
-	return ExecuteHtmlTemplate(tmpl, GroupChanges(changes, f.Localizer), baseVersion, revisionVersion)
+	return ExecuteHtmlTemplate(tmpl, GroupChanges(changes, f.Localizer), baseVersion, revisionVersion, opts.DiffEmpty)
 }
 
 func (f HTMLFormatter) loadCustomTemplate(templatePath string) (*template.Template, error) {
@@ -121,9 +121,9 @@ func HtmlTemplateFuncs() template.FuncMap {
 	return template.FuncMap(changelogTemplateFuncs())
 }
 
-func ExecuteHtmlTemplate(tmpl *template.Template, changes ChangesByGroup, baseVersion, revisionVersion string) ([]byte, error) {
+func ExecuteHtmlTemplate(tmpl *template.Template, changes ChangesByGroup, baseVersion, revisionVersion string, diffEmpty bool) ([]byte, error) {
 	var out bytes.Buffer
-	if err := tmpl.Execute(&out, TemplateData{changes, baseVersion, revisionVersion}); err != nil {
+	if err := tmpl.Execute(&out, TemplateData{changes, baseVersion, revisionVersion, diffEmpty}); err != nil {
 		return nil, err
 	}
 	return out.Bytes(), nil

--- a/formatters/format_html_test.go
+++ b/formatters/format_html_test.go
@@ -120,7 +120,7 @@ var changelogHtml string
 func TestExecuteHtmlTemplate_Err(t *testing.T) {
 	tmpl := template.Must(template.New("changelog").Funcs(formatters.HtmlTemplateFuncs()).Parse(changelogHtml))
 	tmpl.Tree = nil
-	_, err := formatters.ExecuteHtmlTemplate(tmpl, nil, "", "")
+	_, err := formatters.ExecuteHtmlTemplate(tmpl, nil, "", "", false)
 	assert.Error(t, err)
 }
 

--- a/formatters/format_markup.go
+++ b/formatters/format_markup.go
@@ -44,7 +44,7 @@ func (f MarkupFormatter) RenderChangelog(changes checker.Changes, opts RenderOpt
 		tmpl = template.Must(template.New("changelog").Funcs(MarkupTemplateFuncs()).Parse(changelogMarkdown))
 	}
 
-	return ExecuteTextTemplate(tmpl, GroupChanges(changes, f.Localizer), baseVersion, revisionVersion)
+	return ExecuteTextTemplate(tmpl, GroupChanges(changes, f.Localizer), baseVersion, revisionVersion, opts.DiffEmpty)
 }
 
 func (f MarkupFormatter) loadCustomTemplate(templatePath string) (*template.Template, error) {
@@ -66,9 +66,9 @@ func MarkupTemplateFuncs() template.FuncMap {
 	return template.FuncMap(changelogTemplateFuncs())
 }
 
-func ExecuteTextTemplate(tmpl *template.Template, changes ChangesByGroup, baseVersion, revisionVersion string) ([]byte, error) {
+func ExecuteTextTemplate(tmpl *template.Template, changes ChangesByGroup, baseVersion, revisionVersion string, diffEmpty bool) ([]byte, error) {
 	var out bytes.Buffer
-	if err := tmpl.Execute(&out, TemplateData{changes, baseVersion, revisionVersion}); err != nil {
+	if err := tmpl.Execute(&out, TemplateData{changes, baseVersion, revisionVersion, diffEmpty}); err != nil {
 		return nil, err
 	}
 	return out.Bytes(), nil

--- a/formatters/format_markup_test.go
+++ b/formatters/format_markup_test.go
@@ -110,7 +110,7 @@ func TestMarkupFormatter_NotImplemented(t *testing.T) {
 }
 
 func TestExecuteMarkupTemplate_Err(t *testing.T) {
-	_, err := formatters.ExecuteTextTemplate(&template.Template{}, nil, "", "")
+	_, err := formatters.ExecuteTextTemplate(&template.Template{}, nil, "", "", false)
 	assert.Error(t, err)
 }
 

--- a/formatters/format_singleline.go
+++ b/formatters/format_singleline.go
@@ -21,9 +21,16 @@ func newSingleLineFormatter(l checker.Localizer) SingleLineFormatter {
 func (f SingleLineFormatter) RenderChangelog(changes checker.Changes, opts RenderOpts, _, _ string) ([]byte, error) {
 	result := bytes.NewBuffer(nil)
 
-	if len(changes) > 0 {
-		_, _ = fmt.Fprint(result, getChangelogTitle(changes, f.Localizer, opts.ColorMode))
+	if len(changes) == 0 {
+		if opts.DiffEmpty {
+			_, _ = fmt.Fprint(result, "No changes detected")
+		} else {
+			_, _ = fmt.Fprint(result, "No changes to report, but the specs are different")
+		}
+		return result.Bytes(), nil
 	}
+
+	_, _ = fmt.Fprint(result, getChangelogTitle(changes, f.Localizer, opts.ColorMode))
 
 	for _, c := range changes {
 		_, _ = fmt.Fprintf(result, "%s\n\n", c.SingleLineError(f.Localizer, opts.ColorMode))

--- a/formatters/format_text.go
+++ b/formatters/format_text.go
@@ -28,9 +28,16 @@ func (f TEXTFormatter) RenderDiff(diff *diff.Diff, opts RenderOpts) ([]byte, err
 func (f TEXTFormatter) RenderChangelog(changes checker.Changes, opts RenderOpts, _, _ string) ([]byte, error) {
 	result := bytes.NewBuffer(nil)
 
-	if len(changes) > 0 {
-		_, _ = fmt.Fprint(result, getChangelogTitle(changes, f.Localizer, opts.ColorMode))
+	if len(changes) == 0 {
+		if opts.DiffEmpty {
+			_, _ = fmt.Fprint(result, "No changes detected")
+		} else {
+			_, _ = fmt.Fprint(result, "No changes to report, but the specs are different")
+		}
+		return result.Bytes(), nil
 	}
+
+	_, _ = fmt.Fprint(result, getChangelogTitle(changes, f.Localizer, opts.ColorMode))
 
 	for _, c := range changes {
 		_, _ = fmt.Fprintf(result, "%s\n\n", c.MultiLineError(f.Localizer, opts.ColorMode))

--- a/formatters/templates/changelog.html
+++ b/formatters/templates/changelog.html
@@ -155,7 +155,7 @@
     {{ template "section-group" . }}
     {{ end }}
     {{ else }}
-    <p>No changes</p>
+    {{ if .DiffEmpty }}<p>No changes detected</p>{{ else }}<p>No changes to report, but the specs are different</p>{{ end }}
     {{ end }}
 </body>
 

--- a/formatters/templates/changelog.md
+++ b/formatters/templates/changelog.md
@@ -14,5 +14,5 @@
 {{ end }}
 {{ end }}
 {{ else }}
-No changes
+{{ if .DiffEmpty }}No changes detected{{ else }}No changes to report, but the specs are different{{ end }}
 {{ end }}

--- a/formatters/types.go
+++ b/formatters/types.go
@@ -45,6 +45,7 @@ type RenderOpts struct {
 	ColorMode    checker.ColorMode
 	WrapInObject bool   // wrap the output in a JSON object with the key "changes"
 	TemplatePath string // path to custom template file for changelog generation
+	DiffEmpty    bool   // true when the underlying diff found no changes at all
 }
 
 func NewRenderOpts() RenderOpts {
@@ -57,6 +58,7 @@ type TemplateData struct {
 	GroupedChanges  ChangesByGroup
 	BaseVersion     string
 	RevisionVersion string
+	DiffEmpty       bool
 }
 
 // APIChanges returns GroupedChanges.

--- a/internal/changelog.go
+++ b/internal/changelog.go
@@ -70,7 +70,7 @@ func getChangelog(flags *Flags, stdout io.Writer, level checker.Level) (bool, *R
 		return false, returnErr
 	}
 
-	if returnErr := outputChangelog(flags, stdout, errs, diffResult.specInfoPair); returnErr != nil {
+	if returnErr := outputChangelog(flags, stdout, errs, diffResult.specInfoPair, diffResult.diffReport.Empty()); returnErr != nil {
 		return false, returnErr
 	}
 
@@ -106,7 +106,7 @@ func filterIgnored(errs checker.Changes, warnIgnoreFile string, errIgnoreFile st
 	return errs, nil
 }
 
-func outputChangelog(flags *Flags, stdout io.Writer, errs checker.Changes, specInfoPair *load.SpecInfoPair) *ReturnError {
+func outputChangelog(flags *Flags, stdout io.Writer, errs checker.Changes, specInfoPair *load.SpecInfoPair, diffEmpty bool) *ReturnError {
 
 	// formatter lookup
 	formatter, err := formatters.Lookup(flags.getFormat(), formatters.FormatterOpts{
@@ -127,7 +127,7 @@ func outputChangelog(flags *Flags, stdout io.Writer, errs checker.Changes, specI
 		return getErrInvalidColorMode(err)
 	}
 
-	bytes, err := formatter.RenderChangelog(errs, formatters.RenderOpts{ColorMode: colorMode, TemplatePath: flags.getTemplate()}, specInfoPair.GetBaseVersion(), specInfoPair.GetRevisionVersion())
+	bytes, err := formatter.RenderChangelog(errs, formatters.RenderOpts{ColorMode: colorMode, TemplatePath: flags.getTemplate(), DiffEmpty: diffEmpty}, specInfoPair.GetBaseVersion(), specInfoPair.GetRevisionVersion())
 	if err != nil {
 		return getErrFailedPrint(changelogCmd+" "+flags.getFormat(), err)
 	}


### PR DESCRIPTION
## Summary
- Differentiate two empty-result scenarios: specs are identical vs. specs differ but no changes match checker rules
- "No changes detected" when diff is empty
- "No changes to report, but the specs are different" when diff exists but no breaking/changelog entries match
- Only human-readable formats affected: text, singleline, markup, HTML
- JSON, YAML, and GitHub Actions formats unchanged to avoid breaking oasdiff-action, oasdiff-service, and external consumers

## Test plan
- [ ] `oasdiff breaking base.yaml base.yaml` → "No changes detected"
- [ ] `oasdiff breaking base.yaml rev.yaml` (non-breaking diff) → "No changes to report, but the specs are different"
- [ ] `oasdiff breaking base.yaml rev.yaml -f json` → `[]` (unchanged)
- [ ] `oasdiff changelog` — same behavior as breaking
- [ ] `oasdiff breaking base.yaml rev.yaml -f markdown` → differentiated messages in markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)