### PR TITLE
chore: bump kin-openapi to v0.136.0

### DIFF
--- a/flatten/allof/merge_allof.go
+++ b/flatten/allof/merge_allof.go
@@ -32,8 +32,8 @@ type SchemaCollection struct {
 	Description          []string
 	Enum                 [][]any
 	UniqueItems          []bool
-	ExclusiveMin         []bool
-	ExclusiveMax         []bool
+	ExclusiveMin         []openapi3.ExclusiveBound
+	ExclusiveMax         []openapi3.ExclusiveBound
 	Min                  []*float64
 	Max                  []*float64
 	MultipleOf           []*float64
@@ -210,17 +210,17 @@ func mergeInternal(state *state, base *openapi3.SchemaRef) (*openapi3.SchemaRef,
 	result.Value.Default = base.Value.Default
 	result.Value.Discriminator = base.Value.Discriminator
 	if base.Value.MaxLength != nil {
-		result.Value.MaxLength = openapi3.Ptr(*base.Value.MaxLength)
+		result.Value.MaxLength = new(*base.Value.MaxLength)
 	}
 	result.Value.Pattern = base.Value.Pattern
 	result.Value.MinItems = base.Value.MinItems
 	if base.Value.MaxItems != nil {
-		result.Value.MaxItems = openapi3.Ptr(*base.Value.MaxItems)
+		result.Value.MaxItems = new(*base.Value.MaxItems)
 	}
 	result.Value.Required = base.Value.Required
 	result.Value.MinProps = base.Value.MinProps
 	if base.Value.MaxProps != nil {
-		result.Value.MaxProps = openapi3.Ptr(*base.Value.MaxProps)
+		result.Value.MaxProps = new(*base.Value.MaxProps)
 	}
 
 	// merge all fields of type SchemaRef
@@ -431,36 +431,36 @@ func resolveNumberRange(schema *openapi3.Schema, collection *SchemaCollection) *
 
 	//resolve minimum
 	max := math.Inf(-1)
-	isExcluded := false
+	var exclusiveMin openapi3.ExclusiveBound
 	var value *float64
 	for i, s := range collection.Min {
 		if s != nil {
 			if *s > max {
 				max = *s
 				value = s
-				isExcluded = collection.ExclusiveMin[i]
+				exclusiveMin = collection.ExclusiveMin[i]
 			}
 		}
 	}
 
 	schema.Min = value
-	schema.ExclusiveMin = isExcluded
+	schema.ExclusiveMin = exclusiveMin
 	//resolve maximum
 	min := math.Inf(1)
-	isExcluded = false
+	var exclusiveMax openapi3.ExclusiveBound
 	// var value *float64
 	for i, s := range collection.Max {
 		if s != nil {
 			if *s < min {
 				min = *s
 				value = s
-				isExcluded = collection.ExclusiveMax[i]
+				exclusiveMax = collection.ExclusiveMax[i]
 			}
 		}
 	}
 
 	schema.Max = value
-	schema.ExclusiveMax = isExcluded
+	schema.ExclusiveMax = exclusiveMax
 	return schema
 }
 
@@ -547,7 +547,7 @@ func resolveMultipleOf(schema *openapi3.Schema, collection *SchemaCollection) *o
 	for _, v := range uintValues {
 		lcmValue = lcm(lcmValue, v)
 	}
-	schema.MultipleOf = openapi3.Ptr(float64(lcmValue) / factor)
+	schema.MultipleOf = new(float64(lcmValue) / factor)
 	return schema
 }
 
@@ -761,7 +761,7 @@ func findMinValue(values []*uint64) *uint64 {
 			min = num
 		}
 	}
