### PR TITLE
fix(flatten/allof): handle OpenAPI 3.1 numeric exclusive bounds

### DIFF
--- a/docs/OPENAPI-31.md
+++ b/docs/OPENAPI-31.md
@@ -47,10 +47,6 @@ The following 3.1 features are not yet fully supported by [`kin-openapi`](https:
 - **`$dynamicRef` / `$dynamicAnchor`**: parsed but not resolved during loading. Schemas using dynamic references for recursive definitions will not be followed.
 - **`pathItems` in `components`**: not represented in the parser's data model. Specs that declare reusable path items in components will silently drop them.
 
-The `flatten` command has one additional caveat:
-
-- **`flatten` of `allOf` ignores 3.1 numeric `exclusiveMinimum` / `exclusiveMaximum`**: when merging `allOf` subschemas, the merge logic considers only `minimum` / `maximum` and the 3.0-style boolean `exclusiveMinimum` / `exclusiveMaximum`. 3.1 numeric exclusive bounds are silently dropped from the merged result. Tracked in [#868](https://github.com/oasdiff/oasdiff/issues/868).
-
 If you hit any of these, please [open an issue](https://github.com/oasdiff/oasdiff/issues/new?template=bug_report.md&title=[3.1]%20).
 
 ## Feedback

--- a/flatten/allof/merge_allof.go
+++ b/flatten/allof/merge_allof.go
@@ -427,40 +427,146 @@ func hasFalse(values []bool) bool {
 	return false
 }
 
+// boundSource records which schema field a numeric bound came from. Needed
+// because OpenAPI 3.0 (boolean exclusiveMinimum/Maximum modifying min/max)
+// and 3.1 (numeric exclusiveMinimum/Maximum standing alone) round-trip
+// through different fields and the merge result has to be emitted in the
+// same form it came in.
+type boundSource int
+
+const (
+	sourceMinMax     boundSource = iota // schema.Min / schema.Max field, optionally with 3.0-style boolean exclusive
+	sourceExclusive                     // schema.ExclusiveMin.Value / schema.ExclusiveMax.Value (3.1 numeric)
+)
+
+// numericBound is one candidate bound contributed by one schema in the allOf
+// collection, normalized so different forms can be compared on a single axis.
+type numericBound struct {
+	value     float64
+	exclusive bool        // true: strict (>, <); false: inclusive (>=, <=)
+	source    boundSource // how to emit it back when this candidate wins
+}
+
+// collectLowerBounds extracts every effective lower-bound candidate from the
+// merged collection. A 3.1 schema with both `minimum` and `exclusiveMinimum`
+// contributes two candidates and the more restrictive one wins downstream.
+func collectLowerBounds(collection *SchemaCollection) []numericBound {
+	var bounds []numericBound
+	for i, m := range collection.Min {
+		eb := collection.ExclusiveMin[i]
+		if m != nil {
+			// 3.0: `minimum` plus optional boolean `exclusiveMinimum`.
+			// 3.1 with `minimum`: never has Bool set, so IsTrue()==false → inclusive.
+			bounds = append(bounds, numericBound{
+				value:     *m,
+				exclusive: eb.IsTrue(),
+				source:    sourceMinMax,
+			})
+		}
+		if eb.Value != nil {
+			// 3.1: numeric `exclusiveMinimum`. Always strict.
+			bounds = append(bounds, numericBound{
+				value:     *eb.Value,
+				exclusive: true,
+				source:    sourceExclusive,
+			})
+		}
+	}
+	return bounds
+}
+
+func collectUpperBounds(collection *SchemaCollection) []numericBound {
+	var bounds []numericBound
+	for i, m := range collection.Max {
+		eb := collection.ExclusiveMax[i]
+		if m != nil {
+			bounds = append(bounds, numericBound{
+				value:     *m,
+				exclusive: eb.IsTrue(),
+				source:    sourceMinMax,
+			})
+		}
+		if eb.Value != nil {
+			bounds = append(bounds, numericBound{
+				value:     *eb.Value,
+				exclusive: true,
+				source:    sourceExclusive,
+			})
+		}
+	}
+	return bounds
+}
+
+// pickMostRestrictive returns the lower-bound candidate that excludes the most
+// values. For lower bounds (`upper=false`), the most-restrictive bound is the
+// highest one; ties break in favor of the strict (exclusive) variant.
+func pickMostRestrictive(bounds []numericBound, upper bool) (numericBound, bool) {
+	if len(bounds) == 0 {
+		return numericBound{}, false
+	}
+	best := bounds[0]
+	for _, b := range bounds[1:] {
+		if upper {
+			if b.value < best.value || (b.value == best.value && b.exclusive && !best.exclusive) {
+				best = b
+			}
+		} else {
+			if b.value > best.value || (b.value == best.value && b.exclusive && !best.exclusive) {
+				best = b
+			}
+		}
+	}
+	return best, true
+}
+
+// emitLower writes the chosen lower bound back to the schema in its original
+// form: 3.0 boolean style if the winner came from `minimum`, 3.1 numeric
+// exclusive style if it came from `exclusiveMinimum`.
+func emitLower(schema *openapi3.Schema, b numericBound) {
+	v := b.value
+	if b.source == sourceExclusive {
+		schema.Min = nil
+		schema.ExclusiveMin = openapi3.ExclusiveBound{Value: &v}
+		return
+	}
+	schema.Min = &v
+	if b.exclusive {
+		t := true
+		schema.ExclusiveMin = openapi3.ExclusiveBound{Bool: &t}
+	} else {
+		schema.ExclusiveMin = openapi3.ExclusiveBound{}
+	}
+}
+
+func emitUpper(schema *openapi3.Schema, b numericBound) {
+	v := b.value
+	if b.source == sourceExclusive {
+		schema.Max = nil
+		schema.ExclusiveMax = openapi3.ExclusiveBound{Value: &v}
+		return
+	}
+	schema.Max = &v
+	if b.exclusive {
+		t := true
+		schema.ExclusiveMax = openapi3.ExclusiveBound{Bool: &t}
+	} else {
+		schema.ExclusiveMax = openapi3.ExclusiveBound{}
+	}
+}
+
 func resolveNumberRange(schema *openapi3.Schema, collection *SchemaCollection) *openapi3.Schema {
-
-	//resolve minimum
-	max := math.Inf(-1)
-	var exclusiveMin openapi3.ExclusiveBound
-	var value *float64
-	for i, s := range collection.Min {
-		if s != nil {
-			if *s > max {
-				max = *s
-				value = s
-				exclusiveMin = collection.ExclusiveMin[i]
-			}
-		}
+	if best, ok := pickMostRestrictive(collectLowerBounds(collection), false); ok {
+		emitLower(schema, best)
+	} else {
+		schema.Min = nil
+		schema.ExclusiveMin = openapi3.ExclusiveBound{}
 	}
-
-	schema.Min = value
-	schema.ExclusiveMin = exclusiveMin
-	//resolve maximum
-	min := math.Inf(1)
-	var exclusiveMax openapi3.ExclusiveBound
-	// var value *float64
-	for i, s := range collection.Max {
-		if s != nil {
-			if *s < min {
-				min = *s
-				value = s
-				exclusiveMax = collection.ExclusiveMax[i]
-			}
-		}
+	if best, ok := pickMostRestrictive(collectUpperBounds(collection), true); ok {
+		emitUpper(schema, best)
+	} else {
+		schema.Max = nil
+		schema.ExclusiveMax = openapi3.ExclusiveBound{}
 	}
-
-	schema.Max = value
-	schema.ExclusiveMax = exclusiveMax
 	return schema
 }
 

--- a/flatten/allof/merge_allof.go
+++ b/flatten/allof/merge_allof.go
@@ -435,8 +435,8 @@ func hasFalse(values []bool) bool {
 type boundSource int
 
 const (
-	sourceMinMax     boundSource = iota // schema.Min / schema.Max field, optionally with 3.0-style boolean exclusive
-	sourceExclusive                     // schema.ExclusiveMin.Value / schema.ExclusiveMax.Value (3.1 numeric)
+	sourceMinMax    boundSource = iota // schema.Min / schema.Max field, optionally with 3.0-style boolean exclusive
+	sourceExclusive                    // schema.ExclusiveMin.Value / schema.ExclusiveMax.Value (3.1 numeric)
 )
 
 // numericBound is one candidate bound contributed by one schema in the allOf

--- a/flatten/allof/merge_allof_test.go
+++ b/flatten/allof/merge_allof_test.go
@@ -699,9 +699,35 @@ func TestMerge_ExclusiveMinNumeric_PicksHigher(t *testing.T) {
 	require.Equal(t, 10.0, *merged.ExclusiveMin.Value)
 }
 
-// OpenAPI 3.1: same axis, but mixed with a 3.0-style `minimum` with no
-// numeric exclusive on the other side. The numeric exclusive (5 strict) is
-// more restrictive than `minimum: 0`, so the result is the 3.1 form.
+// Same value on both sides — `minimum: 5` (inclusive) vs
+// `exclusiveMinimum: 5` (strict). The strict bound rejects the value
+// 5 itself and is therefore more restrictive at the boundary, so the
+// merged result is `exclusiveMinimum: 5` with `minimum` cleared.
+func TestMerge_ExclusiveMinNumeric_BeatsIdenticalInclusive(t *testing.T) {
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{
+						Type: &openapi3.Types{"number"},
+						Min:  new(5.0),
+					}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{
+						Type:         &openapi3.Types{"number"},
+						ExclusiveMin: exclusiveBoundValue(5),
+					}},
+				},
+			}})
+	require.NoError(t, err)
+	require.Nil(t, merged.Min)
+	require.NotNil(t, merged.ExclusiveMin.Value)
+	require.Equal(t, 5.0, *merged.ExclusiveMin.Value)
+}
+
+// Two subschemas: `minimum: 0` (inclusive) and `exclusiveMinimum: 5`
+// (strict). The strict bound at 5 is more restrictive than the inclusive
+// bound at 0, so the merged result is `exclusiveMinimum: 5` with
+// `minimum` cleared.
 func TestMerge_ExclusiveMinNumeric_BeatsLowerInclusive(t *testing.T) {
 	merged, err := allof.Merge(
 		openapi3.SchemaRef{
@@ -723,8 +749,10 @@ func TestMerge_ExclusiveMinNumeric_BeatsLowerInclusive(t *testing.T) {
 	require.Equal(t, 5.0, *merged.ExclusiveMin.Value)
 }
 
-// OpenAPI 3.1: same axis, the 3.0-style `minimum` wins when its value is
-// higher than the numeric exclusive. Result is the 3.0 inclusive form.
+// Two subschemas: `minimum: 10` (inclusive) and `exclusiveMinimum: 5`
+// (strict). Even though `exclusiveMinimum: 5` is strict, its value is
+// lower, so the inclusive `minimum: 10` is more restrictive overall.
+// The merged result is `minimum: 10` with no `exclusiveMinimum`.
 func TestMerge_InclusiveMinBeatsLowerNumericExclusive(t *testing.T) {
 	merged, err := allof.Merge(
 		openapi3.SchemaRef{
@@ -747,10 +775,12 @@ func TestMerge_InclusiveMinBeatsLowerNumericExclusive(t *testing.T) {
 	require.False(t, merged.ExclusiveMin.IsTrue())
 }
 
-// OpenAPI 3.1: a single schema with both `minimum` and `exclusiveMinimum`
-// (the issue's case 2). The numeric exclusive is more restrictive within
-// that schema, and a less-restrictive `minimum: 10` from the other schema
-// shouldn't change the picture.
+// One schema has both `minimum: 0` (inclusive) and `exclusiveMinimum: 5`
+// (strict) — within that schema, the strict bound at 5 wins (effective
+// constraint: x > 5). A second schema contributes `minimum: 10`
+// (inclusive), which is more restrictive than the first schema's
+// effective `> 5`. The merged result is `minimum: 10` with no
+// `exclusiveMinimum`.
 func TestMerge_ExclusiveMinNumeric_WithSiblingInclusive(t *testing.T) {
 	merged, err := allof.Merge(
 		openapi3.SchemaRef{

--- a/flatten/allof/merge_allof_test.go
+++ b/flatten/allof/merge_allof_test.go
@@ -873,6 +873,47 @@ func TestMerge_InclusiveMaxBeatsHigherNumericExclusive(t *testing.T) {
 	require.False(t, merged.ExclusiveMax.IsTrue())
 }
 
+// Per docs/ALLOF.md, source locations are not available for changes detected
+// in flattened schemas — the merged schema is a new construct that doesn't
+// correspond to a single line in the original file. This test pins that
+// behavior so a future change to the merge code can't accidentally leak
+// stale origin metadata (e.g. a `minimum` field origin pointing at the
+// subschema whose value lost the merge), which would surface as wrong
+// line numbers in downstream consumers.
+func TestMerge_FlattenedNumericBounds_HaveNoSourceLocation(t *testing.T) {
+	loader := openapi3.NewLoader()
+	loader.IncludeOrigin = true
+	doc, err := loader.LoadFromData([]byte(`openapi: 3.1.0
+info: {title: t, version: '1'}
+paths: {}
+components:
+  schemas:
+    Bounded:
+      allOf:
+        - {type: number, minimum: 5}
+        - {type: number, exclusiveMinimum: 6}
+`))
+	require.NoError(t, err)
+
+	// Sanity-check: the loader actually populated origin info on the input —
+	// otherwise the post-merge nil assertion would be vacuously true.
+	require.NotNil(t, doc.Components.Schemas["Bounded"].Value.Origin,
+		"input schema must have origin tracking populated for this test to be meaningful")
+
+	merged, err := allof.Merge(*doc.Components.Schemas["Bounded"])
+	require.NoError(t, err)
+
+	// Sanity-check: merge picked the more restrictive bound (exclusive 6
+	// beats inclusive 5).
+	require.Nil(t, merged.Min)
+	require.NotNil(t, merged.ExclusiveMin.Value)
+	require.Equal(t, 6.0, *merged.ExclusiveMin.Value)
+
+	// The actual assertion: no origin metadata on the merged schema.
+	require.Nil(t, merged.Origin,
+		"flattened schema must not carry origin metadata (per docs/ALLOF.md)")
+}
+
 // merge multiple Not inside AllOf
 func TestMerge_Not(t *testing.T) {
 	merged, err := allof.Merge(

--- a/flatten/allof/merge_allof_test.go
+++ b/flatten/allof/merge_allof_test.go
@@ -15,6 +15,11 @@ func exclusiveBoundBool(b bool) openapi3.ExclusiveBound {
 	return openapi3.ExclusiveBound{Bool: &b}
 }
 
+// exclusiveBoundValue creates an ExclusiveBound with a numeric value (OpenAPI 3.1 style).
+func exclusiveBoundValue(v float64) openapi3.ExclusiveBound {
+	return openapi3.ExclusiveBound{Value: &v}
+}
+
 // identical Default fields are merged successfully
 func TestMerge_Default(t *testing.T) {
 	merged, err := allof.Merge(
@@ -668,6 +673,174 @@ func TestMerge_ExclusiveMinIsTrue(t *testing.T) {
 			}})
 	require.NoError(t, err)
 	require.True(t, merged.ExclusiveMin.IsTrue())
+}
+
+// OpenAPI 3.1: two numeric `exclusiveMinimum` values (no `minimum` on either
+// side). The merged schema must keep the higher one — failing this test was
+// the original symptom in issue #868: both values were silently dropped.
+func TestMerge_ExclusiveMinNumeric_PicksHigher(t *testing.T) {
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{
+						Type:         &openapi3.Types{"number"},
+						ExclusiveMin: exclusiveBoundValue(10),
+					}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{
+						Type:         &openapi3.Types{"number"},
+						ExclusiveMin: exclusiveBoundValue(5),
+					}},
+				},
+			}})
+	require.NoError(t, err)
+	require.Nil(t, merged.Min, "Min must be nil for 3.1 numeric exclusive form")
+	require.NotNil(t, merged.ExclusiveMin.Value)
+	require.Equal(t, 10.0, *merged.ExclusiveMin.Value)
+}
+
+// OpenAPI 3.1: same axis, but mixed with a 3.0-style `minimum` with no
+// numeric exclusive on the other side. The numeric exclusive (5 strict) is
+// more restrictive than `minimum: 0`, so the result is the 3.1 form.
+func TestMerge_ExclusiveMinNumeric_BeatsLowerInclusive(t *testing.T) {
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{
+						Type: &openapi3.Types{"number"},
+						Min:  new(0.0),
+					}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{
+						Type:         &openapi3.Types{"number"},
+						ExclusiveMin: exclusiveBoundValue(5),
+					}},
+				},
+			}})
+	require.NoError(t, err)
+	require.Nil(t, merged.Min)
+	require.NotNil(t, merged.ExclusiveMin.Value)
+	require.Equal(t, 5.0, *merged.ExclusiveMin.Value)
+}
+
+// OpenAPI 3.1: same axis, the 3.0-style `minimum` wins when its value is
+// higher than the numeric exclusive. Result is the 3.0 inclusive form.
+func TestMerge_InclusiveMinBeatsLowerNumericExclusive(t *testing.T) {
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{
+						Type: &openapi3.Types{"number"},
+						Min:  new(10.0),
+					}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{
+						Type:         &openapi3.Types{"number"},
+						ExclusiveMin: exclusiveBoundValue(5),
+					}},
+				},
+			}})
+	require.NoError(t, err)
+	require.NotNil(t, merged.Min)
+	require.Equal(t, 10.0, *merged.Min)
+	require.Nil(t, merged.ExclusiveMin.Value)
+	require.False(t, merged.ExclusiveMin.IsTrue())
+}
+
+// OpenAPI 3.1: a single schema with both `minimum` and `exclusiveMinimum`
+// (the issue's case 2). The numeric exclusive is more restrictive within
+// that schema, and a less-restrictive `minimum: 10` from the other schema
+// shouldn't change the picture.
+func TestMerge_ExclusiveMinNumeric_WithSiblingInclusive(t *testing.T) {
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{
+						Type:         &openapi3.Types{"number"},
+						Min:          new(0.0),
+						ExclusiveMin: exclusiveBoundValue(5),
+					}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{
+						Type: &openapi3.Types{"number"},
+						Min:  new(10.0),
+					}},
+				},
+			}})
+	require.NoError(t, err)
+	// Effective lower bounds: > 5 (from schema 1's numeric exclusive),
+	// >= 0 (from schema 1's minimum), >= 10 (from schema 2). The most
+	// restrictive is >= 10.
+	require.NotNil(t, merged.Min)
+	require.Equal(t, 10.0, *merged.Min)
+	require.Nil(t, merged.ExclusiveMin.Value)
+	require.False(t, merged.ExclusiveMin.IsTrue())
+}
+
+// Mirror cases for the upper bound.
+
+func TestMerge_ExclusiveMaxNumeric_PicksLower(t *testing.T) {
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{
+						Type:         &openapi3.Types{"number"},
+						ExclusiveMax: exclusiveBoundValue(100),
+					}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{
+						Type:         &openapi3.Types{"number"},
+						ExclusiveMax: exclusiveBoundValue(50),
+					}},
+				},
+			}})
+	require.NoError(t, err)
+	require.Nil(t, merged.Max)
+	require.NotNil(t, merged.ExclusiveMax.Value)
+	require.Equal(t, 50.0, *merged.ExclusiveMax.Value)
+}
+
+func TestMerge_ExclusiveMaxNumeric_BeatsHigherInclusive(t *testing.T) {
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{
+						Type: &openapi3.Types{"number"},
+						Max:  new(100.0),
+					}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{
+						Type:         &openapi3.Types{"number"},
+						ExclusiveMax: exclusiveBoundValue(50),
+					}},
+				},
+			}})
+	require.NoError(t, err)
+	require.Nil(t, merged.Max)
+	require.NotNil(t, merged.ExclusiveMax.Value)
+	require.Equal(t, 50.0, *merged.ExclusiveMax.Value)
+}
+
+func TestMerge_InclusiveMaxBeatsHigherNumericExclusive(t *testing.T) {
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{
+						Type: &openapi3.Types{"number"},
+						Max:  new(50.0),
+					}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{
+						Type:         &openapi3.Types{"number"},
+						ExclusiveMax: exclusiveBoundValue(100),
+					}},
+				},
+			}})
+	require.NoError(t, err)
+	require.NotNil(t, merged.Max)
+	require.Equal(t, 50.0, *merged.Max)
+	require.Nil(t, merged.ExclusiveMax.Value)
+	require.False(t, merged.ExclusiveMax.IsTrue())
 }
 
 // merge multiple Not inside AllOf


