### PR TITLE
fix: preserve git ref prefix when resolving relative $refs

### DIFF
--- a/load/load.go
+++ b/load/load.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -30,39 +31,46 @@ func from(loader *openapi3.Loader, source *Source) (*openapi3.T, error) {
 // It runs "git show <ref>" to obtain the content and loads it via LoadFromDataWithPath so that
 // relative $refs are resolved against the spec's path.
 //
-// Relative $refs (e.g. "./schemas/pet.yaml") are resolved by kin-openapi into paths like
-// "origin/main:multi-file/schemas/pet.yaml". We install a ReadFromURIFunc so the loader
-// recognises that pattern and reads referenced files via "git show" too.
+// Relative $refs (e.g. "./schemas/pet.yaml") are resolved by kin-openapi; we install a
+// JoinFunc so the "<rev>:" prefix is preserved (the default path.Dir strips it), and a
+// ReadFromURIFunc so referenced files are read via "git show" too.
 func loadFromGitRevision(loader *openapi3.Loader, gitRef string) (*openapi3.T, error) {
 	out, err := gitShow(gitRef)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load spec from git revision %q: %w", gitRef, err)
 	}
 
-	// gitPrefix is the "revision:" part of gitRef (e.g. "HEAD:", "origin/main:").
-	// When a spec lives at the repo root (no "/" in gitRef after the ":"), Go's URL
-	// resolution strips the prefix from relative $refs — e.g. "HEAD:openapi.yaml" +
-	// "./schemas/pet.yaml" → "schemas/pet.yaml" instead of "HEAD:schemas/pet.yaml".
-	// We capture the prefix here so we can restore it in ReadFromURIFunc.
-	gitPrefix := gitRef[:strings.Index(gitRef, ":")+1]
+	// Copy the loader so we can install custom resolvers without mutating the caller's
+	// instance. The shallow copy shares the unexported visitedDocuments cache, which is
+	// intentional: common $ref files are not fetched twice, and the unique gitRef-based
+	// URL keys prevent collisions between base and revision entries.
+	loaderCopy := *loader
 
-	// Copy the loader so we can install a custom ReadFromURIFunc without mutating the
-	// caller's instance. The shallow copy shares the unexported visitedDocuments cache,
-	// which is intentional: common $ref files are not fetched twice, and the unique
-	// gitRef-based URL keys prevent collisions between base and revision entries.
+	// JoinFunc preserves the "<rev>:" prefix when resolving relative $refs.
+	// Without this, path.Dir("origin/main:openapi.yaml") returns "origin" and
+	// "./schemas/pet.yaml" resolves to "origin/schemas/pet.yaml" instead of
+	// "origin/main:schemas/pet.yaml".
+	loaderCopy.JoinFunc = func(basePath, relativePath *url.URL) *url.URL {
+		if basePath == nil {
+			return relativePath
+		}
+		result := *basePath
+		base := basePath.Path
+		if i := strings.IndexByte(base, ':'); i >= 0 {
+			result.Path = base[:i+1] + path.Join(path.Dir(base[i+1:]), relativePath.Path)
+		} else {
+			result.Path = path.Join(path.Dir(base), relativePath.Path)
+		}
+		return &result
+	}
+
 	// kin-openapi calls ReadFromURIFunc before checking IsExternalRefsAllowed, so the
 	// caller's --allow-external-refs setting is still enforced for non-git refs via
 	// DefaultReadFromURI.
-	loaderCopy := *loader
 	loaderCopy.ReadFromURIFunc = func(loader *openapi3.Loader, location *url.URL) ([]byte, error) {
 		p := filepath.FromSlash(location.Path)
 		if isGitRevision(p) {
 			return gitShow(p)
-		}
-		// Relative path without the git prefix — happens when the spec is at the repo
-		// root and Go URL resolution drops the "revision:" prefix. Restore it.
-		if location.Scheme == "" && location.Host == "" {
-			return gitShow(gitPrefix + p)
 		}
 		return openapi3.DefaultReadFromURI(loader, location)
 	}

--- a/load/spec_info_git_test.go
+++ b/load/spec_info_git_test.go
@@ -188,6 +188,83 @@ paths: {}
 	require.Nil(t, loader.ReadFromURIFunc, "loadFromGitRevision must not mutate the caller's loader")
 }
 
