### PR TITLE
fix: helpful error message when install.sh   lacks write permission

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -105,8 +105,15 @@ do_install() {
   echo "Extracting tar file"
   (cd $tmp_dir && tar -xzf "$asset_name")
 
-  echo "Installing $BINARY_NAME into $tmp_dir"
-  mv "$tmp_dir/$BINARY_NAME" $INSTALL_DIR
+  echo "Installing $BINARY_NAME into $INSTALL_DIR"
+  if ! mv "$tmp_dir/$BINARY_NAME" $INSTALL_DIR 2>/dev/null; then
+    echo "Permission denied installing to $INSTALL_DIR"
+    echo "Try one of:"
+    echo "  curl -fsSL https://raw.githubusercontent.com/oasdiff/oasdiff/main/install.sh | version=$version sudo sh"
+    echo "  curl -fsSL https://raw.githubusercontent.com/oasdiff/oasdiff/main/install.sh | version=$version INSTALL_DIR=~/bin sh"
+    rm -rf $tmp_dir
+    exit 1
+  fi
 
   chmod +x $INSTALL_DIR/$BINARY_NAME
   echo "Installed oasdiff to $INSTALL_DIR"


### PR DESCRIPTION
  ## Summary
  - Replace silent `mv` failure with a clear error message when the binary can't be installed to `INSTALL_DIR` (default `/usr/local/bin`)
  - Print actionable alternatives: re-run with `sudo` or set `INSTALL_DIR=~/bin`
  - Fix misleading log line that printed the temp dir instead of the install destination

  ## Test plan
  - [ ] Run install script without sudo on a system where `/usr/local/bin` is not writable — confirm the new error message and suggested commands appear
  - [ ] Run with `sudo` — confirm normal install still works
  - [ ] Run with `INSTALL_DIR=~/bin` — confirm normal install still works
