### PR TITLE
feat(flatten/allof): handle OpenAPI 3.1 dependentRequired

### DIFF
--- a/flatten/allof/merge_allof.go
+++ b/flatten/allof/merge_allof.go
@@ -60,6 +60,7 @@ type SchemaCollection struct {
 	MaxContains          []*uint64
 	ContentMediaType     []string
 	ContentEncoding      []string
+	DependentRequired    []map[string][]string
 }
 
 type state struct {
@@ -224,6 +225,7 @@ func mergeInternal(state *state, base *openapi3.SchemaRef) (*openapi3.SchemaRef,
 	}
 	result.Value.ContentMediaType = base.Value.ContentMediaType
 	result.Value.ContentEncoding = base.Value.ContentEncoding
+	result.Value.DependentRequired = base.Value.DependentRequired
 	result.Value.Discriminator = base.Value.Discriminator
 	// Fields documented in ALLOF.md as "not merged" — i.e. the merge
 	// logic doesn't combine them across allOf subschemas. They MUST
@@ -399,6 +401,7 @@ func flattenSchemas(state *state, result *openapi3.SchemaRef, schemas []*openapi
 	result.Value.ReadOnly = hasTrue(collection.ReadOnly)
 	result.Value.WriteOnly = hasTrue(collection.WriteOnly)
 	result.Value.Required = resolveRequired(collection.Required)
+	result.Value.DependentRequired = resolveDependentRequired(collection.DependentRequired)
 	result.Value = resolveMultipleOf(result.Value, &collection)
 	result.Value.UniqueItems = resolveUniqueItems(collection.UniqueItems)
 	result.Value.Const, err = resolveConst(&collection)
@@ -1097,6 +1100,33 @@ func resolveRequired(values [][]string) []string {
 	return uniqueValues
 }
 
+// resolveDependentRequired handles 3.1 / JSON Schema 2020-12 `dependentRequired`:
+// per-trigger-property maps to a list of properties that must be present when
+// the trigger is. Under allOf, every subschema's constraints apply, so we
+// take the per-key union of required-property lists (deduplicated).
+func resolveDependentRequired(maps []map[string][]string) map[string][]string {
+	merged := map[string][]string{}
+	seen := map[string]map[string]bool{} // trigger -> set of dependents
+	for _, m := range maps {
+		for trigger, deps := range m {
+			if _, ok := seen[trigger]; !ok {
+				seen[trigger] = map[string]bool{}
+			}
+			for _, dep := range deps {
+				if seen[trigger][dep] {
+					continue
+				}
+				seen[trigger][dep] = true
+				merged[trigger] = append(merged[trigger], dep)
+			}
+		}
+	}
+	if len(merged) == 0 {
+		return nil
+	}
+	return merged
+}
+
 func collect(schemas []*openapi3.SchemaRef) SchemaCollection {
 	collection := SchemaCollection{}
 	for _, s := range schemas {
@@ -1139,6 +1169,7 @@ func collect(schemas []*openapi3.SchemaRef) SchemaCollection {
 		collection.MaxContains = append(collection.MaxContains, s.Value.MaxContains)
 		collection.ContentMediaType = append(collection.ContentMediaType, s.Value.ContentMediaType)
 		collection.ContentEncoding = append(collection.ContentEncoding, s.Value.ContentEncoding)
+		collection.DependentRequired = append(collection.DependentRequired, s.Value.DependentRequired)
 	}
 	return collection
 }

--- a/flatten/allof/merge_allof_test.go
+++ b/flatten/allof/merge_allof_test.go
@@ -2669,3 +2669,114 @@ func TestMerge_ContentEncoding_Conflict(t *testing.T) {
 		})
 	require.EqualError(t, err, allof.ContentEncodingErrorMessage)
 }
+
+// OpenAPI 3.1 / JSON Schema 2020-12 `dependentRequired`: per-trigger-property
+// map naming OTHER properties that must be present when the trigger is.
+// Under allOf, every subschema's constraints apply, so the merge is a
+// per-key union of required-property lists (deduplicated).
+
+// Single subschema with dependentRequired flows through unchanged.
+func TestMerge_DependentRequired_SinglePass(t *testing.T) {
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				DependentRequired: map[string][]string{
+					"credit_card": {"billing_address", "country"},
+				},
+			},
+		})
+	require.NoError(t, err)
+	require.Equal(t,
+		map[string][]string{"credit_card": {"billing_address", "country"}},
+		merged.DependentRequired)
+}
+
+// Same trigger appears in two subschemas with different dependents → union.
+func TestMerge_DependentRequired_UnionsSameTrigger(t *testing.T) {
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{
+						DependentRequired: map[string][]string{
+							"credit_card": {"billing_address"},
+						},
+					}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{
+						DependentRequired: map[string][]string{
+							"credit_card": {"country"},
+						},
+					}},
+				},
+			},
+		})
+	require.NoError(t, err)
+	require.Contains(t, merged.DependentRequired, "credit_card")
+	require.ElementsMatch(t,
+		[]string{"billing_address", "country"},
+		merged.DependentRequired["credit_card"])
+}
+
+// Different triggers are kept separate; overlapping dependents are deduped.
+func TestMerge_DependentRequired_DistinctTriggersAndDedup(t *testing.T) {
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{
+						DependentRequired: map[string][]string{
+							"credit_card": {"billing_address"},
+							"ssn":         {"country"},
+						},
+					}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{
+						DependentRequired: map[string][]string{
+							"credit_card": {"billing_address", "country"}, // billing_address dupes
+						},
+					}},
+				},
+			},
+		})
+	require.NoError(t, err)
+	require.Len(t, merged.DependentRequired, 2)
+	require.ElementsMatch(t,
+		[]string{"billing_address", "country"},
+		merged.DependentRequired["credit_card"])
+	require.ElementsMatch(t,
+		[]string{"country"},
+		merged.DependentRequired["ssn"])
+}
+
+// dependentRequired set on one subschema, absent on another → flows through.
+func TestMerge_DependentRequired_WithAbsentSibling(t *testing.T) {
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{
+						DependentRequired: map[string][]string{
+							"a": {"b"},
+						},
+					}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"object"}}},
+				},
+			},
+		})
+	require.NoError(t, err)
+	require.Equal(t, map[string][]string{"a": {"b"}}, merged.DependentRequired)
+}
+
+// No subschema sets dependentRequired → merged value stays nil.
+func TestMerge_DependentRequired_AllUnset(t *testing.T) {
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"object"}}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"object"}}},
+				},
+			},
+		})
+	require.NoError(t, err)
+	require.Nil(t, merged.DependentRequired)
+}