-	return openapi3.Ptr(min)
+	return new(min)
 }
 
 func resolveType(schema *openapi3.Schema, collection *SchemaCollection) (*openapi3.Schema, error) {

--- a/flatten/allof/merge_allof_test.go
+++ b/flatten/allof/merge_allof_test.go
@@ -10,6 +10,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// exclusiveBoundBool creates an ExclusiveBound with a boolean value (OpenAPI 3.0 style).
+func exclusiveBoundBool(b bool) openapi3.ExclusiveBound {
+	return openapi3.ExclusiveBound{Bool: &b}
+}
+
 // identical Default fields are merged successfully
 func TestMerge_Default(t *testing.T) {
 	merged, err := allof.Merge(
@@ -298,14 +303,14 @@ func TestMerge_NestedAllOfInProperties(t *testing.T) {
 									Value: &openapi3.Schema{
 										Type:     &openapi3.Types{"object"},
 										MinProps: 10,
-										MaxProps: openapi3.Ptr(uint64(40)),
+										MaxProps: new(uint64(40)),
 									},
 								},
 								&openapi3.SchemaRef{
 									Value: &openapi3.Schema{
 										Type:     &openapi3.Types{"object"},
 										MinProps: 5,
-										MaxProps: openapi3.Ptr(uint64(25)),
+										MaxProps: new(uint64(25)),
 									},
 								},
 							},
@@ -331,14 +336,14 @@ func TestMerge_NestedAllOfInNot(t *testing.T) {
 								Value: &openapi3.Schema{
 									Type:     &openapi3.Types{"object"},
 									MinProps: 10,
-									MaxProps: openapi3.Ptr(uint64(40)),
+									MaxProps: new(uint64(40)),
 								},
 							},
 							&openapi3.SchemaRef{
 								Value: &openapi3.Schema{
 									Type:     &openapi3.Types{"object"},
 									MinProps: 5,
-									MaxProps: openapi3.Ptr(uint64(25)),
+									MaxProps: new(uint64(25)),
 								},
 							},
 						},
@@ -364,14 +369,14 @@ func TestMerge_NestedAllOfInOneOf(t *testing.T) {
 									Value: &openapi3.Schema{
 										Type:     &openapi3.Types{"object"},
 										MinProps: 10,
-										MaxProps: openapi3.Ptr(uint64(40)),
+										MaxProps: new(uint64(40)),
 									},
 								},
 								&openapi3.SchemaRef{
 									Value: &openapi3.Schema{
 										Type:     &openapi3.Types{"object"},
 										MinProps: 5,
-										MaxProps: openapi3.Ptr(uint64(25)),
+										MaxProps: new(uint64(25)),
 									},
 								},
 							},
@@ -399,14 +404,14 @@ func TestMerge_NestedAllOfInAnyOf(t *testing.T) {
 									Value: &openapi3.Schema{
 										Type:     &openapi3.Types{"object"},
 										MinProps: 10,
-										MaxProps: openapi3.Ptr(uint64(40)),
+										MaxProps: new(uint64(40)),
 									},
 								},
 								&openapi3.SchemaRef{
 									Value: &openapi3.Schema{
 										Type:     &openapi3.Types{"object"},
 										MinProps: 5,
-										MaxProps: openapi3.Ptr(uint64(25)),
+										MaxProps: new(uint64(25)),
 									},
 								},
 							},
@@ -570,21 +575,21 @@ func TestMerge_ExclusiveMaxIsTrue(t *testing.T) {
 					&openapi3.SchemaRef{
 						Value: &openapi3.Schema{
 							Type:         &openapi3.Types{"object"},
-							ExclusiveMax: true,
-							Max:          openapi3.Ptr(1.0),
+							ExclusiveMax: exclusiveBoundBool(true),
+							Max:          new(1.0),
 						},
 					},
 					&openapi3.SchemaRef{
 						Value: &openapi3.Schema{
 							Type:         &openapi3.Types{"object"},
-							ExclusiveMax: false,
-							Max:          openapi3.Ptr(2.0),
+							ExclusiveMax: exclusiveBoundBool(false),
+							Max:          new(2.0),
 						},
 					},
 				},
 			}})
 	require.NoError(t, err)
-	require.Equal(t, true, merged.ExclusiveMax)
+	require.True(t, merged.ExclusiveMax.IsTrue())
 }
 
 // if ExclusiveMax is false on the minimum Max value, then ExclusiveMax is false in the merged schema.