### PR DESCRIPTION
Fixes #868.

## Summary

`resolveNumberRange` iterated only over the `Min` / `Max` slices and ignored `ExclusiveMin.Value` / `ExclusiveMax.Value`. For OpenAPI 3.1 specs that use the numeric form of `exclusiveMinimum` / `exclusiveMaximum` (no `minimum` or `maximum` on the same axis), the merged schema lost both bounds and silently accepted any value. Mixed cases (one schema with `minimum`, another with `exclusiveMinimum`) only worked by coincidence — the comparison wasn't actually consulting the exclusive-bound values.

## The fix

`resolveNumberRange` now compares across both axes:

- **`collectLowerBounds` / `collectUpperBounds`** extract every effective bound candidate from the collection. A schema with both `minimum: N` and `exclusiveMinimum: M` contributes two candidates and the merge picks the most restrictive (this is legal in pure 3.1 — both keywords are independent assertions per JSON Schema 2020-12).
- **`pickMostRestrictive`** picks the highest lower bound (or lowest upper bound); ties break in favor of the strict variant — matching the boundary semantics where `value > N` is strictly tighter than `value >= N` at the same value.
- **`emitLower` / `emitUpper`** write the winner back in the form it came from: `minimum: N` (with optional 3.0-style boolean exclusive) if the winner was a `minimum`-derived candidate, `exclusiveMinimum: N` (3.1 numeric, standalone) if it came from a numeric `exclusiveMinimum`. Source-tracking is needed because pure 3.1 specs can mix both forms within a single allOf.

