### PR TITLE
docs: drop beta label for OpenAPI 3.1 support

### DIFF
--- a/docs/OPENAPI-31.md
+++ b/docs/OPENAPI-31.md
@@ -1,8 +1,8 @@
-# OpenAPI 3.1 Support (Beta)
+# OpenAPI 3.1 Support
 
-oasdiff now supports OpenAPI 3.1 specs across all commands: `diff`, `breaking`, and `changelog`.
+oasdiff supports OpenAPI 3.1 specs across all commands: `diff`, `breaking`, and `changelog`.
 
-This feature is currently in **beta** and available for community testing before general availability.
+OpenAPI 3.1 support is generally available starting with `v1.15.0`. Previous beta tags (`v1.15.0-openapi31.beta.*` and `v2.2.0-openapi31.beta.*`) are superseded.
 
 ## What's supported
 
@@ -25,7 +25,7 @@ Changes are detected for all 3.1-specific fields:
 - Info `summary`, License `identifier`
 
 ### Breaking changes and changelog
-148 new rule IDs covering:
+162 new rule IDs covering:
 - **Nullable type arrays**: `type: ["string", "null"]` correctly detected as nullable changes (not false-positive type changes)
 - **Webhooks**: added/removed detection + all existing operation-level checks automatically applied to modified webhook operations
 - **const**: added/removed/changed for request and response body/properties
@@ -40,80 +40,19 @@ Changes are detected for all 3.1-specific fields:
 - **unevaluatedItems/unevaluatedProperties**: added/removed
 - **contentSchema/contentMediaType/contentEncoding**: added/removed/changed
 
-## Known limitations
+## Caveats
 
