### PR TITLE
feat(flatten/allof): handle OpenAPI 3.1 contains

### DIFF
--- a/docs/ALLOF.md
+++ b/docs/ALLOF.md
@@ -47,4 +47,8 @@ The following schema fields are not merged:
 
 The merger is defensive about spec violations — values that would crash the merge or produce nonsense are silently skipped rather than reported. For example, `multipleOf` values that are zero or negative (disallowed by the OpenAPI / JSON Schema spec) are dropped from the merged result. To surface invalid values in your spec rather than rely on the merger swallowing them, validate the spec separately.
 
+## `contains` is over-constrained when subschemas differ (OpenAPI 3.1)
+
+The strict `allOf` semantics for `contains` are *"≥1 array item matches X AND ≥1 item matches Y"* — the two matching items can be different. We can't express that as a single subschema, so when multiple `allOf` siblings each set `contains`, oasdiff merges the subschemas recursively (as if wrapped in `allOf`) and emits a single `contains: Merge(X, Y)`. That is *stricter* than the original: it requires one item to satisfy both X and Y. Arrays the original spec accepts (where X and Y are matched by distinct items) may be rejected after flattening; arrays the original rejects are never accepted. In practice this rarely matters because most specs have at most one `contains` per `allOf` chain.
+
 Please help us improve this feature by providing feedback and reporting issues.

--- a/flatten/allof/merge_allof.go
+++ b/flatten/allof/merge_allof.go
@@ -58,6 +58,7 @@ type SchemaCollection struct {
 	Const                []any
 	MinContains          []*uint64
 	MaxContains          []*uint64
+	Contains             []*openapi3.SchemaRef
 	ContentMediaType     []string
 	ContentEncoding      []string
 	DependentRequired    []map[string][]string
@@ -223,6 +224,7 @@ func mergeInternal(state *state, base *openapi3.SchemaRef) (*openapi3.SchemaRef,
 	if base.Value.MaxContains != nil {
 		result.Value.MaxContains = new(*base.Value.MaxContains)
 	}
+	result.Value.Contains = base.Value.Contains
 	result.Value.ContentMediaType = base.Value.ContentMediaType
 	result.Value.ContentEncoding = base.Value.ContentEncoding
 	result.Value.DependentRequired = base.Value.DependentRequired
@@ -436,6 +438,10 @@ func flattenSchemas(state *state, result *openapi3.SchemaRef, schemas []*openapi
 	if err != nil {
 		return err
 	}
+	result.Value, err = resolveContains(state, result.Value, &collection)
+	if err != nil {
+		return err
+	}
 	result.Value, err = resolveProperties(state, result.Value, &collection)
 	if err != nil {
 		return err
@@ -635,6 +641,41 @@ func resolveItems(state *state, schema *openapi3.Schema, collection *SchemaColle
 		return nil, err
 	}
 	schema.Items = result
+	return schema, nil
+}
+
+// resolveContains merges OpenAPI 3.1 / JSON Schema 2020-12 `contains`
+// subschemas across allOf siblings. `contains` means "at least one array
+// item matches the subschema", so the strict allOf semantics are
+// "≥1 item matches X AND ≥1 item matches Y" — the two matching items can
+// be different. We can't express that as a single subschema, so we
+// over-constrain: we recursively flatten X and Y as if wrapped in allOf,
+// producing a single subschema that ≥1 item must match. This rejects some
+// arrays that the original spec accepts (those where X and Y are matched
+// by distinct items) but never accepts an array the original rejects.
+// Documented in docs/ALLOF.md.
+func resolveContains(state *state, schema *openapi3.Schema, collection *SchemaCollection) (*openapi3.Schema, error) {
+
+	contains := openapi3.SchemaRefs{}
+	for _, sref := range collection.Contains {
+		if sref != nil {
+			contains = append(contains, sref)
+		}
+	}
+	if len(contains) == 0 {
+		schema.Contains = nil
+		return schema, nil
+	}
+	if len(contains) == 1 {
+		schema.Contains = contains[0]
+		return schema, nil
+	}
+	result := openapi3.NewSchemaRef("", openapi3.NewSchema())
+	err := flattenSchemas(state, result, contains)
+	if err != nil {
+		return nil, err
+	}
+	schema.Contains = result
 	return schema, nil
 }
 
@@ -1170,6 +1211,7 @@ func collect(schemas []*openapi3.SchemaRef) SchemaCollection {
 		collection.Const = append(collection.Const, s.Value.Const)
 		collection.MinContains = append(collection.MinContains, s.Value.MinContains)
 		collection.MaxContains = append(collection.MaxContains, s.Value.MaxContains)
+		collection.Contains = append(collection.Contains, s.Value.Contains)
 		collection.ContentMediaType = append(collection.ContentMediaType, s.Value.ContentMediaType)
 		collection.ContentEncoding = append(collection.ContentEncoding, s.Value.ContentEncoding)
 		collection.DependentRequired = append(collection.DependentRequired, s.Value.DependentRequired)

--- a/flatten/allof/merge_allof_test.go
+++ b/flatten/allof/merge_allof_test.go
@@ -2833,3 +2833,104 @@ func TestMerge_MultipleOf_NegativeIsSkipped(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, merged.MultipleOf)
 }
+
+// OpenAPI 3.1 / JSON Schema 2020-12 `contains`: at least one array item
+// must validate against the subschema. Strict allOf semantics are
+// "≥1 item matches X AND ≥1 item matches Y" (different items allowed),
+// but we over-constrain to "≥1 item matches Merge(X, Y)" — see
+// resolveContains and docs/ALLOF.md for the rationale.
+
+// Single subschema with `contains` flows through unchanged.
+func TestMerge_Contains_SinglePass(t *testing.T) {
+	contains := &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"string"}}}
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{Contains: contains},
+		})
+	require.NoError(t, err)
+	require.NotNil(t, merged.Contains)
+	require.Equal(t, &openapi3.Types{"string"}, merged.Contains.Value.Type)
+}
+
+// `contains` set on one subschema, absent on another — the present
+// subschema flows through.
+func TestMerge_Contains_WithAbsentSibling(t *testing.T) {
+	contains := &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"string"}}}
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{Contains: contains}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"array"}}},
+				},
+			},
+		})
+	require.NoError(t, err)
+	require.NotNil(t, merged.Contains)
+	require.Equal(t, &openapi3.Types{"string"}, merged.Contains.Value.Type)
+}
+
+// Two subschemas with compatible `contains` are recursively merged into
+// one (over-constrained: requires a single item satisfying both).
+func TestMerge_Contains_TwoCompatibleAreMerged(t *testing.T) {
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{
+						Contains: &openapi3.SchemaRef{Value: &openapi3.Schema{
+							Type: &openapi3.Types{"integer"},
+							Min:  new(10.0),
+						}},
+					}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{
+						Contains: &openapi3.SchemaRef{Value: &openapi3.Schema{
+							Type: &openapi3.Types{"integer"},
+							Max:  new(100.0),
+						}},
+					}},
+				},
+			},
+		})
+	require.NoError(t, err)
+	require.NotNil(t, merged.Contains)
+	require.Equal(t, &openapi3.Types{"integer"}, merged.Contains.Value.Type)
+	require.NotNil(t, merged.Contains.Value.Min)
+	require.Equal(t, 10.0, *merged.Contains.Value.Min)
+	require.NotNil(t, merged.Contains.Value.Max)
+	require.Equal(t, 100.0, *merged.Contains.Value.Max)
+}
+
+// Two subschemas with `contains` whose Types disagree → recursive merge
+// surfaces the underlying conflict as an error (Type "must be identical").
+func TestMerge_Contains_ConflictBubblesUp(t *testing.T) {
+	_, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{
+						Contains: &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"string"}}},
+					}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{
+						Contains: &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"integer"}}},
+					}},
+				},
+			},
+		})
+	require.EqualError(t, err, allof.TypeErrorMessage)
+}
+
+// No subschema sets `contains` → merged value stays nil.
+func TestMerge_Contains_AllUnset(t *testing.T) {
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"array"}}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"array"}}},
+				},
+			},
+		})
+	require.NoError(t, err)
+	require.Nil(t, merged.Contains)
+}