@@ -596,21 +601,21 @@ func TestMerge_ExclusiveMaxIsFalse(t *testing.T) {
 					&openapi3.SchemaRef{
 						Value: &openapi3.Schema{
 							Type:         &openapi3.Types{"object"},
-							ExclusiveMax: false,
-							Max:          openapi3.Ptr(1.0),
+							ExclusiveMax: exclusiveBoundBool(false),
+							Max:          new(1.0),
 						},
 					},
 					&openapi3.SchemaRef{
 						Value: &openapi3.Schema{
 							Type:         &openapi3.Types{"object"},
-							ExclusiveMax: true,
-							Max:          openapi3.Ptr(2.0),
+							ExclusiveMax: exclusiveBoundBool(true),
+							Max:          new(2.0),
 						},
 					},
 				},
 			}})
 	require.NoError(t, err)
-	require.Equal(t, false, merged.ExclusiveMax)
+	require.False(t, merged.ExclusiveMax.IsTrue())
 }
 
 // if ExclusiveMin is false on the highest Min value, then ExclusiveMin is false in the merged schema.
@@ -622,21 +627,21 @@ func TestMerge_ExclusiveMinIsFalse(t *testing.T) {
 					&openapi3.SchemaRef{
 						Value: &openapi3.Schema{
 							Type:         &openapi3.Types{"object"},
-							ExclusiveMin: false,
-							Min:          openapi3.Ptr(40.0),
+							ExclusiveMin: exclusiveBoundBool(false),
+							Min:          new(40.0),
 						},
 					},
 					&openapi3.SchemaRef{
 						Value: &openapi3.Schema{
 							Type:         &openapi3.Types{"object"},
-							ExclusiveMin: true,
-							Min:          openapi3.Ptr(5.0),
+							ExclusiveMin: exclusiveBoundBool(true),
+							Min:          new(5.0),
 						},
 					},
 				},
 			}})
 	require.NoError(t, err)
-	require.Equal(t, false, merged.ExclusiveMin)
+	require.False(t, merged.ExclusiveMin.IsTrue())
 }
 
 // if ExclusiveMin is true on the highest Min value, then ExclusiveMin is true in the merged schema.
@@ -648,21 +653,21 @@ func TestMerge_ExclusiveMinIsTrue(t *testing.T) {
 					&openapi3.SchemaRef{
 						Value: &openapi3.Schema{
 							Type:         &openapi3.Types{"object"},
-							ExclusiveMin: true,
-							Min:          openapi3.Ptr(40.0),
+							ExclusiveMin: exclusiveBoundBool(true),
+							Min:          new(40.0),
 						},
 					},
 					&openapi3.SchemaRef{
 						Value: &openapi3.Schema{
 							Type:         &openapi3.Types{"object"},
-							ExclusiveMin: false,
-							Min:          openapi3.Ptr(5.0),
+							ExclusiveMin: exclusiveBoundBool(false),
+							Min:          new(5.0),
 						},
 					},
 				},
 			}})
 	require.NoError(t, err)
-	require.Equal(t, true, merged.ExclusiveMin)
+	require.True(t, merged.ExclusiveMin.IsTrue())
 }
 
 // merge multiple Not inside AllOf
@@ -939,13 +944,13 @@ func TestMerge_MultipleOfContained(t *testing.T) {
 					&openapi3.SchemaRef{
 						Value: &openapi3.Schema{
 							Type:       &openapi3.Types{"object"},
-							MultipleOf: openapi3.Ptr(10.0),
+							MultipleOf: new(10.0),
 						},
 					},
 					&openapi3.SchemaRef{
 						Value: &openapi3.Schema{
 							Type:       &openapi3.Types{"object"},
-							MultipleOf: openapi3.Ptr(2.0),
+							MultipleOf: new(2.0),
 						},
 					},
 				},
@@ -962,13 +967,13 @@ func TestMerge_MultipleOfDecimal(t *testing.T) {
 					&openapi3.SchemaRef{
 						Value: &openapi3.Schema{
 							Type:       &openapi3.Types{"object"},
-							MultipleOf: openapi3.Ptr(11.0),
+							MultipleOf: new(11.0),
 						},
 					},
 					&openapi3.SchemaRef{
 						Value: &openapi3.Schema{
 							Type:       &openapi3.Types{"object"},
-							MultipleOf: openapi3.Ptr(0.7),
+							MultipleOf: new(0.7),
 						},
 					},
 				},
