### PR TITLE
feat(flatten/allof): handle OpenAPI 3.1 minContains / maxContains

### DIFF
--- a/flatten/allof/merge_allof.go
+++ b/flatten/allof/merge_allof.go
@@ -54,6 +54,8 @@ type SchemaCollection struct {
 	WriteOnly            []bool
 	Default              []any
 	Const                []any
+	MinContains          []*uint64
+	MaxContains          []*uint64
 }
 
 type state struct {
@@ -210,6 +212,12 @@ func mergeInternal(state *state, base *openapi3.SchemaRef) (*openapi3.SchemaRef,
 	result.Value.MinLength = base.Value.MinLength
 	result.Value.Default = base.Value.Default
 	result.Value.Const = base.Value.Const
+	if base.Value.MinContains != nil {
+		result.Value.MinContains = new(*base.Value.MinContains)
+	}
+	if base.Value.MaxContains != nil {
+		result.Value.MaxContains = new(*base.Value.MaxContains)
+	}
 	result.Value.Discriminator = base.Value.Discriminator
 	// Fields documented in ALLOF.md as "not merged" — i.e. the merge
 	// logic doesn't combine them across allOf subschemas. They MUST
@@ -373,11 +381,13 @@ func flattenSchemas(state *state, result *openapi3.SchemaRef, schemas []*openapi
 	result.Value.Description = firstOrSecondNonEmpty(collection.Description)
 	result.Value = resolveNumberRange(result.Value, &collection)
 	result.Value.MinLength = findMaxValue(collection.MinLength)
-	result.Value.MaxLength = findMinValue(collection.MaxLength)
+	result.Value.MaxLength = findMinValuePtr(collection.MaxLength)
 	result.Value.MinItems = findMaxValue(collection.MinItems)
-	result.Value.MaxItems = findMinValue(collection.MaxItems)
+	result.Value.MaxItems = findMinValuePtr(collection.MaxItems)
 	result.Value.MinProps = findMaxValue(collection.MinProps)
-	result.Value.MaxProps = findMinValue(collection.MaxProps)
+	result.Value.MaxProps = findMinValuePtr(collection.MaxProps)
+	result.Value.MinContains = findMaxValuePtr(collection.MinContains)
+	result.Value.MaxContains = findMinValuePtr(collection.MaxContains)
 	result.Value.Pattern = resolvePattern(collection.Pattern)
 	result.Value.Nullable = !hasFalse(collection.Nullable)
 	result.Value.ReadOnly = hasTrue(collection.ReadOnly)
@@ -867,7 +877,7 @@ func findMaxValue(values []uint64) uint64 {
 	return max
 }
 
-func findMinValue(values []*uint64) *uint64 {
+func findMinValuePtr(values []*uint64) *uint64 {
 	dvalues := []uint64{}
 	for _, v := range values {
 		if v != nil {
@@ -884,6 +894,25 @@ func findMinValue(values []*uint64) *uint64 {
 		}
 	}
 	return new(min)
+}
+
+// findMaxValuePtr is the upper-bound counterpart to findMinValuePtr: returns
+// nil if every value is nil, otherwise the highest non-nil value.
+func findMaxValuePtr(values []*uint64) *uint64 {
+	var max *uint64
+	for _, v := range values {
+		if v == nil {
+			continue
+		}
+		if max == nil || *v > *max {
+			max = v
+		}
+	}
+	if max == nil {
+		return nil
+	}
+	out := *max
+	return &out
 }
 
 func resolveType(schema *openapi3.Schema, collection *SchemaCollection) (*openapi3.Schema, error) {
@@ -1092,6 +1121,8 @@ func collect(schemas []*openapi3.SchemaRef) SchemaCollection {
 		collection.WriteOnly = append(collection.WriteOnly, s.Value.WriteOnly)
 		collection.Default = append(collection.Default, s.Value.Default)
 		collection.Const = append(collection.Const, s.Value.Const)
+		collection.MinContains = append(collection.MinContains, s.Value.MinContains)
+		collection.MaxContains = append(collection.MaxContains, s.Value.MaxContains)
 	}
 	return collection
 }

--- a/flatten/allof/merge_allof_test.go
+++ b/flatten/allof/merge_allof_test.go
@@ -1048,6 +1048,93 @@ components:
 		"flattened schema must not carry origin metadata (per docs/ALLOF.md)")
 }
 
+// OpenAPI 3.1 / JSON Schema 2020-12 `minContains`: lower bound on how
+// many array items must match the `contains` schema. Under allOf, the
+// most restrictive (highest) value wins.
+func TestMerge_MinContains_PicksHigher(t *testing.T) {
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{MinContains: uint64Ptr(2)}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{MinContains: uint64Ptr(5)}},
+				},
+			},
+		})
+	require.NoError(t, err)
+	require.NotNil(t, merged.MinContains)
+	require.Equal(t, uint64(5), *merged.MinContains)
+}
+
+// `minContains` set on one subschema, absent on another — the present
+// value flows through.
+func TestMerge_MinContains_WithAbsentSibling(t *testing.T) {
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{MinContains: uint64Ptr(3)}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"array"}}},
+				},
+			},
+		})
+	require.NoError(t, err)
+	require.NotNil(t, merged.MinContains)
+	require.Equal(t, uint64(3), *merged.MinContains)
+}
+
+// No subschema sets `minContains` — merged value stays nil (no constraint).
+func TestMerge_MinContains_AllUnset(t *testing.T) {
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"array"}}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"array"}}},
+				},
+			},
+		})
+	require.NoError(t, err)
+	require.Nil(t, merged.MinContains)
+}
+
+// `maxContains`: upper bound on how many array items match. Under allOf,
+// the most restrictive (lowest) value wins.
+func TestMerge_MaxContains_PicksLower(t *testing.T) {
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{MaxContains: uint64Ptr(10)}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{MaxContains: uint64Ptr(4)}},
+				},
+			},
+		})
+	require.NoError(t, err)
+	require.NotNil(t, merged.MaxContains)
+	require.Equal(t, uint64(4), *merged.MaxContains)
+}
+
+// `maxContains` set on one subschema, absent on another — the present
+// value flows through.
+func TestMerge_MaxContains_WithAbsentSibling(t *testing.T) {
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{MaxContains: uint64Ptr(7)}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"array"}}},
+				},
+			},
+		})
+	require.NoError(t, err)
+	require.NotNil(t, merged.MaxContains)
+	require.Equal(t, uint64(7), *merged.MaxContains)
+}
+
+// uint64Ptr is a small helper for *uint64 literal in tests.
+func uint64Ptr(v uint64) *uint64 { return &v }
+
 // merge multiple Not inside AllOf
 func TestMerge_Not(t *testing.T) {
 	merged, err := allof.Merge(


### PR DESCRIPTION
Part of #878. Same shape as the `const` fix in #879.

`minContains` and `maxContains` are 3.1 keywords (JSON Schema 2020-12) that constrain the count of array items matching the `contains` schema. Both are `*uint64` — `nil` means "no constraint" (default of `1` for `minContains`, unbounded for `maxContains`).

## What was wrong

Before this PR, both fields were silently dropped during `flatten/allOf`: the merged schema lost the constraint regardless of which subschema specified it.

## Changes in `merge_allof.go`

- Add `MinContains`, `MaxContains` to `SchemaCollection` and the `collect()` loop.
- Copy them in `mergeInternal` (alongside `MaxLength` / `MaxItems` / `MaxProps`, which use the same `if non-nil { result.X = new(*base.X) }` pattern for `*uint64` fields).
- Resolve in `flattenSchemas`: `minContains` takes the most restrictive (highest) value; `maxContains` the most restrictive (lowest). Matches the existing `minItems`/`maxItems` convention.
- Add `findMaxValuePtr` helper — the `*uint64` counterpart to the existing `findMinValue`. (`findMaxValue` handles non-pointer `uint64` already; the pointer case had no helper because no existing field needed it.)

## Tests (5 new)

- `minContains`: picks higher of two; flows through when sibling absent; stays nil when no subschema sets it.
- `maxContains`: picks lower of two; flows through when sibling absent.

All existing `flatten/allof` tests still pass. Lands cleanly on top of #879 (independent `SchemaCollection` field).

## Tracker

Part of #878. Remaining easy items: `ContentMediaType`/`ContentEncoding`, `DependentRequired`, `$defs`. Will land in follow-up PRs of similar shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)