+// TestLoadInfo_GitRevisionSlashedRef_WithExternalRef verifies that $ref resolution
+// works when the git revision contains a slash (e.g. "origin/main:openapi.yaml").
+// Reproduces the production failure in oasdiff-test/tmp: path.Dir("origin/main:openapi.yaml")
+// returns "origin" (not "origin/main:"), so a naive join mangles "./schemas/pet.yaml"
+// into "origin/schemas/pet.yaml" instead of "origin/main:schemas/pet.yaml".
+func TestLoadInfo_GitRevisionSlashedRef_WithExternalRef(t *testing.T) {
+	dir := t.TempDir()
+	remoteDir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(out))
+	}
+
+	// Bare remote to enable "origin/main:..." refs.
+	bareCmd := exec.Command("git", "init", "--bare", remoteDir)
+	out, err := bareCmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	run("git", "init", "-b", "main")
+	run("git", "config", "user.email", "test@test.com")
+	run("git", "config", "user.name", "Test")
+	run("git", "remote", "add", "origin", remoteDir)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "schemas"), 0755))
+
+	topLevel := `openapi: "3.0.0"
+info:
+  title: Test
+  version: "1.0"
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "./schemas/pet.yaml"
+`
+	petSchema := `type: object
+required:
+  - id
+properties:
+  id:
+    type: integer
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "openapi.yaml"), []byte(topLevel), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "schemas", "pet.yaml"), []byte(petSchema), 0644))
+
+	run("git", "add", ".")
+	run("git", "commit", "-m", "add multi-file spec")
+	run("git", "push", "origin", "main")
+	run("git", "fetch", "origin")
+
+	// Remove working-tree copies so $ref resolution must go through "git show".
+	require.NoError(t, os.Remove(filepath.Join(dir, "openapi.yaml")))
+	require.NoError(t, os.Remove(filepath.Join(dir, "schemas", "pet.yaml")))
+
+	oldDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	defer os.Chdir(oldDir) //nolint:errcheck
+
+	specInfo, err := load.NewSpecInfo(openapi3.NewLoader(), load.NewSource("origin/main:openapi.yaml"))
+	require.NoError(t, err)
+	require.Equal(t, "1.0", specInfo.GetVersion())
+
+	schema := specInfo.Spec.Paths.Value("/pets").Get.Responses.Value("200").Value.Content["application/json"].Schema.Value
+	require.NotNil(t, schema.Properties["id"], "id property from $ref chain should be resolved")
+}
+
 func TestLoadInfo_GitRevisionNoGit(t *testing.T) {
 	t.Setenv("PATH", t.TempDir()) // remove git from PATH
 	_, err := load.NewSpecInfo(openapi3.NewLoader(), load.NewSource("HEAD:openapi.yaml"))


### PR DESCRIPTION
## Summary

- Fix `origin/main:openapi.yaml`-style base-spec failures when the spec has relative `$ref`s. `path.Dir("origin/main:openapi.yaml")` returns `"origin"` (not `"origin/main:"`), so kin-openapi's default join mangles `./schemas/pet.yaml` into `origin/schemas/pet.yaml`. The prior `ReadFromURIFunc` fallback compounded the bug by prepending `origin/main:` to the already-mangled path, producing `origin/main:origin/schemas/pet.yaml` and a git *"path does not exist"* error.
- Install `JoinFunc` (added in kin-openapi#1154) so relative `$refs` resolve against only the file portion of the ref and the `<rev>:` prefix is preserved. Remove the now-redundant fallback in `ReadFromURIFunc` — one extension point, no workaround.
- Add `TestLoadInfo_GitRevisionSlashedRef_WithExternalRef` reproducing the production failure observed in `oasdiff-test/tmp` (run [24828770261](https://github.com/oasdiff-test/tmp/actions/runs/24828770261)).

## Dependency — this PR is blocked

The code uses `loader.JoinFunc`, which is added by **getkin/kin-openapi#1154** (not yet merged, no release). This PR will not build or pass CI until:

1. kin-openapi#1154 is merged
2. A new kin-openapi release is cut
3. `go.mod` is bumped to that release in a follow-up commit

Opening as draft now to make the oasdiff-side change reviewable in parallel with the upstream PR.

Local verification against the #1154 branch (via `replace` directive): all 13 tests in `load/`  including the new repro pass; end-to-end `oasdiff diff origin/main:openapi.yaml …` against oasdiff-test/tmp succeeds (whereas without the fix it reproduces the exact production error).

## Test plan

- [x] New test `TestLoadInfo_GitRevisionSlashedRef_WithExternalRef` fails on current main with the identical production error, and passes with this patch
- [x] All pre-existing git-revision tests still pass (`HEAD:openapi.yaml` root case, two-revision shared-loader, git-then-local-file, no-git)
- [x] Full suite `go test ./...` green
- [ ] Re-verify after `go.mod` is bumped to a released kin-openapi version containing #1154
- [ ] Re-run the oasdiff-test/tmp action end-to-end against a published build

🤖 Generated with [Claude Code](https://claude.com/claude-code)