### PR TITLE
docs(readme): mention PR review workflow at oasdiff.com

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,8 @@
 
 Command-line and Go package to compare and detect breaking changes in OpenAPI specs.
 
+Run it locally, in CI via the [GitHub Action](https://github.com/oasdiff/oasdiff-action), or use the hosted PR review workflow at [oasdiff.com](https://www.oasdiff.com) to approve or reject each change with a CI commit status.
+
 ## Installation
 
 ### Install with Go
@@ -80,7 +82,7 @@ docker run --rm -t tufin/oasdiff changelog https://raw.githubusercontent.com/oas
 - [Customize HTML and Markdown changelog reports](CHANGELOG-TEMPLATE.md)
 - [Run with configuration file](CONFIG-FILES.md)
 - [Run from Docker](DOCKER.md)
-- [GitHub Action](https://github.com/oasdiff/oasdiff-action)
+- [GitHub Action](https://github.com/oasdiff/oasdiff-action) for CI; for teams, [oasdiff.com](https://www.oasdiff.com) adds a per-change PR comment with approve/reject and commit-status checks
 - [Embed in your go program](GO.md)
 
 ## Demo


### PR DESCRIPTION
## Summary

The README currently lists the [GitHub Action](https://github.com/oasdiff/oasdiff-action) as a single bare link in the Features list, with no explanation of what it produces. New visitors finish reading the README without knowing that oasdiff can post a per-change report on a pull request, or that there is a hosted review workflow.

This PR adds two small pointers:

1. A one-line note under the tagline introducing the GitHub Action and the hosted review workflow at oasdiff.com.
2. An expanded Features bullet that explains what the Action gives a team beyond CLI usage.

The CLI is still the headline; the additions are kept short and link-only, in line with the rest of the README.

## Test plan

- [ ] Render the README on GitHub and confirm the new line under the tagline appears above Installation.
- [ ] Confirm both new links resolve (https://github.com/oasdiff/oasdiff-action and https://www.oasdiff.com).
- [ ] Confirm the Features bullet renders correctly with the inline link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)