### PR TITLE
fix(html): drop external Google Fonts import from changelog template

### DIFF
--- a/examples/changelog.html
+++ b/examples/changelog.html
@@ -7,10 +7,8 @@
     <title>API Changelog</title>
     <style>
 
-        @import url(//fonts.googleapis.com/css?family=Nunito);
-
         * {
-            font-family: 'Nunito','Helvetica Neue',Helvetica,Arial,sans-serif;
+            font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
         }
         
         .title {

--- a/formatters/templates/changelog.html
+++ b/formatters/templates/changelog.html
@@ -7,10 +7,8 @@
     <title>API Changelog</title>
     <style>
 
-        @import url(//fonts.googleapis.com/css?family=Nunito);
-
         * {
-            font-family: 'Nunito','Helvetica Neue',Helvetica,Arial,sans-serif;
+            font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
         }
         
         .title {


### PR DESCRIPTION
## Summary

The HTML changelog report had `@import url(//fonts.googleapis.com/css?family=Nunito)` at the top of its `<style>` block, pulling Nunito from Google's CDN on every render.

Two problems with that:

- **Privacy** — Google sees the IP of every viewer of every changelog report. This includes hosted-product use cases (e.g. oasdiff.com renders the report inside a sandboxed iframe and the parent page's enforced CSP now blocks the font request entirely).
- **Reliability** — a Google Fonts outage would silently degrade the report's appearance for every consumer.

The `font-family` declaration already lists `'Helvetica Neue', Helvetica, Arial, sans-serif` as fallbacks. This PR drops the `@import` and removes Nunito from the font stack — the system fonts render cleanly on every modern OS with no external dependency.

## Files

- `formatters/templates/changelog.html` — the live template that ships in the binary
- `examples/changelog.html` — the rendered example checked into the repo

## Test plan

- [x] `go test ./formatters/...` passes (no test asserted the @import line)
- [ ] Generate a sample report locally with `oasdiff changelog -f html base.yaml revision.yaml > out.html`, open in a browser, confirm the report renders with system sans-serif fonts and no Network-tab requests to `fonts.googleapis.com` or `fonts.gstatic.com`
- [ ] Render the same report inside oasdiff.com's `/diff` page (the iframe used to be blocked by the enforced CSP) — confirm no CSP violation in the console

🤖 Generated with [Claude Code](https://claude.com/claude-code)