### PR TITLE
refactor(flatten/allof): rename findMaxValue -> findMaxValueScalar

### DIFF
--- a/flatten/allof/merge_allof.go
+++ b/flatten/allof/merge_allof.go
@@ -388,11 +388,11 @@ func flattenSchemas(state *state, result *openapi3.SchemaRef, schemas []*openapi
 	result.Value.Title = firstOrSecondNonEmpty(collection.Title)
 	result.Value.Description = firstOrSecondNonEmpty(collection.Description)
 	result.Value = resolveNumberRange(result.Value, &collection)
-	result.Value.MinLength = findMaxValue(collection.MinLength)
+	result.Value.MinLength = findMaxValueScalar(collection.MinLength)
 	result.Value.MaxLength = findMinValuePtr(collection.MaxLength)
-	result.Value.MinItems = findMaxValue(collection.MinItems)
+	result.Value.MinItems = findMaxValueScalar(collection.MinItems)
 	result.Value.MaxItems = findMinValuePtr(collection.MaxItems)
-	result.Value.MinProps = findMaxValue(collection.MinProps)
+	result.Value.MinProps = findMaxValueScalar(collection.MinProps)
 	result.Value.MaxProps = findMinValuePtr(collection.MaxProps)
 	result.Value.MinContains = findMaxValuePtr(collection.MinContains)
 	result.Value.MaxContains = findMinValuePtr(collection.MaxContains)
@@ -884,7 +884,7 @@ func isPatternResolved(pattern string) bool {
 	return match
 }
 
-func findMaxValue(values []uint64) uint64 {
+func findMaxValueScalar(values []uint64) uint64 {
 	max := uint64(0)
 	for _, num := range values {
 		if num > max {


### PR DESCRIPTION
Closes #885.

The `*Ptr` suffix on the `find*` helpers in `flatten/allof/merge_allof.go` exists to distinguish from a non-`Ptr` sibling. After #880 renamed `findMinValue` → `findMinValuePtr`, the suffix was load-bearing on the `Min` side but decorative on the `Max` side: `findMaxValue` (scalar) and `findMaxValuePtr` lived alongside each other with the suffix only on one of them.

This PR renames `findMaxValue` → `findMaxValueScalar` so both type variants of the upper-bound reduction carry an explicit type marker, matching the `findMinValuePtr` convention.

After this lands, the helper set is symmetric:

| Helper | Signature |
|---|---|
| `findMaxValueScalar` | `([]uint64) uint64` |
| `findMaxValuePtr` | `([]\*uint64) \*uint64` |
| `findMinValuePtr` | `([]\*uint64) \*uint64` |

(`findMinValueScalar` doesn't exist yet — none of the non-pointer fields need a "min wins" reduction. Add when first needed.)

Touches the helper definition plus three callers (`MinLength`, `MinItems`, `MinProps` in `flattenSchemas`). Pure rename, no behavior change, no new tests.
