### PR TITLE
feat(flatten/allof): handle OpenAPI 3.1 contentMediaType / contentEncoding

### DIFF
--- a/flatten/allof/merge_allof.go
+++ b/flatten/allof/merge_allof.go
@@ -12,10 +12,12 @@ import (
 )
 
 const (
-	FormatErrorMessage  = "unable to resolve Format conflict using default resolver: all Format values must be identical"
-	TypeErrorMessage    = "unable to resolve Type conflict: all Type values must be identical"
-	DefaultErrorMessage = "unable to resolve Default conflict: all Default values must be identical"
-	ConstErrorMessage   = "unable to resolve Const conflict: all Const values must be identical"
+	FormatErrorMessage           = "unable to resolve Format conflict using default resolver: all Format values must be identical"
+	TypeErrorMessage             = "unable to resolve Type conflict: all Type values must be identical"
+	DefaultErrorMessage          = "unable to resolve Default conflict: all Default values must be identical"
+	ConstErrorMessage            = "unable to resolve Const conflict: all Const values must be identical"
+	ContentMediaTypeErrorMessage = "unable to resolve ContentMediaType conflict: all ContentMediaType values must be identical"
+	ContentEncodingErrorMessage  = "unable to resolve ContentEncoding conflict: all ContentEncoding values must be identical"
 
 	FormatInt32  = "int32"
 	FormatInt64  = "int64"
@@ -56,6 +58,8 @@ type SchemaCollection struct {
 	Const                []any
 	MinContains          []*uint64
 	MaxContains          []*uint64
+	ContentMediaType     []string
+	ContentEncoding      []string
 }
 
 type state struct {
@@ -218,6 +222,8 @@ func mergeInternal(state *state, base *openapi3.SchemaRef) (*openapi3.SchemaRef,
 	if base.Value.MaxContains != nil {
 		result.Value.MaxContains = new(*base.Value.MaxContains)
 	}
+	result.Value.ContentMediaType = base.Value.ContentMediaType
+	result.Value.ContentEncoding = base.Value.ContentEncoding
 	result.Value.Discriminator = base.Value.Discriminator
 	// Fields documented in ALLOF.md as "not merged" — i.e. the merge
 	// logic doesn't combine them across allOf subschemas. They MUST
@@ -396,6 +402,14 @@ func flattenSchemas(state *state, result *openapi3.SchemaRef, schemas []*openapi
 	result.Value = resolveMultipleOf(result.Value, &collection)
 	result.Value.UniqueItems = resolveUniqueItems(collection.UniqueItems)
 	result.Value.Const, err = resolveConst(&collection)
+	if err != nil {
+		return err
+	}
+	result.Value.ContentMediaType, err = resolveStringEqual(collection.ContentMediaType, ContentMediaTypeErrorMessage)
+	if err != nil {
+		return err
+	}
+	result.Value.ContentEncoding, err = resolveStringEqual(collection.ContentEncoding, ContentEncodingErrorMessage)
 	if err != nil {
 		return err
 	}
@@ -1123,6 +1137,8 @@ func collect(schemas []*openapi3.SchemaRef) SchemaCollection {
 		collection.Const = append(collection.Const, s.Value.Const)
 		collection.MinContains = append(collection.MinContains, s.Value.MinContains)
 		collection.MaxContains = append(collection.MaxContains, s.Value.MaxContains)
+		collection.ContentMediaType = append(collection.ContentMediaType, s.Value.ContentMediaType)
+		collection.ContentEncoding = append(collection.ContentEncoding, s.Value.ContentEncoding)
 	}
 	return collection
 }
@@ -1312,6 +1328,27 @@ func findIntersection(arrays ...[]string) []string {
 	}
 
 	return intersection
+}
+
+// resolveStringEqual handles 3.1 string-valued schema keywords whose merge
+// semantics are simple equality: every non-empty candidate must equal every
+// other; otherwise the merged schema is unsatisfiable. Empty string means
+// "unset" (matches the kin-openapi convention for these fields).
+func resolveStringEqual(values []string, errMessage string) (string, error) {
+	first := ""
+	for _, v := range values {
+		if v == "" {
+			continue
+		}
+		if first == "" {
+			first = v
+			continue
+		}
+		if v != first {
+			return "", errors.New(errMessage)
+		}
+	}
+	return first, nil
 }
 
 func resolveDefault(collection *SchemaCollection) (any, error) {

--- a/flatten/allof/merge_allof_test.go
+++ b/flatten/allof/merge_allof_test.go
@@ -2581,3 +2581,91 @@ func TestMerge_DifferentOneOfGroups(t *testing.T) {
 	// Different oneOf groups should produce cartesian product (1 * 1 = 1 in this case)
 	require.Len(t, merged.OneOf, 1)
 }
+
+// OpenAPI 3.1: contentMediaType and contentEncoding describe how a string
+// is encoded and what it represents. They're string-valued and must agree
+// across allOf subschemas — two different content types describe an
+// unsatisfiable schema, not a merge ambiguity. Mirrors the Format
+// "must be identical" pattern.
+
+func TestMerge_ContentMediaType_Equal(t *testing.T) {
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{ContentMediaType: "application/json"}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{ContentMediaType: "application/json"}},
+				},
+			},
+		})
+	require.NoError(t, err)
+	require.Equal(t, "application/json", merged.ContentMediaType)
+}
+
+func TestMerge_ContentMediaType_WithAbsentSibling(t *testing.T) {
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{ContentMediaType: "image/png"}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"string"}}},
+				},
+			},
+		})
+	require.NoError(t, err)
+	require.Equal(t, "image/png", merged.ContentMediaType)
+}
+
+func TestMerge_ContentMediaType_Conflict(t *testing.T) {
+	_, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{ContentMediaType: "application/json"}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{ContentMediaType: "text/plain"}},
+				},
+			},
+		})
+	require.EqualError(t, err, allof.ContentMediaTypeErrorMessage)
+}
+
+func TestMerge_ContentEncoding_Equal(t *testing.T) {
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{ContentEncoding: "base64"}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{ContentEncoding: "base64"}},
+				},
+			},
+		})
+	require.NoError(t, err)
+	require.Equal(t, "base64", merged.ContentEncoding)
+}
+
+func TestMerge_ContentEncoding_WithAbsentSibling(t *testing.T) {
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{ContentEncoding: "base16"}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"string"}}},
+				},
+			},
+		})
+	require.NoError(t, err)
+	require.Equal(t, "base16", merged.ContentEncoding)
+}
+
+func TestMerge_ContentEncoding_Conflict(t *testing.T) {
+	_, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{ContentEncoding: "base64"}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{ContentEncoding: "base16"}},
+				},
+			},
+		})
+	require.EqualError(t, err, allof.ContentEncodingErrorMessage)
+}


