### PR TITLE
fix(formatters): distinguish 'no breaking changes' from 'no changes' for breaking command

### DIFF
--- a/formatters/format_html.go
+++ b/formatters/format_html.go
@@ -57,7 +57,7 @@ func (f HTMLFormatter) RenderChangelog(changes checker.Changes, opts RenderOpts,
 		tmpl = template.Must(template.New("changelog").Funcs(HtmlTemplateFuncs()).Parse(changelogHtml))
 	}
 
-	return ExecuteHtmlTemplate(tmpl, GroupChanges(changes, f.Localizer), baseVersion, revisionVersion, opts.DiffEmpty)
+	return ExecuteHtmlTemplate(tmpl, GroupChanges(changes, f.Localizer), baseVersion, revisionVersion, opts.DiffEmpty, opts.IsBreaking)
 }
 
 func (f HTMLFormatter) loadCustomTemplate(templatePath string) (*template.Template, error) {
@@ -121,9 +121,9 @@ func HtmlTemplateFuncs() template.FuncMap {
 	return template.FuncMap(changelogTemplateFuncs())
 }
 
-func ExecuteHtmlTemplate(tmpl *template.Template, changes ChangesByGroup, baseVersion, revisionVersion string, diffEmpty bool) ([]byte, error) {
+func ExecuteHtmlTemplate(tmpl *template.Template, changes ChangesByGroup, baseVersion, revisionVersion string, diffEmpty, isBreaking bool) ([]byte, error) {
 	var out bytes.Buffer
-	if err := tmpl.Execute(&out, TemplateData{changes, baseVersion, revisionVersion, diffEmpty}); err != nil {
+	if err := tmpl.Execute(&out, TemplateData{changes, baseVersion, revisionVersion, diffEmpty, isBreaking}); err != nil {
 		return nil, err
 	}
 	return out.Bytes(), nil

--- a/formatters/format_html_test.go
+++ b/formatters/format_html_test.go
@@ -120,7 +120,7 @@ var changelogHtml string
 func TestExecuteHtmlTemplate_Err(t *testing.T) {
 	tmpl := template.Must(template.New("changelog").Funcs(formatters.HtmlTemplateFuncs()).Parse(changelogHtml))
 	tmpl.Tree = nil
-	_, err := formatters.ExecuteHtmlTemplate(tmpl, nil, "", "", false)
+	_, err := formatters.ExecuteHtmlTemplate(tmpl, nil, "", "", false, false)
 	assert.Error(t, err)
 }
 

--- a/formatters/format_markup.go
+++ b/formatters/format_markup.go
@@ -44,7 +44,7 @@ func (f MarkupFormatter) RenderChangelog(changes checker.Changes, opts RenderOpt
 		tmpl = template.Must(template.New("changelog").Funcs(MarkupTemplateFuncs()).Parse(changelogMarkdown))
 	}
 
-	return ExecuteTextTemplate(tmpl, GroupChanges(changes, f.Localizer), baseVersion, revisionVersion, opts.DiffEmpty)
+	return ExecuteTextTemplate(tmpl, GroupChanges(changes, f.Localizer), baseVersion, revisionVersion, opts.DiffEmpty, opts.IsBreaking)
 }
 
 func (f MarkupFormatter) loadCustomTemplate(templatePath string) (*template.Template, error) {
@@ -66,9 +66,9 @@ func MarkupTemplateFuncs() template.FuncMap {
 	return template.FuncMap(changelogTemplateFuncs())
 }
 
-func ExecuteTextTemplate(tmpl *template.Template, changes ChangesByGroup, baseVersion, revisionVersion string, diffEmpty bool) ([]byte, error) {
+func ExecuteTextTemplate(tmpl *template.Template, changes ChangesByGroup, baseVersion, revisionVersion string, diffEmpty, isBreaking bool) ([]byte, error) {
 	var out bytes.Buffer
-	if err := tmpl.Execute(&out, TemplateData{changes, baseVersion, revisionVersion, diffEmpty}); err != nil {
+	if err := tmpl.Execute(&out, TemplateData{changes, baseVersion, revisionVersion, diffEmpty, isBreaking}); err != nil {
 		return nil, err
 	}
 	return out.Bytes(), nil

--- a/formatters/format_markup_test.go
+++ b/formatters/format_markup_test.go
@@ -110,7 +110,7 @@ func TestMarkupFormatter_NotImplemented(t *testing.T) {
 }
 
 func TestExecuteMarkupTemplate_Err(t *testing.T) {
-	_, err := formatters.ExecuteTextTemplate(&template.Template{}, nil, "", "", false)
+	_, err := formatters.ExecuteTextTemplate(&template.Template{}, nil, "", "", false, false)
 	assert.Error(t, err)
 }
 

--- a/formatters/format_singleline.go
+++ b/formatters/format_singleline.go
@@ -24,6 +24,8 @@ func (f SingleLineFormatter) RenderChangelog(changes checker.Changes, opts Rende
 	if len(changes) == 0 {
 		if opts.DiffEmpty {
 			_, _ = fmt.Fprint(result, "No changes detected")
+		} else if opts.IsBreaking {
+			_, _ = fmt.Fprint(result, "No breaking changes to report, but the specs are different")
 		} else {
 			_, _ = fmt.Fprint(result, "No changes to report, but the specs are different")
 		}

--- a/formatters/format_singleline_test.go
+++ b/formatters/format_singleline_test.go
@@ -33,6 +33,18 @@ func TestSingleLineFormatter_RenderChangelog(t *testing.T) {
 	require.Equal(t, "1 changes: 1 error, 0 warning, 0 info\nerror, in components/test This is a breaking change. [change_id]. \n\n", string(out))
 }
 
+func TestSingleLineFormatter_RenderChangelog_EmptyChangesDifferentSpecs(t *testing.T) {
+	out, err := singleLineFormatter.RenderChangelog(checker.Changes{}, formatters.RenderOpts{}, "", "")
+	require.NoError(t, err)
+	require.Equal(t, "No changes to report, but the specs are different", string(out))
+}
+
+func TestSingleLineFormatter_RenderChangelog_EmptyChangesDifferentSpecs_BreakingMode(t *testing.T) {
+	out, err := singleLineFormatter.RenderChangelog(checker.Changes{}, formatters.RenderOpts{IsBreaking: true}, "", "")
+	require.NoError(t, err)
+	require.Equal(t, "No breaking changes to report, but the specs are different", string(out))
+}
+
 func TestSingleLineFormatter_NotImplemented(t *testing.T) {
 	var err error
 

--- a/formatters/format_text.go
+++ b/formatters/format_text.go
@@ -31,6 +31,8 @@ func (f TEXTFormatter) RenderChangelog(changes checker.Changes, opts RenderOpts,
 	if len(changes) == 0 {
 		if opts.DiffEmpty {
 			_, _ = fmt.Fprint(result, "No changes detected")
+		} else if opts.IsBreaking {
+			_, _ = fmt.Fprint(result, "No breaking changes to report, but the specs are different")
 		} else {
 			_, _ = fmt.Fprint(result, "No changes to report, but the specs are different")
 		}

--- a/formatters/format_text_test.go
+++ b/formatters/format_text_test.go
@@ -47,6 +47,18 @@ func TestTextFormatter_RenderChecks(t *testing.T) {
 	require.Equal(t, string(out), "ID        DESCRIPTION                LEVEL\nchange_id This is a breaking change. info\n")
 }
 
+func TestTextFormatter_RenderChangelog_EmptyChangesDifferentSpecs(t *testing.T) {
+	out, err := textFormatter.RenderChangelog(checker.Changes{}, formatters.RenderOpts{}, "", "")
+	require.NoError(t, err)
+	require.Equal(t, "No changes to report, but the specs are different", string(out))
+}
+
+func TestTextFormatter_RenderChangelog_EmptyChangesDifferentSpecs_BreakingMode(t *testing.T) {
+	out, err := textFormatter.RenderChangelog(checker.Changes{}, formatters.RenderOpts{IsBreaking: true}, "", "")
+	require.NoError(t, err)
+	require.Equal(t, "No breaking changes to report, but the specs are different", string(out))
+}
+
 func TestTextFormatter_RenderDiff(t *testing.T) {
 	out, err := textFormatter.RenderDiff(nil, formatters.NewRenderOpts())
 	require.NoError(t, err)

--- a/formatters/templates/changelog.html
+++ b/formatters/templates/changelog.html
@@ -155,7 +155,7 @@
     {{ template "section-group" . }}
     {{ end }}
     {{ else }}
-    {{ if .DiffEmpty }}<p>No changes detected</p>{{ else }}<p>No changes to report, but the specs are different</p>{{ end }}
+    {{ if .DiffEmpty }}<p>No changes detected</p>{{ else if .IsBreaking }}<p>No breaking changes to report, but the specs are different</p>{{ else }}<p>No changes to report, but the specs are different</p>{{ end }}
     {{ end }}
 </body>
 

--- a/formatters/templates/changelog.md
+++ b/formatters/templates/changelog.md
@@ -14,5 +14,5 @@
 {{ end }}
 {{ end }}
 {{ else }}
-{{ if .DiffEmpty }}No changes detected{{ else }}No changes to report, but the specs are different{{ end }}
+{{ if .DiffEmpty }}No changes detected{{ else if .IsBreaking }}No breaking changes to report, but the specs are different{{ else }}No changes to report, but the specs are different{{ end }}
 {{ end }}

--- a/formatters/types.go
+++ b/formatters/types.go
@@ -46,6 +46,7 @@ type RenderOpts struct {
 	WrapInObject bool   // wrap the output in a JSON object with the key "changes"
 	TemplatePath string // path to custom template file for changelog generation
 	DiffEmpty    bool   // true when the underlying diff found no changes at all
+	IsBreaking   bool   // true when invoked via `oasdiff breaking` (vs `changelog`); affects empty-result wording
 }
 
 func NewRenderOpts() RenderOpts {
@@ -59,6 +60,7 @@ type TemplateData struct {
 	BaseVersion     string
 	RevisionVersion string
 	DiffEmpty       bool
+	IsBreaking      bool
 }
 
 // APIChanges returns GroupedChanges.

--- a/internal/breaking_changes.go
+++ b/internal/breaking_changes.go
@@ -25,5 +25,5 @@ func getBreakingChangesCmd() *cobra.Command {
 }
 
 func runBreakingChanges(flags *Flags, stdout io.Writer) (bool, *ReturnError) {
-	return getChangelog(flags, stdout, checker.WARN)
+	return getChangelog(flags, stdout, checker.WARN, true)
 }

--- a/internal/changelog.go
+++ b/internal/changelog.go
@@ -41,10 +41,10 @@ func runChangelog(flags *Flags, stdout io.Writer) (bool, *ReturnError) {
 		return false, getErrInvalidFlags(fmt.Errorf("invalid level value: %q", flags.getLevel()))
 	}
 
-	return getChangelog(flags, stdout, level)
+	return getChangelog(flags, stdout, level, false)
 }
 
-func getChangelog(flags *Flags, stdout io.Writer, level checker.Level) (bool, *ReturnError) {
+func getChangelog(flags *Flags, stdout io.Writer, level checker.Level, isBreaking bool) (bool, *ReturnError) {
 
 	diffResult, returnErr := calcDiff(flags)
 	if returnErr != nil {
@@ -70,7 +70,7 @@ func getChangelog(flags *Flags, stdout io.Writer, level checker.Level) (bool, *R
 		return false, returnErr
 	}
 
-	if returnErr := outputChangelog(flags, stdout, errs, diffResult.specInfoPair, diffResult.diffReport.Empty()); returnErr != nil {
+	if returnErr := outputChangelog(flags, stdout, errs, diffResult.specInfoPair, diffResult.diffReport.Empty(), isBreaking); returnErr != nil {
 		return false, returnErr
 	}
 
@@ -106,7 +106,7 @@ func filterIgnored(errs checker.Changes, warnIgnoreFile string, errIgnoreFile st
 	return errs, nil
 }
 
-func outputChangelog(flags *Flags, stdout io.Writer, errs checker.Changes, specInfoPair *load.SpecInfoPair, diffEmpty bool) *ReturnError {
+func outputChangelog(flags *Flags, stdout io.Writer, errs checker.Changes, specInfoPair *load.SpecInfoPair, diffEmpty, isBreaking bool) *ReturnError {
 
 	// formatter lookup
 	formatter, err := formatters.Lookup(flags.getFormat(), formatters.FormatterOpts{
@@ -127,7 +127,7 @@ func outputChangelog(flags *Flags, stdout io.Writer, errs checker.Changes, specI
 		return getErrInvalidColorMode(err)
 	}
 
-	bytes, err := formatter.RenderChangelog(errs, formatters.RenderOpts{ColorMode: colorMode, TemplatePath: flags.getTemplate(), DiffEmpty: diffEmpty}, specInfoPair.GetBaseVersion(), specInfoPair.GetRevisionVersion())
+	bytes, err := formatter.RenderChangelog(errs, formatters.RenderOpts{ColorMode: colorMode, TemplatePath: flags.getTemplate(), DiffEmpty: diffEmpty, IsBreaking: isBreaking}, specInfoPair.GetBaseVersion(), specInfoPair.GetRevisionVersion())
 	if err != nil {
 		return getErrFailedPrint(changelogCmd+" "+flags.getFormat(), err)
 	}


### PR DESCRIPTION
## Summary

When `oasdiff breaking` finds no breaking changes but the specs do differ in non-breaking ways (e.g. description-only edits), every formatter reported:

> No changes to report, but the specs are different

That message is wrong in this context — there *are* changes, just no breaking ones. The user is left wondering whether oasdiff missed something. After this PR:

> No breaking changes to report, but the specs are different

The `changelog` command's wording is unchanged (it does report all changes, so "no changes to report" is correct there).

## Implementation

Threads an `IsBreaking` flag through the rendering pipeline:

- `RenderOpts` and `TemplateData` each gain an `IsBreaking bool`.
- `runBreakingChanges` (in `internal/breaking_changes.go`) passes `true` through the new `getChangelog` parameter; `runChangelog` passes `false`.
- The text and singleline formatters branch on `opts.IsBreaking` to produce the more accurate message.
- `changelog.html` and `changelog.md` templates use `{{ if .IsBreaking }}` for the same branch.
- `ExecuteHtmlTemplate` and `ExecuteTextTemplate` gain explicit `isBreaking` parameters. I considered taking the whole `RenderOpts` instead but kept explicit params — these are low-level template helpers; coupling them to the larger formatter-options bag (with fields like `ColorMode`, `WrapInObject`, `TemplatePath`) would obscure their actual contract.

## Tests

Adds 4 new tests covering both branches of the new wording:

- `TestTextFormatter_RenderChangelog_EmptyChangesDifferentSpecs` (and `_BreakingMode` variant)
- `TestSingleLineFormatter_RenderChangelog_EmptyChangesDifferentSpecs` (and `_BreakingMode` variant)

Existing tests pass without modification — they exercise the default `IsBreaking: false` path, which keeps the original wording.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./formatters/... ./internal/...` passes
- [ ] Manual smoke: run `oasdiff breaking` against two specs that differ only in descriptions, with `-f text`, `-f singleline`, `-f html`, and `-f markup` — confirm each says "No breaking changes to report"
- [ ] Same specs with `oasdiff changelog` — confirm message still says "No changes to report"

🤖 Generated with [Claude Code](https://claude.com/claude-code)