### PR TITLE
docs(allof): document that $defs is intentionally dropped during flatten

### DIFF
--- a/docs/ALLOF.md
+++ b/docs/ALLOF.md
@@ -41,5 +41,6 @@ The following schema fields are not merged:
 - Deprecated
 - XML
 - Discriminator
+- `$defs` (OpenAPI 3.1) — intentionally dropped from the flattened output. `$defs` is a reusable-schema namespace used as the target of `$ref` pointers. After `--flatten-allof` runs, the merged schema has no `$ref`s left to resolve, so the namespace contributes nothing to its semantics. Preserving it would only add noise (and risk silent collisions when two `allOf` subschemas define different things under the same `$defs` key).
 
 Please help us improve this feature by providing feedback and reporting issues.


### PR DESCRIPTION
Closes the last item in #878's easy bucket. Unlike the other 3.1 keywords landed in #879 / #880 / #881 / #882, `$defs` needs no code change — it's already dropped today, and that's the right behavior:

- `$defs` is a reusable-schema namespace whose only role is being the target of `$ref` pointers within the same document.
- After `--flatten-allof` runs, the merged schema has no `$ref`s left to resolve.
- Preserving `$defs` would only add noise to the flattened output, plus risk silent collisions where two `allOf` subschemas defined different things under the same `$defs` key.

Adds an entry to the existing "fields not merged" list in `ALLOF.md` with that rationale, so users who pass a 3.1 spec through `oasdiff flatten` and notice `$defs` missing have the answer.

## Tracker

Closes the easy bucket of #878. Remaining items in #878:

- **Medium:** `Contains` / `PropertyNames` / `PatternProperties` / `DependentSchemas` / `PrefixItems` — schema-valued, need recursive merge.
- **Hard:** `If` / `Then` / `Else`, `UnevaluatedItems` / `UnevaluatedProperties` — semantics don't compose cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
