### PR TITLE
fix: point tag source to specific tag line

### DIFF
--- a/checker/check_api_tag_updated.go
+++ b/checker/check_api_tag_updated.go
@@ -27,9 +27,11 @@ func APITagUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.Operation
 				continue
 			}
 
-			baseSource, revisionSource := OperationFieldSources(operationsSources, operationItem, "tags")
-
 			for _, tag := range operationItem.TagsDiff.Deleted {
+				var baseSource *Source
+				if operationItem.Base != nil && operationItem.Base.Origin != nil {
+					baseSource = NewSourceFromSequenceItem(operationsSources, operationItem.Base, operationItem.Base.Origin, "tags", tag)
+				}
 				result = append(result, NewApiChange(
 					APITagRemovedId,
 					config,
@@ -39,10 +41,14 @@ func APITagUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.Operation
 					op,
 					operation,
 					path,
-				).WithSources(baseSource, revisionSource))
+				).WithSources(baseSource, nil))
 			}
 
 			for _, tag := range operationItem.TagsDiff.Added {
+				var revisionSource *Source
+				if operationItem.Revision != nil && operationItem.Revision.Origin != nil {
+					revisionSource = NewSourceFromSequenceItem(operationsSources, operationItem.Revision, operationItem.Revision.Origin, "tags", tag)
+				}
 				result = append(result, NewApiChange(
 					APITagAddedId,
 					config,
@@ -52,7 +58,7 @@ func APITagUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.Operation
 					op,
 					operation,
 					path,
-				).WithSources(baseSource, revisionSource))
+				).WithSources(nil, revisionSource))
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- For `api-tag-added` and `api-tag-removed`, use `NewSourceFromSequenceItem` to report the exact line of the added/deleted tag value instead of the `tags:` field key
- Set only `baseSource` for deletions and only `revisionSource` for additions (previously both were set for every change)

**Before:** source pointed to line 108 (`tags:` key)
**After:** source points to line 110 (`- dogs`)

## Test plan
- [x] Built and tested manually with petstore specs differing in tags
- [x] Verified other sequence-field checkers (enum, oneOf/anyOf/allOf) already use item-level sources correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)