### PR DESCRIPTION
Part of #878. Same pattern as #879 (`const`), #880 (`minContains`/`maxContains`), #881 (`contentMediaType`/`contentEncoding`).

`dependentRequired` is a 3.1 / JSON Schema 2020-12 keyword: a per-trigger-property map naming OTHER properties that MUST be present when the trigger is. Type is `map[string][]string`.

## What was wrong

Before this PR, the field was silently dropped during `flatten/allOf` — the merged schema lost every conditional-required constraint.

## Changes in `merge_allof.go`

- Add `DependentRequired` to `SchemaCollection` and the `collect()` loop.
- Copy it in `mergeInternal` (the map field is reference-copied, consistent with how other maps like `Properties` are handled before the resolve pass).
- Resolve in `flattenSchemas` via a new `resolveDependentRequired` helper. Under allOf every subschema's constraints apply, so the merge is a **per-trigger union** of dependent-property lists with **dedup**. Returns `nil` when no subschema specified the keyword (so the merged schema doesn't carry an empty map that the loader wouldn't have produced).

## Tests (5 new)

- Single subschema → flows through unchanged.
- Same trigger across two subschemas → per-key union.
- Distinct triggers + overlapping dependents → triggers kept separate, dependents deduped.
- One subschema sets it, sibling absent → flows through.
- No subschema sets it → merged value stays nil.

All existing `flatten/allof` tests still pass. Lands cleanly on top of #879, #880, #881 (independent `SchemaCollection` field and resolver).

## Tracker

Part of #878. Remaining easy item: `$defs` (definitions namespace) — needs a design call on whether to preserve it post-flatten at all. Will surface that question separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)