### PR TITLE
chore: remove dead Slack badge from README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,6 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/oasdiff/oasdiff)](https://goreportcard.com/report/github.com/oasdiff/oasdiff)
 [![GoDoc](https://godoc.org/github.com/oasdiff/oasdiff?status.svg)](https://godoc.org/github.com/oasdiff/oasdiff)
 [![Docker Image Version](https://img.shields.io/docker/v/tufin/oasdiff?sort=semver)](https://hub.docker.com/r/tufin/oasdiff/tags)
-[![Slack](https://img.shields.io/badge/slack-&#64;oasdiff-green.svg?logo=slack)](https://join.slack.com/t/oasdiff/shared_invite/zt-1wvo7wois-ttncNBmyjyRXqBzyg~P6oA)
 
 ![oasdiff banner](https://github.com/yonatanmgr/oasdiff/assets/31913495/ac9b154e-72d1-4969-bc3b-f527bbe7751d)
 


### PR DESCRIPTION
## Summary

Remove the Slack badge from `docs/README.md`. The shared-invite link had expired, causing the `detect-broken-links` workflow to fail with HTTP 403 on every PR (blocking #862 among others).

Slack is not actively used for oasdiff, so removing the badge is cleaner than generating a new invite.

## Test plan

- [ ] `detect-broken-links` check passes on this PR
- [ ] Verify no other Slack references linger in the repo (grep came back clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)