@@ -1033,14 +1038,14 @@ func TestMerge_RangeProperties(t *testing.T) {
 						Value: &openapi3.Schema{
 							Type:     &openapi3.Types{"object"},
 							MinProps: 10,
-							MaxProps: openapi3.Ptr(uint64(40)),
+							MaxProps: new(uint64(40)),
 						},
 					},
 					&openapi3.SchemaRef{
 						Value: &openapi3.Schema{
 							Type:     &openapi3.Types{"object"},
 							MinProps: 5,
-							MaxProps: openapi3.Ptr(uint64(25)),
+							MaxProps: new(uint64(25)),
 						},
 					},
 				},
@@ -1061,14 +1066,14 @@ func TestMerge_RangeItems(t *testing.T) {
 						Value: &openapi3.Schema{
 							Type:     &openapi3.Types{"object"},
 							MinItems: 10,
-							MaxItems: openapi3.Ptr(uint64(40)),
+							MaxItems: new(uint64(40)),
 						},
 					},
 					&openapi3.SchemaRef{
 						Value: &openapi3.Schema{
 							Type:     &openapi3.Types{"object"},
 							MinItems: 5,
-							MaxItems: openapi3.Ptr(uint64(25)),
+							MaxItems: new(uint64(25)),
 						},
 					},
 				},
@@ -1086,15 +1091,15 @@ func TestMerge_Range(t *testing.T) {
 					&openapi3.SchemaRef{
 						Value: &openapi3.Schema{
 							Type: &openapi3.Types{"object"},
-							Min:  openapi3.Ptr(10.0),
-							Max:  openapi3.Ptr(40.0),
+							Min:  new(10.0),
+							Max:  new(40.0),
 						},
 					},
 					&openapi3.SchemaRef{
 						Value: &openapi3.Schema{
 							Type: &openapi3.Types{"object"},
-							Min:  openapi3.Ptr(5.0),
-							Max:  openapi3.Ptr(25.0),
+							Min:  new(5.0),
+							Max:  new(25.0),
 						},
 					},
 				},
@@ -1112,13 +1117,13 @@ func TestMerge_MaxLength(t *testing.T) {
 					&openapi3.SchemaRef{
 						Value: &openapi3.Schema{
 							Type:      &openapi3.Types{"object"},
-							MaxLength: openapi3.Ptr(uint64(10)),
+							MaxLength: new(uint64(10)),
 						},
 					},
 					&openapi3.SchemaRef{
 						Value: &openapi3.Schema{
 							Type:      &openapi3.Types{"object"},
-							MaxLength: openapi3.Ptr(uint64(20)),
+							MaxLength: new(uint64(20)),
 						},
 					},
 				},

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	cloud.google.com/go v0.123.0
 	github.com/TwiN/go-color v1.4.1
-	github.com/getkin/kin-openapi v0.135.0
+	github.com/getkin/kin-openapi v0.136.0
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
@@ -20,9 +20,10 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/oasdiff/yaml v0.0.9 // indirect
-	github.com/oasdiff/yaml3 v0.0.9 // indirect
+	github.com/oasdiff/yaml3 v0.0.12 // indirect
 	github.com/pelletier/go-toml/v2 v2.3.0 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,12 +5,14 @@ github.com/TwiN/go-color v1.4.1/go.mod h1:WcPf/jtiW95WBIsEeY1Lc/b8aaWoiqQpu5cf8W
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
-github.com/getkin/kin-openapi v0.135.0 h1:751SjYfbiwqukYuVjwYEIKNfrSwS5YpA7DZnKSwQgtg=
-github.com/getkin/kin-openapi v0.135.0/go.mod h1:6dd5FJl6RdX4usBtFBaQhk9q62Yb2J0Mk5IhUO/QqFI=
+github.com/getkin/kin-openapi v0.136.0 h1:mJC/W0ZFnwGYkUUwujw+LmWGFuKcqHklJjpl8JAH5eE=
+github.com/getkin/kin-openapi v0.136.0/go.mod h1:f97ss9nLJZRi9fm0vSwKZa4KrPMltWnZf9peal6MBrs=
 github.com/go-openapi/jsonpointer v0.22.5 h1:8on/0Yp4uTb9f4XvTrM2+1CPrV05QPZXu+rvu2o9jcA=
 github.com/go-openapi/jsonpointer v0.22.5/go.mod h1:gyUR3sCvGSWchA2sUBJGluYMbe1zazrYWIkWPjjMUY0=
 github.com/go-openapi/swag/jsonname v0.25.5 h1:8p150i44rv/Drip4vWI3kGi9+4W9TdI3US3uUYSFhSo=
