### PR TITLE
fix(flatten/allof): preserve fields documented as "not merged"; drop dup Type copy

### DIFF
--- a/flatten/allof/merge_allof.go
+++ b/flatten/allof/merge_allof.go
@@ -195,7 +195,6 @@ func mergeInternal(state *state, base *openapi3.SchemaRef) (*openapi3.SchemaRef,
 	result.Value.Type = base.Value.Type
 	result.Value.Format = base.Value.Format
 	result.Value.Description = base.Value.Description
-	result.Value.Type = base.Value.Type
 	result.Value.Enum = base.Value.Enum
 	result.Value.UniqueItems = base.Value.UniqueItems
 	result.Value.ExclusiveMax = base.Value.ExclusiveMax
@@ -209,6 +208,16 @@ func mergeInternal(state *state, base *openapi3.SchemaRef) (*openapi3.SchemaRef,
 	result.Value.MinLength = base.Value.MinLength
 	result.Value.Default = base.Value.Default
 	result.Value.Discriminator = base.Value.Discriminator
+	// Fields documented in ALLOF.md as "not merged" — i.e. the merge
+	// logic doesn't combine them across allOf subschemas. They MUST
+	// still flow through from the outer (base) schema, otherwise a
+	// single-schema Merge silently loses them.
+	result.Value.Example = base.Value.Example
+	result.Value.Deprecated = base.Value.Deprecated
+	result.Value.AllowEmptyValue = base.Value.AllowEmptyValue
+	result.Value.ExternalDocs = base.Value.ExternalDocs
+	result.Value.XML = base.Value.XML
+	result.Value.Extensions = base.Value.Extensions
 	if base.Value.MaxLength != nil {
 		result.Value.MaxLength = new(*base.Value.MaxLength)
 	}

--- a/flatten/allof/merge_allof_test.go
+++ b/flatten/allof/merge_allof_test.go
@@ -20,6 +20,79 @@ func exclusiveBoundValue(v float64) openapi3.ExclusiveBound {
 	return openapi3.ExclusiveBound{Value: &v}
 }
 
+// Single-schema round-trip tests: Merge on a schema with no allOf must not
+// silently drop scalar fields. mergeInternal hand-copied a curated allowlist
+// of base fields into result, so any field not on the list (Example,
+// Deprecated, AllowEmptyValue, XML, ExternalDocs, Extensions) was lost on
+// every Merge call — including pure passthroughs with no actual merging.
+// These tests pin "round-trip preserves the field" so a future regression
+// in the copy block is caught.
+
+func TestMerge_SingleSchema_PreservesExample(t *testing.T) {
+	merged, err := allof.Merge(openapi3.SchemaRef{
+		Value: &openapi3.Schema{Example: "sample-value"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "sample-value", merged.Example)
+}
+
+func TestMerge_SingleSchema_PreservesDeprecated(t *testing.T) {
+	merged, err := allof.Merge(openapi3.SchemaRef{
+		Value: &openapi3.Schema{Deprecated: true},
+	})
+	require.NoError(t, err)
+	require.True(t, merged.Deprecated)
+}
+
+func TestMerge_SingleSchema_PreservesAllowEmptyValue(t *testing.T) {
+	merged, err := allof.Merge(openapi3.SchemaRef{
+		Value: &openapi3.Schema{AllowEmptyValue: true},
+	})
+	require.NoError(t, err)
+	require.True(t, merged.AllowEmptyValue)
+}
+
+func TestMerge_SingleSchema_PreservesExternalDocs(t *testing.T) {
+	docs := &openapi3.ExternalDocs{Description: "more info", URL: "https://example.com/docs"}
+	merged, err := allof.Merge(openapi3.SchemaRef{
+		Value: &openapi3.Schema{ExternalDocs: docs},
+	})
+	require.NoError(t, err)
+	require.Same(t, docs, merged.ExternalDocs)
+}
+
+func TestMerge_SingleSchema_PreservesXML(t *testing.T) {
+	xml := &openapi3.XML{Name: "user", Namespace: "https://example.com/ns"}
+	merged, err := allof.Merge(openapi3.SchemaRef{
+		Value: &openapi3.Schema{XML: xml},
+	})
+	require.NoError(t, err)
+	require.Same(t, xml, merged.XML)
+}
+
+func TestMerge_SingleSchema_PreservesExtensions(t *testing.T) {
+	ext := map[string]any{"x-internal-id": "abc-123"}
+	merged, err := allof.Merge(openapi3.SchemaRef{
+		Value: &openapi3.Schema{Extensions: ext},
+	})
+	require.NoError(t, err)
+	require.Equal(t, ext, merged.Extensions)
+}
+
+// Single-schema with Type set must round-trip the Type. Pins regression
+// against the duplicate `result.Value.Type = base.Value.Type` lines that
+// existed before — if both were removed accidentally, the field would
+// be lost; if only the duplicate was removed (the intended cleanup),
+// this test still passes.
+func TestMerge_SingleSchema_PreservesType(t *testing.T) {
+	merged, err := allof.Merge(openapi3.SchemaRef{
+		Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, merged.Type)
+	require.True(t, merged.Type.Is("string"))
+}
+
 // identical Default fields are merged successfully
 func TestMerge_Default(t *testing.T) {
 	merged, err := allof.Merge(


### PR DESCRIPTION
Two bugs in `flatten/allof/merge_allof.go`'s `mergeInternal` field-copy block.

## Bugs

**1. Duplicate copy.** `result.Value.Type = base.Value.Type` was set on two consecutive lines (likely a merge accident). Removed the second.

**2. Silent field-drop on single-schema `Merge`.** The function hand-copies a curated allowlist of base fields into result. Six fields documented in `docs/ALLOF.md` as "not merged" were missing from the allowlist entirely: `Example`, `Deprecated`, `AllowEmptyValue`, `ExternalDocs`, `XML`, `Extensions`. Result: a single-schema `Merge` (no allOf) silently lost them.

```go
merged, _ := allof.Merge(openapi3.SchemaRef{Value: &openapi3.Schema{Example: "x"}})
// Before this PR: merged.Example == nil
// After this PR:  merged.Example == "x"
```

"Not merged" in `ALLOF.md` means the merge logic doesn't *combine* these fields across allOf subschemas — but they should still flow through from the outer schema, the same way `Discriminator` already does.

This is the same class of bug as the `Const` issue caught in #879 and the cause of the entire #878 backlog: every new kin-openapi field is silently dropped until added to the copy block.

## Tests

Added 7 new round-trip tests under `TestMerge_SingleSchema_*`:

- `PreservesExample`, `PreservesDeprecated`, `PreservesAllowEmptyValue`, `PreservesExternalDocs`, `PreservesXML`, `PreservesExtensions` — each passes a single-field schema through `Merge` and asserts the field survives. **All 6 FAILED on `main` before this fix; all PASS after.**
- `PreservesType` — passed before AND after; pins the regression guarantee that the duplicate-Type cleanup doesn't accidentally remove the (single, correct) `Type` copy too.

All existing `flatten/allof` tests still pass.

## Out of scope

The deeper design issue (the field-allowlist pattern itself is fragile and is the root cause of the entire #878 backlog) is not addressed here — this PR is a focused correctness fix. A registry-style refactor of `mergeInternal` + `flattenSchemas` would prevent the next class of silent drop, and is worth doing once the medium bucket of #878 has landed and we have empirical data on the cost of the current shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)