-The following OpenAPI 3.1 / JSON Schema 2020-12 features are not yet fully implemented:
+The following 3.1 features are not yet fully supported by [`kin-openapi`](https://github.com/getkin/kin-openapi) (the parser oasdiff uses) and therefore do not appear in oasdiff diffs:
 
-- **`$dynamicRef`/`$dynamicAnchor`**: not resolved during loading; referenced schemas are not followed
-- **`pathItems` in `components`**: not yet supported
-- **Built-in validator**: most 3.1-specific keywords (e.g. `prefixItems`, `contains`, `if`/`then`/`else`) are only enforced when JSON Schema 2020-12 validation is explicitly enabled via `EnableJSONSchema2020()`; without it, validation silently skips them
-- **`prefixItems` in array validation**: not enforced by the built-in validator even with JSON Schema 2020-12 enabled
+- **`$dynamicRef` / `$dynamicAnchor`**: parsed but not resolved during loading. Schemas using dynamic references for recursive definitions will not be followed.
+- **`pathItems` in `components`**: not represented in the parser's data model. Specs that declare reusable path items in components will silently drop them.
 
-## How to try it
+The `flatten` command has one additional caveat:
 
-### Install the beta release
-```bash
-curl -fsSL https://raw.githubusercontent.com/oasdiff/oasdiff/main/install.sh | version=1.15.0-openapi31.beta.3 sh
-```
+- **`flatten` of `allOf` ignores 3.1 numeric `exclusiveMinimum` / `exclusiveMaximum`**: when merging `allOf` subschemas, the merge logic considers only `minimum` / `maximum` and the 3.0-style boolean `exclusiveMinimum` / `exclusiveMaximum`. 3.1 numeric exclusive bounds are silently dropped from the merged result. Tracked in [#868](https://github.com/oasdiff/oasdiff/issues/868).
 
-Then use oasdiff as normal:
-```bash
-oasdiff diff base.yaml revision.yaml
-oasdiff breaking base.yaml revision.yaml
-oasdiff changelog base.yaml revision.yaml
-```
+If you hit any of these, please [open an issue](https://github.com/oasdiff/oasdiff/issues/new?template=bug_report.md&title=[3.1]%20).
 
-### Docker
-```bash
-docker pull tufin/oasdiff:v1.15.0-openapi31.beta.3
+## Feedback
 
-# Diff
-docker run --rm -v $(pwd):/specs tufin/oasdiff:v1.15.0-openapi31.beta.3 diff /specs/base.yaml /specs/revision.yaml
-
-# Breaking changes
-docker run --rm -v $(pwd):/specs tufin/oasdiff:v1.15.0-openapi31.beta.3 breaking /specs/base.yaml /specs/revision.yaml
-
-# Changelog
-docker run --rm -v $(pwd):/specs tufin/oasdiff:v1.15.0-openapi31.beta.3 changelog /specs/base.yaml /specs/revision.yaml
-```
-
-### GitHub Action
-```yaml
-- uses: oasdiff/oasdiff-action/breaking@v0.0.40-beta.3
-  with:
-    base: specs/base.yaml
-    revision: specs/revision.yaml
-```
-
-Other actions: `oasdiff/oasdiff-action/diff`, `oasdiff/oasdiff-action/changelog`, `oasdiff/oasdiff-action/pr-comment`.
-
-### Build from source
-```bash
-git clone -b feat/openapi-3.1-support https://github.com/oasdiff/oasdiff.git
-cd oasdiff
-go build
-./oasdiff diff base.yaml revision.yaml
-```
-
-## Provide feedback
-
-We need your feedback to move this to general availability.
-
-### Found an issue?
-[Open an issue](https://github.com/oasdiff/oasdiff/issues/new?template=bug_report.md&title=[3.1]%20) with `[3.1]` in the title.
-
-### It works for you?
-We need to hear from you too! Please add a thumbs-up reaction to [this tracking issue](https://github.com/oasdiff/oasdiff/issues/52) and optionally leave a comment describing your use case and which 3.1 features you tested. Knowing how many users are running 3.1 successfully helps us decide when to make it generally available.
-
-## Status
-
-| Milestone | Status |
-|-----------|--------|
-| Spec loading | Done |
-| Diff | Done |
-| Breaking changes | Done |
-| Changelog | Done |
-| GitHub Action | Done |
-| Online diff tool (oasdiff.com) | Done |
-| Community testing | **In progress** |
-| General availability | Pending testing feedback |
+Found an issue? [Open one here](https://github.com/oasdiff/oasdiff/issues/new?template=bug_report.md&title=[3.1]%20) with `[3.1]` in the title.

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,7 +52,6 @@ docker run --rm -t tufin/oasdiff changelog https://raw.githubusercontent.com/oas
 ```
 
 ## Features
-- [OpenAPI 3.1 support](OPENAPI-31.md) (beta)
 - Detect [breaking changes](BREAKING-CHANGES.md)
 - Display a user-friendly [changelog](BREAKING-CHANGES.md) of all important API changes
 - Generate comprehensive [diff](DIFF.md) reports including all aspects of [OpenAPI Specification](https://swagger.io/specification/): paths, operations, parameters, request bodies, responses, schemas, enums, callbacks, security etc.
@@ -60,6 +59,7 @@ docker run --rm -t tufin/oasdiff changelog https://raw.githubusercontent.com/oas
 - [Source location tracking](SOURCE-LOCATOR.md)
 - Compare specs from local files, http/s URLs, or [git revisions](GIT-REVISION.md)
 - Compare specs in YAML or JSON format
+- [OpenAPI 3.1 support](OPENAPI-31.md)
 - [Change fingerprints](FINGERPRINT.md) for stable cross-commit change identity
 - [Compare two collections of specs](COMPOSED.md)
 - [Deprecate APIs and Parameters](DEPRECATION.md)
@@ -93,11 +93,8 @@ docker run --rm -t tufin/oasdiff changelog https://raw.githubusercontent.com/oas
 - [flatten](ALLOF.md): replace all instances of allOf by a merged equivalent
 - [checks](CHECKS.md): display the checks that oasdiff uses to detect changes
 
-## Roadmap
-- **[OpenAPI 3.1](OPENAPI-31.md)** (beta)
-
 ## Credits
-This project relies on the excellent implementation of OpenAPI 3.0 for Go: [kin-openapi](https://github.com/getkin/kin-openapi).
+This project relies on the excellent implementation of OpenAPI 3.0 and 3.1 for Go: [kin-openapi](https://github.com/getkin/kin-openapi).
 
 ## Feedback
 We welcome your feedback.  


### PR DESCRIPTION
## Summary

OpenAPI 3.1 support is now generally available with the upcoming `v1.15.0` release. Update documentation to reflect that.

### `docs/README.md`
- Move OpenAPI 3.1 entry from the top of the Features list to the input-format cluster (after `Compare specs in YAML or JSON format`) and drop the `(beta)` suffix.
- Remove the Roadmap section (was a single 3.1 entry, now obsolete).
- Update Credits to mention both 3.0 and 3.1 support in `kin-openapi`.

### `docs/OPENAPI-31.md`
- Drop `(Beta)` from the page title.
- Replace the beta disclaimer with a GA notice referencing `v1.15.0` and noting the superseded `v1.15.0-openapi31.beta.*` and `v2.2.0-openapi31.beta.*` tags.
- Drop the `How to use it` section (install instructions are now standard, covered by the main README).
- Update the rule-IDs count from 148 to 162 to reflect the actual delta merged on main.
- Replace `Known limitations` with a tighter `Caveats` section listing only items that affect oasdiff: two `kin-openapi` parser gaps (`$dynamicRef` / `$dynamicAnchor` not resolved, `pathItems` in `components` not represented) and the `flatten`-of-`allOf` ExclusiveBound issue tracked in #868.

## Test plan

- `grep -i beta docs/README.md docs/OPENAPI-31.md` returns no problematic matches (only the GA notice line).
- After merge, tag oasdiff `v1.15.0` to start the GA release.