@@ -41,8 +43,8 @@ github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/oasdiff/yaml v0.0.9 h1:zQOvd2UKoozsSsAknnWoDJlSK4lC0mpmjfDsfqNwX48=
 github.com/oasdiff/yaml v0.0.9/go.mod h1:8lvhgJG4xiKPj3HN5lDow4jZHPlx1i7dIwzkdAo6oAM=
-github.com/oasdiff/yaml3 v0.0.9 h1:rWPrKccrdUm8J0F3sGuU+fuh9+1K/RdJlWF7O/9yw2g=
-github.com/oasdiff/yaml3 v0.0.9/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
+github.com/oasdiff/yaml3 v0.0.12 h1:75urAtPeDg2/iDEWwzNrLOWxI9N/dCh81nTTJtokt2M=
+github.com/oasdiff/yaml3 v0.0.12/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 github.com/pelletier/go-toml/v2 v2.3.0 h1:k59bC/lIZREW0/iVaQR8nDHxVq8OVlIzYCOJf421CaM=
 github.com/pelletier/go-toml/v2 v2.3.0/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=
@@ -54,6 +56,8 @@ github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.12.0 h1:/NQhBAkUb4+fH1jivKHWusDYFjMOOKU88eegjfxfHb4=
 github.com/sagikazarmark/locafero v0.12.0/go.mod h1:sZh36u/YSZ918v0Io+U9ogLYQJ9tLLBmM4eneO6WwsI=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=
 github.com/spf13/afero v1.15.0/go.mod h1:NC2ByUVxtQs4b3sIUphxK0NioZnmxgyCrfzeuq8lxMg=
 github.com/spf13/cast v1.10.0 h1:h2x0u2shc1QuLHfxi+cTJvs30+ZAHOGRic8uyGTDWxY=


### PR DESCRIPTION
## Summary

Bump `github.com/getkin/kin-openapi` from v0.135.0 to v0.136.0. v0.136.0 introduces two breaking API changes that touched `flatten/allof`:

1. **`openapi3.Schema.ExclusiveMin` / `ExclusiveMax`**: type changed from `bool` to a new `openapi3.ExclusiveBound` union (holds `*bool` for OpenAPI 3.0 style or `*float64` for OpenAPI 3.1 numeric style).
2. **`openapi3.*Ptr()` helpers removed**: per the v0.136.0 release notes, all `openapi3.Ptr()`, `openapi3.Float64Ptr()`, etc. helpers can be replaced with Go 1.26's `new(value)` builtin.

## Changes

- `flatten/allof/merge_allof.go`: `SchemaCollection.ExclusiveMin`/`ExclusiveMax` changed to `[]openapi3.ExclusiveBound`; `resolveNumberRange` updated accordingly. `openapi3.Ptr(x)` replaced with `new(x)`.
- `flatten/allof/merge_allof_test.go`: added small `exclusiveBoundBool(bool) ExclusiveBound` helper for constructing boolean-style ExclusiveBound values in struct literals; assertions updated to compare via `ExclusiveBound.IsTrue()`.
- `go.mod` / `go.sum`: dependency bump.

Pure adaptation. No oasdiff behavior change.

## Test plan

- [x] `go test ./...` green
- [x] `go build ./...` clean

## Why this PR exists

This is a prep PR to unblock other work that depends on v0.136.0:
- #860 (JoinFunc integration for git-ref `$ref` resolution) needs v0.136.0 to expose `loader.JoinFunc`.
- The `feat/openapi-3.1-support` branch will rebase on top of this and drop its `replace` directive against the `oasdiff/kin-openapi` fork beta.

Keeping this change small and isolated for easy review.
