### PR TITLE
fix: drop leading slash from property paths at schema root

### DIFF
--- a/checker/check_breaking_property_test.go
+++ b/checker/check_breaking_property_test.go
@@ -603,7 +603,7 @@ func TestBreaking_Items(t *testing.T) {
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
 	require.Equal(t, checker.RequestPropertyBecameRequiredId, errs[0].GetId())
-	require.Equal(t, []any{"/items/id"}, errs[0].GetArgs())
+	require.Equal(t, []any{"items/id"}, errs[0].GetArgs())
 }
 
 // BC: changing an existing property in request body items to required with a default value is not breaking

--- a/checker/check_breaking_response_type_changed_test.go
+++ b/checker/check_breaking_response_type_changed_test.go
@@ -119,5 +119,5 @@ func TestBreaking_RespTypeChanged(t *testing.T) {
 	errs := checker.CheckBackwardCompatibility(allChecksConfig(), d, osm)
 	require.Len(t, errs, 1)
 	require.Equal(t, "response-property-type-changed", errs[0].GetId())
-	require.Equal(t, "the `/items/testField` response's property type/format changed from `string`/`` to `integer`/`int32` for status `200`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "the `items/testField` response's property type/format changed from `string`/`` to `integer`/`int32` for status `200`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }

--- a/checker/check_breaking_test.go
+++ b/checker/check_breaking_test.go
@@ -652,7 +652,7 @@ func TestBreaking_RequestPropertyAnyOfRemoved(t *testing.T) {
 
 	require.Equal(t, checker.RequestPropertyAnyOfRemovedId, errs[1].GetId())
 	require.Equal(t, checker.ERR, errs[1].GetLevel())
-	require.Equal(t, "removed `#/components/schemas/Breed3` from the `/anyOf[#/components/schemas/Dog]/breed` request property `anyOf` list", errs[1].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "removed `#/components/schemas/Breed3` from the `anyOf[#/components/schemas/Dog]/breed` request property `anyOf` list", errs[1].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // BC: removing 'oneOf' schema from the request body or request body property is breaking
@@ -673,7 +673,7 @@ func TestBreaking_RequestPropertyOneOfRemoved(t *testing.T) {
 
 	require.Equal(t, checker.RequestPropertyOneOfRemovedId, errs[1].GetId())
 	require.Equal(t, checker.ERR, errs[1].GetLevel())
-	require.Equal(t, "removed `#/components/schemas/Breed3` from the `/oneOf[#/components/schemas/Dog]/breed` request property `oneOf` list", errs[1].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "removed `#/components/schemas/Breed3` from the `oneOf[#/components/schemas/Dog]/breed` request property `oneOf` list", errs[1].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // BC: adding 'allOf' subschema to the request body or request body property is breaking
@@ -695,7 +695,7 @@ func TestBreaking_RequestPropertyAllOfAdded(t *testing.T) {
 
 	require.Equal(t, checker.RequestPropertyAllOfAddedId, errs[1].GetId())
 	require.Equal(t, checker.ERR, errs[1].GetLevel())
-	require.Equal(t, "added `#/components/schemas/Breed3` to the `/allOf[#/components/schemas/Dog]/breed` request property `allOf` list", errs[1].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "added `#/components/schemas/Breed3` to the `allOf[#/components/schemas/Dog]/breed` request property `allOf` list", errs[1].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // BC: removing 'allOf' subschema from the request body or request body property is breaking with warn
@@ -717,5 +717,5 @@ func TestBreaking_RequestPropertyAllOfRemoved(t *testing.T) {
 
 	require.Equal(t, checker.RequestPropertyAllOfRemovedId, errs[1].GetId())
 	require.Equal(t, checker.WARN, errs[1].GetLevel())
-	require.Equal(t, "removed `#/components/schemas/Breed3` from the `/allOf[#/components/schemas/Dog]/breed` request property `allOf` list", errs[1].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "removed `#/components/schemas/Breed3` from the `allOf[#/components/schemas/Dog]/breed` request property `allOf` list", errs[1].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }

--- a/checker/check_request_discriminator_updated_test.go
+++ b/checker/check_request_discriminator_updated_test.go
@@ -33,7 +33,7 @@ func TestRequestDiscriminatorUpdatedCheckAdded(t *testing.T) {
 		},
 		{
 			Id:          checker.RequestPropertyDiscriminatorAddedId,
-			Args:        []any{"/oneOf[#/components/schemas/Dog]/breed"},
+			Args:        []any{"oneOf[#/components/schemas/Dog]/breed"},
 			Level:       checker.INFO,
 			Operation:   "POST",
 			Path:        "/pets",
@@ -66,7 +66,7 @@ func TestRequestDiscriminatorUpdatedCheckRemoved(t *testing.T) {
 		},
 		{
 			Id:          checker.RequestPropertyDiscriminatorRemovedId,
-			Args:        []any{"/oneOf[#/components/schemas/Dog]/breed"},
+			Args:        []any{"oneOf[#/components/schemas/Dog]/breed"},
 			Level:       checker.INFO,
 			Operation:   "POST",
 			Path:        "/pets",
@@ -100,7 +100,7 @@ func TestRequestDiscriminatorUpdatedCheckPropertyNameChanging(t *testing.T) {
 		},
 		{
 			Id:          checker.RequestPropertyDiscriminatorPropertyNameChangedId,
-			Args:        []any{"/oneOf[#/components/schemas/Dog]/breed", "name", "name2"},
+			Args:        []any{"oneOf[#/components/schemas/Dog]/breed", "name", "name2"},
 			Level:       checker.INFO,
 			Operation:   "POST",
 			Path:        "/pets",
@@ -143,7 +143,7 @@ func TestRequestDiscriminatorUpdatedCheckMappingChanging(t *testing.T) {
 		},
 		{
 			Id:          checker.RequestPropertyDiscriminatorMappingAddedId,
-			Args:        []any{[]string{"breed1Code"}, "/oneOf[#/components/schemas/Dog]/breed"},
+			Args:        []any{[]string{"breed1Code"}, "oneOf[#/components/schemas/Dog]/breed"},
 			Level:       checker.INFO,
 			Operation:   "POST",
 			Path:        "/pets",
@@ -152,7 +152,7 @@ func TestRequestDiscriminatorUpdatedCheckMappingChanging(t *testing.T) {
 		},
 		{
 			Id:          checker.RequestPropertyDiscriminatorMappingChangedId,
-			Args:        []any{"breed2", "#/components/schemas/Breed2", "#/components/schemas/Breed3", "/oneOf[#/components/schemas/Dog]/breed"},
+			Args:        []any{"breed2", "#/components/schemas/Breed2", "#/components/schemas/Breed3", "oneOf[#/components/schemas/Dog]/breed"},
 			Level:       checker.INFO,
 			Operation:   "POST",
 			Path:        "/pets",
@@ -161,7 +161,7 @@ func TestRequestDiscriminatorUpdatedCheckMappingChanging(t *testing.T) {
 		},
 		{
 			Id:          checker.RequestPropertyDiscriminatorMappingDeletedId,
-			Args:        []any{[]string{"breed1"}, "/oneOf[#/components/schemas/Dog]/breed"},
+			Args:        []any{[]string{"breed1"}, "oneOf[#/components/schemas/Dog]/breed"},
 			Level:       checker.INFO,
 			Operation:   "POST",
 			Path:        "/pets",

--- a/checker/check_request_property_all_of_updated_test.go
+++ b/checker/check_request_property_all_of_updated_test.go
@@ -34,7 +34,7 @@ func TestRequestPropertyAllOfAdded(t *testing.T) {
 		},
 		{
 			Id:          checker.RequestPropertyAllOfAddedId,
-			Args:        []any{"#/components/schemas/Breed3", "/allOf[#/components/schemas/Dog]/breed"},
+			Args:        []any{"#/components/schemas/Breed3", "allOf[#/components/schemas/Dog]/breed"},
 			Level:       checker.ERR,
 			Operation:   "POST",
 			Path:        "/pets",
@@ -114,7 +114,7 @@ func TestRequestPropertyAllOfRemoved(t *testing.T) {
 		},
 		{
 			Id:          checker.RequestPropertyAllOfRemovedId,
-			Args:        []any{"#/components/schemas/Breed3", "/allOf[#/components/schemas/Dog]/breed"},
+			Args:        []any{"#/components/schemas/Breed3", "allOf[#/components/schemas/Dog]/breed"},
 			Level:       checker.WARN,
 			Operation:   "POST",
 			Path:        "/pets",

--- a/checker/check_request_property_any_of_updated_test.go
+++ b/checker/check_request_property_any_of_updated_test.go
@@ -34,7 +34,7 @@ func TestRequestPropertyAnyOfAdded(t *testing.T) {
 		},
 		{
 			Id:          checker.RequestPropertyAnyOfAddedId,
-			Args:        []any{"#/components/schemas/Breed3", "/anyOf[#/components/schemas/Dog]/breed"},
+			Args:        []any{"#/components/schemas/Breed3", "anyOf[#/components/schemas/Dog]/breed"},
 			Level:       checker.INFO,
 			Operation:   "POST",
 			Path:        "/pets",
@@ -91,7 +91,7 @@ func TestRequestPropertyAnyOfRemoved(t *testing.T) {
 		},
 		{
 			Id:          checker.RequestPropertyAnyOfRemovedId,
-			Args:        []any{"#/components/schemas/Breed3", "/anyOf[#/components/schemas/Dog]/breed"},
+			Args:        []any{"#/components/schemas/Breed3", "anyOf[#/components/schemas/Dog]/breed"},
 			Level:       checker.ERR,
 			Operation:   "POST",
 			Path:        "/pets",

--- a/checker/check_request_property_one_of_updated_test.go
+++ b/checker/check_request_property_one_of_updated_test.go
@@ -34,7 +34,7 @@ func TestRequestPropertyOneOfAdded(t *testing.T) {
 		},
 		{
 			Id:          checker.RequestPropertyOneOfAddedId,
-			Args:        []any{"#/components/schemas/Breed3", "/oneOf[#/components/schemas/Dog]/breed"},
+			Args:        []any{"#/components/schemas/Breed3", "oneOf[#/components/schemas/Dog]/breed"},
 			Level:       checker.INFO,
 			Operation:   "POST",
 			Path:        "/pets",
@@ -91,7 +91,7 @@ func TestRequestPropertyOneOfRemoved(t *testing.T) {
 		},
 		{
 			Id:          checker.RequestPropertyOneOfRemovedId,
-			Args:        []any{"#/components/schemas/Breed3", "/oneOf[#/components/schemas/Dog]/breed"},
+			Args:        []any{"#/components/schemas/Breed3", "oneOf[#/components/schemas/Dog]/breed"},
 			Level:       checker.ERR,
 			Operation:   "POST",
 			Path:        "/pets",

--- a/checker/check_response_discriminator_updated_test.go
+++ b/checker/check_response_discriminator_updated_test.go
@@ -34,7 +34,7 @@ func TestResponseDiscriminatorUpdatedCheckAdded(t *testing.T) {
 		},
 		{
 			Id:          checker.ResponsePropertyDiscriminatorAddedId,
-			Args:        []any{"/oneOf[#/components/schemas/Dog]/breed", "200"},
+			Args:        []any{"oneOf[#/components/schemas/Dog]/breed", "200"},
 			Level:       checker.INFO,
 			Operation:   "POST",
 			Path:        "/pets",
@@ -68,7 +68,7 @@ func TestResponseDiscriminatorUpdatedCheckRemoved(t *testing.T) {
 		},
 		{
 			Id:          checker.ResponsePropertyDiscriminatorRemovedId,
-			Args:        []any{"/oneOf[#/components/schemas/Dog]/breed", "200"},
+			Args:        []any{"oneOf[#/components/schemas/Dog]/breed", "200"},
 			Level:       checker.INFO,
 			Operation:   "POST",
 			Path:        "/pets",
@@ -102,7 +102,7 @@ func TestResponseDiscriminatorUpdatedCheckPropertyNameChanging(t *testing.T) {
 		},
 		{
 			Id:          checker.ResponsePropertyDiscriminatorPropertyNameChangedId,
-			Args:        []any{"/oneOf[#/components/schemas/Dog]/breed", "name", "name2", "200"},
+			Args:        []any{"oneOf[#/components/schemas/Dog]/breed", "name", "name2", "200"},
 			Level:       checker.INFO,
 			Operation:   "POST",
 			Path:        "/pets",
@@ -145,7 +145,7 @@ func TestResponseDiscriminatorUpdatedCheckMappingChanging(t *testing.T) {
 		},
 		{
 			Id:          checker.ResponsePropertyDiscriminatorMappingAddedId,
-			Args:        []any{[]string{"breed1Code"}, "/oneOf[#/components/schemas/Dog]/breed", "200"},
+			Args:        []any{[]string{"breed1Code"}, "oneOf[#/components/schemas/Dog]/breed", "200"},
 			Level:       checker.INFO,
 			Operation:   "POST",
 			Path:        "/pets",
@@ -154,7 +154,7 @@ func TestResponseDiscriminatorUpdatedCheckMappingChanging(t *testing.T) {
 		},
 		{
 			Id:          checker.ResponsePropertyDiscriminatorMappingChangedId,
-			Args:        []any{"breed2", "#/components/schemas/Breed2", "#/components/schemas/Breed3", "/oneOf[#/components/schemas/Dog]/breed", "200"},
+			Args:        []any{"breed2", "#/components/schemas/Breed2", "#/components/schemas/Breed3", "oneOf[#/components/schemas/Dog]/breed", "200"},
 			Level:       checker.INFO,
 			Operation:   "POST",
 			Path:        "/pets",
@@ -163,7 +163,7 @@ func TestResponseDiscriminatorUpdatedCheckMappingChanging(t *testing.T) {
 		},
 		{
 			Id:          checker.ResponsePropertyDiscriminatorMappingDeletedId,
-			Args:        []any{[]string{"breed1"}, "/oneOf[#/components/schemas/Dog]/breed", "200"},
+			Args:        []any{[]string{"breed1"}, "oneOf[#/components/schemas/Dog]/breed", "200"},
 			Level:       checker.INFO,
 			Operation:   "POST",
 			Path:        "/pets",

--- a/checker/check_response_property_all_of_updated_test.go
+++ b/checker/check_response_property_all_of_updated_test.go
@@ -34,7 +34,7 @@ func TestResponsePropertyAllOfAdded(t *testing.T) {
 		},
 		{
 			Id:          checker.ResponsePropertyAllOfAddedId,
-			Args:        []any{"#/components/schemas/Breed3", "/allOf[#/components/schemas/Dog]/breed", "200"},
+			Args:        []any{"#/components/schemas/Breed3", "allOf[#/components/schemas/Dog]/breed", "200"},
 			Level:       checker.INFO,
 			Operation:   "GET",
 			Path:        "/pets",
@@ -113,7 +113,7 @@ func TestResponsePropertyAllOfRemoved(t *testing.T) {
 		},
 		{
 			Id:          checker.ResponsePropertyAllOfRemovedId,
-			Args:        []any{"#/components/schemas/Breed3", "/allOf[#/components/schemas/Dog]/breed", "200"},
+			Args:        []any{"#/components/schemas/Breed3", "allOf[#/components/schemas/Dog]/breed", "200"},
 			Level:       checker.INFO,
 			Operation:   "GET",
 			Path:        "/pets",

--- a/checker/check_response_property_any_of_updated_test.go
+++ b/checker/check_response_property_any_of_updated_test.go
@@ -34,7 +34,7 @@ func TestResponsePropertyAnyOfAdded(t *testing.T) {
 		},
 		{
 			Id:          checker.ResponsePropertyAnyOfAddedId,
-			Args:        []any{"#/components/schemas/Breed3", "/anyOf[#/components/schemas/Dog]/breed", "200"},
+			Args:        []any{"#/components/schemas/Breed3", "anyOf[#/components/schemas/Dog]/breed", "200"},
 			Level:       checker.INFO,
 			Operation:   "GET",
 			Path:        "/pets",
@@ -91,7 +91,7 @@ func TestResponsePropertyAnyOfRemoved(t *testing.T) {
 		},
 		{
 			Id:          checker.ResponsePropertyAnyOfRemovedId,
-			Args:        []any{"#/components/schemas/Breed3", "/anyOf[#/components/schemas/Dog]/breed", "200"},
+			Args:        []any{"#/components/schemas/Breed3", "anyOf[#/components/schemas/Dog]/breed", "200"},
 			Level:       checker.INFO,
 			Operation:   "GET",
 			Path:        "/pets",

--- a/checker/check_response_property_one_of_updated_test.go
+++ b/checker/check_response_property_one_of_updated_test.go
@@ -34,7 +34,7 @@ func TestResponsePropertyOneOfAdded(t *testing.T) {
 		},
 		{
 			Id:          checker.ResponsePropertyOneOfAddedId,
-			Args:        []any{"#/components/schemas/Breed3", "/oneOf[#/components/schemas/Dog]/breed", "200"},
+			Args:        []any{"#/components/schemas/Breed3", "oneOf[#/components/schemas/Dog]/breed", "200"},
 			Level:       checker.ERR,
 			Operation:   "GET",
 			Path:        "/pets",
@@ -43,7 +43,7 @@ func TestResponsePropertyOneOfAdded(t *testing.T) {
 		},
 		{
 			Id:          checker.ResponsePropertyOneOfAddedId,
-			Args:        []any{"subschema #2: Dark brown types", "/oneOf[#/components/schemas/Fox]/breed", "200"},
+			Args:        []any{"subschema #2: Dark brown types", "oneOf[#/components/schemas/Fox]/breed", "200"},
 			Level:       checker.ERR,
 			Operation:   "GET",
 			Path:        "/pets",
@@ -100,7 +100,7 @@ func TestResponsePropertyOneOfRemoved(t *testing.T) {
 		},
 		{
 			Id:          checker.ResponsePropertyOneOfRemovedId,
-			Args:        []any{"#/components/schemas/Breed3", "/oneOf[#/components/schemas/Dog]/breed", "200"},
+			Args:        []any{"#/components/schemas/Breed3", "oneOf[#/components/schemas/Dog]/breed", "200"},
 			Level:       checker.INFO,
 			Operation:   "GET",
 			Path:        "/pets",
@@ -109,7 +109,7 @@ func TestResponsePropertyOneOfRemoved(t *testing.T) {
 		},
 		{
 			Id:          checker.ResponsePropertyOneOfRemovedId,
-			Args:        []any{"subschema #2: Dark brown types", "/oneOf[#/components/schemas/Fox]/breed", "200"},
+			Args:        []any{"subschema #2: Dark brown types", "oneOf[#/components/schemas/Fox]/breed", "200"},
 			Level:       checker.INFO,
 			Operation:   "GET",
 			Path:        "/pets",

--- a/checker/check_response_property_type_changed_test.go
+++ b/checker/check_response_property_type_changed_test.go
@@ -95,7 +95,7 @@ func TestResponsePropertyAnyOfModified(t *testing.T) {
 	require.ElementsMatch(t, []checker.ApiChange{
 		{
 			Id:          checker.ResponsePropertyTypeChangedId,
-			Args:        []any{"/anyOf[#/components/schemas/Dog]/breed/anyOf[#/components/schemas/Breed2]/name", []string{"string"}, "", []string{"number"}, "", "200"},
+			Args:        []any{"anyOf[#/components/schemas/Dog]/breed/anyOf[#/components/schemas/Breed2]/name", []string{"string"}, "", []string{"number"}, "", "200"},
 			Level:       checker.ERR,
 			Operation:   "GET",
 			Path:        "/pets",
@@ -104,7 +104,7 @@ func TestResponsePropertyAnyOfModified(t *testing.T) {
 		},
 		{
 			Id:          checker.ResponsePropertyTypeChangedId,
-			Args:        []any{"/anyOf[subschema #3: Rabbit]/", []string{"string"}, "", []string{"number"}, "", "200"},
+			Args:        []any{"anyOf[subschema #3: Rabbit]/", []string{"string"}, "", []string{"number"}, "", "200"},
 			Level:       checker.ERR,
 			Operation:   "GET",
 			Path:        "/pets",
@@ -113,7 +113,7 @@ func TestResponsePropertyAnyOfModified(t *testing.T) {
 		},
 		{
 			Id:          checker.ResponsePropertyTypeChangedId,
-			Args:        []any{"/anyOf[subschema #4 -> subschema #5]/", []string{"string"}, "", []string{"number"}, "", "200"},
+			Args:        []any{"anyOf[subschema #4 -> subschema #5]/", []string{"string"}, "", []string{"number"}, "", "200"},
 			Level:       checker.ERR,
 			Operation:   "GET",
 			Path:        "/pets",
@@ -159,7 +159,7 @@ func TestResponseAdditionalPropertyTypeChangedCheck(t *testing.T) {
 	require.Len(t, errs, 1)
 	require.Equal(t, checker.ApiChange{
 		Id:          checker.ResponsePropertyTypeChangedId,
-		Args:        []any{"/additionalProperties/property1", []string{"integer"}, "", []string{"string"}, "", "200"},
+		Args:        []any{"additionalProperties/property1", []string{"integer"}, "", []string{"string"}, "", "200"},
 		Level:       checker.ERR,
 		Operation:   "GET",
 		Path:        "/value",

--- a/checker/checks-utils.go
+++ b/checker/checks-utils.go
@@ -24,6 +24,15 @@ func propertyFullName(propertyPath string, propertyNames ...string) string {
 	return propertyFullName
 }
 
+// joinPath joins a property path with a segment using "/" as separator,
+// avoiding a leading slash when the path is empty.
+func joinPath(propertyPath, segment string) string {
+	if propertyPath == "" {
+		return segment
+	}
+	return propertyPath + "/" + segment
+}
+
 func interfaceToString(arg any) string {
 	if arg == nil {
 		return "undefined"
@@ -79,24 +88,24 @@ func processModifiedPropertiesDiff(propertyPath string, propertyName string, sch
 
 	if schemaDiff.AllOfDiff != nil {
 		for _, v := range schemaDiff.AllOfDiff.Modified {
-			processModifiedPropertiesDiff(fmt.Sprintf("%s/allOf[%s]", propertyPath, v), "", v.Diff, schemaDiff, processor)
+			processModifiedPropertiesDiff(joinPath(propertyPath, fmt.Sprintf("allOf[%s]", v)), "", v.Diff, schemaDiff, processor)
 		}
 	}
 
 	if schemaDiff.AnyOfDiff != nil {
 		for _, v := range schemaDiff.AnyOfDiff.Modified {
-			processModifiedPropertiesDiff(fmt.Sprintf("%s/anyOf[%s]", propertyPath, v), "", v.Diff, schemaDiff, processor)
+			processModifiedPropertiesDiff(joinPath(propertyPath, fmt.Sprintf("anyOf[%s]", v)), "", v.Diff, schemaDiff, processor)
 		}
 	}
 
 	if schemaDiff.OneOfDiff != nil {
 		for _, v := range schemaDiff.OneOfDiff.Modified {
-			processModifiedPropertiesDiff(fmt.Sprintf("%s/oneOf[%s]", propertyPath, v), "", v.Diff, schemaDiff, processor)
+			processModifiedPropertiesDiff(joinPath(propertyPath, fmt.Sprintf("oneOf[%s]", v)), "", v.Diff, schemaDiff, processor)
 		}
 	}
 
 	if schemaDiff.ItemsDiff != nil {
-		processModifiedPropertiesDiff(fmt.Sprintf("%s/items", propertyPath), "", schemaDiff.ItemsDiff, schemaDiff, processor)
+		processModifiedPropertiesDiff(joinPath(propertyPath, "items"), "", schemaDiff.ItemsDiff, schemaDiff, processor)
 	}
 
 	if schemaDiff.PropertiesDiff != nil {
@@ -106,7 +115,7 @@ func processModifiedPropertiesDiff(propertyPath string, propertyName string, sch
 	}
 
 	if schemaDiff.AdditionalPropertiesDiff != nil {
-		processModifiedPropertiesDiff(fmt.Sprintf("%s/additionalProperties", propertyPath), "", schemaDiff.AdditionalPropertiesDiff, schemaDiff, processor)
+		processModifiedPropertiesDiff(joinPath(propertyPath, "additionalProperties"), "", schemaDiff.AdditionalPropertiesDiff, schemaDiff, processor)
 	}
 }
 
@@ -128,24 +137,24 @@ func processAddedPropertiesDiff(propertyPath string, propertyName string, schema
 
 	if schemaDiff.AllOfDiff != nil {
 		for _, v := range schemaDiff.AllOfDiff.Modified {
-			processAddedPropertiesDiff(fmt.Sprintf("%s/allOf[%s]", propertyPath, v), "", v.Diff, processor)
+			processAddedPropertiesDiff(joinPath(propertyPath, fmt.Sprintf("allOf[%s]", v)), "", v.Diff, processor)
 		}
 	}
 
 	if schemaDiff.AnyOfDiff != nil {
 		for _, v := range schemaDiff.AnyOfDiff.Modified {
-			processAddedPropertiesDiff(fmt.Sprintf("%s/anyOf[%s]", propertyPath, v), "", v.Diff, processor)
+			processAddedPropertiesDiff(joinPath(propertyPath, fmt.Sprintf("anyOf[%s]", v)), "", v.Diff, processor)
 		}
 	}
 
 	if schemaDiff.OneOfDiff != nil {
 		for _, v := range schemaDiff.OneOfDiff.Modified {
-			processAddedPropertiesDiff(fmt.Sprintf("%s/oneOf[%s]", propertyPath, v), "", v.Diff, processor)
+			processAddedPropertiesDiff(joinPath(propertyPath, fmt.Sprintf("oneOf[%s]", v)), "", v.Diff, processor)
 		}
 	}
 
 	if schemaDiff.ItemsDiff != nil {
-		processAddedPropertiesDiff(fmt.Sprintf("%s/items", propertyPath), "", schemaDiff.ItemsDiff, processor)
+		processAddedPropertiesDiff(joinPath(propertyPath, "items"), "", schemaDiff.ItemsDiff, processor)
 	}
 
 	if schemaDiff.PropertiesDiff != nil {
@@ -177,23 +186,23 @@ func processDeletedPropertiesDiff(propertyPath string, propertyName string, sche
 
 	if schemaDiff.AllOfDiff != nil {
 		for _, v := range schemaDiff.AllOfDiff.Modified {
-			processDeletedPropertiesDiff(fmt.Sprintf("%s/allOf[%s]", propertyPath, v), "", v.Diff, processor)
+			processDeletedPropertiesDiff(joinPath(propertyPath, fmt.Sprintf("allOf[%s]", v)), "", v.Diff, processor)
 		}
 	}
 	if schemaDiff.AnyOfDiff != nil {
 		for _, v := range schemaDiff.AnyOfDiff.Modified {
-			processDeletedPropertiesDiff(fmt.Sprintf("%s/anyOf[%s]", propertyPath, v), "", v.Diff, processor)
+			processDeletedPropertiesDiff(joinPath(propertyPath, fmt.Sprintf("anyOf[%s]", v)), "", v.Diff, processor)
 		}
 	}
 
 	if schemaDiff.OneOfDiff != nil {
 		for _, v := range schemaDiff.OneOfDiff.Modified {
-			processDeletedPropertiesDiff(fmt.Sprintf("%s/oneOf[%s]", propertyPath, v), "", v.Diff, processor)
+			processDeletedPropertiesDiff(joinPath(propertyPath, fmt.Sprintf("oneOf[%s]", v)), "", v.Diff, processor)
 		}
 	}
 
 	if schemaDiff.ItemsDiff != nil {
-		processDeletedPropertiesDiff(fmt.Sprintf("%s/items", propertyPath), "", schemaDiff.ItemsDiff, processor)
+		processDeletedPropertiesDiff(joinPath(propertyPath, "items"), "", schemaDiff.ItemsDiff, processor)
 	}
 
 	if schemaDiff.PropertiesDiff != nil {


### PR DESCRIPTION
## Summary

When a breaking change involved `additionalProperties`, `allOf`, `anyOf`, `oneOf`, or `items` at the root of a response or request schema, the reported property path started with a spurious leading slash.

**Before**
```
the '/additionalProperties/property1' response's property type/format changed from 'integer'/'' to 'string'/'' for status '200'
```

**After**
```
the 'additionalProperties/property1' response's property type/format changed from 'integer'/'' to 'string'/'' for status '200'
```

## Root cause

The three recursive path walkers in `checker/checks-utils.go` (`process{Modified,Added,Deleted}PropertiesDiff`) already handle the empty-path case correctly for regular property names:

```go
if propertyPath == "" {
    propertyPath = propertyName
} else {
    propertyPath = propertyPath + "/" + propertyName
}
```

But for the composite keywords (`allOf`, `anyOf`, `oneOf`, `items`, `additionalProperties`) they unconditionally prepended a slash via `fmt.Sprintf("%s/allOf[%s]", propertyPath, v)` etc. When `propertyPath` was empty (root schema) this produced a leading slash.

## Fix

Added a `joinPath(propertyPath, segment)` helper that matches the existing empty-path handling, and used it in all five composite-keyword branches across all three walkers.

## Test impact

This changes user-visible output. 31 test assertions across 12 files pinned the buggy format — all updated to the corrected format.

## Test plan
- [x] All checker tests pass
- [x] Full `go test ./...` passes
- [x] CLI verified against `data/additional-properties` — leading slash gone

## Note for users

If you have ignore-file patterns that match paths starting with `/additionalProperties`, `/allOf[`, `/anyOf[`, `/oneOf[`, or `/items` at the root of a schema, those patterns will need their leading slash removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)