### PR DESCRIPTION
Part of #878. Same shape as #879 (`const`) and #880 (`minContains`/`maxContains`).

`contentMediaType` (e.g. `application/json`, `image/png`) and `contentEncoding` (e.g. `base64`, `base16`) are 3.1 string-valued schema keywords (JSON Schema 2020-12). The kin-openapi convention is empty string == unset.

## What was wrong

Before this PR, both fields were silently dropped during `flatten/allOf` — the merged schema lost the constraint regardless of which subschema specified it.

## Changes in `merge_allof.go`

- Add `ContentMediaType`, `ContentEncoding` to `SchemaCollection` and the `collect()` loop.
- Copy them in `mergeInternal` (alongside the existing string-field copies).
- Resolve in `flattenSchemas` via a new `resolveStringEqual` helper — every non-empty candidate must equal every other; otherwise the merged schema is unsatisfiable. Two distinct error messages (`ContentMediaTypeErrorMessage`, `ContentEncodingErrorMessage`) so failures point at the right keyword.

The new `resolveStringEqual` helper is reusable for any future 3.1 string keyword with the same "must agree" semantics.

## Tests (6 new, 3 per keyword)

- Equal across subschemas → merged value preserved
- One subschema sets it, sibling absent → flows through
- Distinct values → expected error message

All existing `flatten/allof` tests still pass. Lands cleanly on top of #879 and #880 (independent `SchemaCollection` fields and resolver).

## Tracker

Part of #878. Remaining easy items: `dependentRequired`, `$defs`. Will land in follow-up PRs of similar shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)