### PR TITLE
feat(flatten/allof): handle OpenAPI 3.1 const keyword

### DIFF
--- a/flatten/allof/merge_allof.go
+++ b/flatten/allof/merge_allof.go
@@ -15,6 +15,7 @@ const (
 	FormatErrorMessage  = "unable to resolve Format conflict using default resolver: all Format values must be identical"
 	TypeErrorMessage    = "unable to resolve Type conflict: all Type values must be identical"
 	DefaultErrorMessage = "unable to resolve Default conflict: all Default values must be identical"
+	ConstErrorMessage   = "unable to resolve Const conflict: all Const values must be identical"
 
 	FormatInt32  = "int32"
 	FormatInt64  = "int64"
@@ -52,6 +53,7 @@ type SchemaCollection struct {
 	ReadOnly             []bool
 	WriteOnly            []bool
 	Default              []any
+	Const                []any
 }
 
 type state struct {
@@ -208,6 +210,7 @@ func mergeInternal(state *state, base *openapi3.SchemaRef) (*openapi3.SchemaRef,
 	result.Value.MultipleOf = base.Value.MultipleOf
 	result.Value.MinLength = base.Value.MinLength
 	result.Value.Default = base.Value.Default
+	result.Value.Const = base.Value.Const
 	result.Value.Discriminator = base.Value.Discriminator
 	if base.Value.MaxLength != nil {
 		result.Value.MaxLength = new(*base.Value.MaxLength)
@@ -373,6 +376,10 @@ func flattenSchemas(state *state, result *openapi3.SchemaRef, schemas []*openapi
 	result.Value.Required = resolveRequired(collection.Required)
 	result.Value = resolveMultipleOf(result.Value, &collection)
 	result.Value.UniqueItems = resolveUniqueItems(collection.UniqueItems)
+	result.Value.Const, err = resolveConst(&collection)
+	if err != nil {
+		return err
+	}
 	result.Value.Default, err = resolveDefault(&collection)
 	if err != nil {
 		return err
@@ -1075,6 +1082,7 @@ func collect(schemas []*openapi3.SchemaRef) SchemaCollection {
 		collection.ReadOnly = append(collection.ReadOnly, s.Value.ReadOnly)
 		collection.WriteOnly = append(collection.WriteOnly, s.Value.WriteOnly)
 		collection.Default = append(collection.Default, s.Value.Default)
+		collection.Const = append(collection.Const, s.Value.Const)
 	}
 	return collection
 }
@@ -1280,6 +1288,29 @@ func resolveDefault(collection *SchemaCollection) (any, error) {
 	for _, v := range values {
 		if !reflect.DeepEqual(first, v) {
 			return nil, errors.New(DefaultErrorMessage)
+		}
+	}
+	return first, nil
+}
+
+// resolveConst handles the OpenAPI 3.1 / JSON Schema 2020-12 `const` keyword.
+// `const` constrains the instance to a single value, so under allOf every
+// non-nil candidate must be deep-equal to every other; a mismatch is an
+// unsatisfiable schema, not a merge ambiguity. Mirrors resolveDefault.
+func resolveConst(collection *SchemaCollection) (any, error) {
+	values := make([]any, 0)
+	for _, v := range collection.Const {
+		if v != nil {
+			values = append(values, v)
+		}
+	}
+	if len(values) == 0 {
+		return nil, nil
+	}
+	first := values[0]
+	for _, v := range values {
+		if !reflect.DeepEqual(first, v) {
+			return nil, errors.New(ConstErrorMessage)
 		}
 	}
 	return first, nil

--- a/flatten/allof/merge_allof_test.go
+++ b/flatten/allof/merge_allof_test.go
@@ -141,6 +141,67 @@ func TestMerge_DefaultFailure(t *testing.T) {
 	require.EqualError(t, err, allof.DefaultErrorMessage)
 }
 
+// OpenAPI 3.1 / JSON Schema 2020-12 `const`: a single subschema with `const`
+// is preserved as-is — the value flows through unchanged.
+func TestMerge_Const(t *testing.T) {
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				Const: "ACTIVE",
+			},
+		})
+	require.NoError(t, err)
+	require.Equal(t, "ACTIVE", merged.Const)
+}
+
+// `const` with the same value across allOf subschemas merges to that value
+// (the constraints are equal — no conflict).
+func TestMerge_ConstEqual(t *testing.T) {
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{Const: float64(42)}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{Const: float64(42)}},
+				},
+			},
+		})
+	require.NoError(t, err)
+	require.Equal(t, float64(42), merged.Const)
+}
+
+// `const` set on one subschema and absent on another — the present value
+// wins (nothing to conflict with).
+func TestMerge_ConstWithAbsentSibling(t *testing.T) {
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{Const: "only"}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"string"}}},
+				},
+			},
+		})
+	require.NoError(t, err)
+	require.Equal(t, "only", merged.Const)
+}
+
+// Conflicting `const` values across allOf subschemas describe an
+// unsatisfiable schema (no instance is both 1 and 2). Merge must surface
+// the conflict, not silently pick a winner.
+func TestMerge_ConstFailure(t *testing.T) {
+	_, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{Const: float64(1)}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{Const: float64(2)}},
+				},
+			},
+		})
+	require.EqualError(t, err, allof.ConstErrorMessage)
+}
+
 // verify that if all ReadOnly fields are set to false, then the ReadOnly field in the merged schema is false.
 func TestMerge_ReadOnlyIsSetToFalse(t *testing.T) {
 	merged, err := allof.Merge(


### PR DESCRIPTION
First fix in the easy bucket of #878 — `flatten/allOf` was silently dropping every 3.1-specific schema keyword. This PR handles `const`.

## What was wrong

A `const` value on either the outer schema or any allOf subschema was discarded by the merge. The merged schema accepted any value, defeating the constraint.

## Fix

Two changes in `flatten/allof/merge_allof.go`:

1. **Add `Const` to `SchemaCollection`**, collect from each subschema in `collect()`, and resolve in `flattenSchemas()` just before `resolveDefault`. The resolver mirrors `resolveDefault`'s pattern (deep-equal across non-nil values; conflict if mismatched) — same semantics fit: `const` constrains to a single value, so two non-equal `const` candidates describe an unsatisfiable schema, not a merge ambiguity.
2. **Copy `Const` in `mergeInternal`** alongside the existing field-copy block (lines 196–226). Without this, subschema results lost their `Const` before `flattenSchemas` could collect them — the single-schema test failed until I added it.

## Tests

Four new tests, mirroring the existing `TestMerge_Default` / `TestMerge_DefaultFailure` pair:

- `TestMerge_Const` — single schema with `const`, value preserved.
- `TestMerge_ConstEqual` — two subschemas with the same `const`, preserved.
- `TestMerge_ConstWithAbsentSibling` — `const` on one subschema only, preserved.
- `TestMerge_ConstFailure` — conflicting `const` values yield `ConstErrorMessage`.

All existing `flatten/allof` tests still pass.

## Tracker

Part of #878. Remaining easy items: `MinContains`/`MaxContains`, `ContentMediaType`/`ContentEncoding`, `DependentRequired`, `$defs`. Will land in follow-up PRs of similar shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)