### PR DESCRIPTION
First medium-bucket item from #878. Unlike the easy-bucket keywords (#879, #880, #881, #882) — all scalar flow-throughs — `contains` carries a subschema and the merge needs real recursion.

## Semantics + tradeoff

`contains: X` means *"at least one array item matches X"*. The strict `allOf` interpretation of `contains: X + contains: Y` is *"≥1 item matches X AND ≥1 item matches Y"* — the matching items can be different. That isn't expressible as a single subschema, so `resolveContains` over-constrains: it recursively flattens X and Y as if wrapped in `allOf` and emits one `contains: Merge(X, Y)`, which requires a single item to satisfy both.

The flattened spec rejects some arrays the original accepts (those where X and Y are matched by distinct items) but **never accepts an array the original rejects**. Over-reporting is the only failure mode and it's loud, not silent. In practice most specs have at most one `contains` per `allOf` chain, so this rarely bites.

Mirrors `resolveItems` both in shape and in this same correctness/usability tradeoff.

## Tests (5)

- `SinglePass` — single subschema with `contains` flows through unchanged
- `WithAbsentSibling` — `contains` set on one of two siblings flows through
- `TwoCompatibleAreMerged` — round-trip through `Merge`: integer + `Min: 10` and integer + `Max: 100` produce one merged subschema with both bounds
- `ConflictBubblesUp` — recursive `Type` conflict surfaces as the existing `TypeErrorMessage` rather than silently picking one
- `AllUnset` — both siblings without `contains` → merged value stays nil

## Docs

`docs/ALLOF.md` updated with a section explaining the over-constrain choice so users hitting an unexpected breaking-change report on `contains` can find the rationale.

## Refs

- Refs #878 (3.1 keyword backlog) — first medium-bucket item
- Establishes the recursive-merge pattern for the remaining medium items (`PropertyNames`, `PatternProperties`, `DependentSchemas`, `PrefixItems`)
- Real-world stress test for the registry refactor in #886