## Tests

Eight new tests in `flatten/allof/merge_allof_test.go`:

| Test | Scenario |
|---|---|
| `TestMerge_ExclusiveMinNumeric_PicksHigher` | Two numeric `exclusiveMinimum` values — assert higher one wins (the original bug case) |
| `TestMerge_ExclusiveMinNumeric_BeatsIdenticalInclusive` | `minimum: 5` vs `exclusiveMinimum: 5` — exact-equal boundary tie-break, strict wins |
| `TestMerge_ExclusiveMinNumeric_BeatsLowerInclusive` | `minimum: 0` vs `exclusiveMinimum: 5` — strict at higher value wins |
| `TestMerge_InclusiveMinBeatsLowerNumericExclusive` | `minimum: 10` vs `exclusiveMinimum: 5` — inclusive at higher value wins |
| `TestMerge_ExclusiveMinNumeric_WithSiblingInclusive` | Single schema with both `minimum` and `exclusiveMinimum`, plus another schema's `minimum: 10` — overall winner is the 10 inclusive |
| 3 mirror cases for `exclusiveMaximum` | Same shapes for the upper-bound axis |
| `TestMerge_FlattenedNumericBounds_HaveNoSourceLocation` | Pins the documented `flatten`-discards-origin contract: input has full origin tracking, merged schema has `Origin == nil`. Guards against a future "helpful" Merge change that would copy origin from inputs and produce wrong line numbers downstream. |

All 4 existing 3.0 boolean exclusive-bound tests still pass.

## Other changes in this PR

- `gofmt` alignment fix in the new const block (initial CI failure).
- Reworded comments on the four bound-merge tests to drop the misleading "3.0/3.1 form" labels — both `minimum: N` and `exclusiveMinimum: N` (numeric) are valid in 3.1; only the 3.0 boolean `exclusiveMinimum: true` is strictly version-bound.
- Fixed a logic-backwards comment on `TestMerge_ExclusiveMinNumeric_WithSiblingInclusive` (the old comment said the second schema's `minimum: 10` "shouldn't change the picture" but the test asserts `merged.Min=10`, so it absolutely does).
- Removed the now-resolved caveat in `docs/OPENAPI-31.md` about `flatten` ignoring 3.1 numeric exclusive bounds.

## Out of scope

Issue #868 also mentions auditing other parts of oasdiff that read `ExclusiveMin` / `ExclusiveMax` for similar 3.1 gaps — left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
