### PR TITLE
fix(flatten/allof): skip non-positive MultipleOf instead of panicking

### DIFF
--- a/docs/ALLOF.md
+++ b/docs/ALLOF.md
@@ -43,4 +43,8 @@ The following schema fields are not merged:
 - Discriminator
 - `$defs` (OpenAPI 3.1) — intentionally dropped from the flattened output. `$defs` is a reusable-schema namespace used as the target of `$ref` pointers. After `--flatten-allof` runs, the merged schema has no `$ref`s left to resolve, so the namespace contributes nothing to its semantics. Preserving it would only add noise (and risk silent collisions when two `allOf` subschemas define different things under the same `$defs` key).
 
+## Invalid input handling
+
+The merger is defensive about spec violations — values that would crash the merge or produce nonsense are silently skipped rather than reported. For example, `multipleOf` values that are zero or negative (disallowed by the OpenAPI / JSON Schema spec) are dropped from the merged result. To surface invalid values in your spec rather than rely on the merger swallowing them, validate the spec separately.
+
 Please help us improve this feature by providing feedback and reporting issues.

--- a/flatten/allof/merge_allof.go
+++ b/flatten/allof/merge_allof.go
@@ -671,7 +671,10 @@ func containsNonInteger(arr []float64) bool {
 func resolveMultipleOf(schema *openapi3.Schema, collection *SchemaCollection) *openapi3.Schema {
 	values := []float64{}
 	for _, v := range collection.MultipleOf {
-		if v == nil {
+		// Per OpenAPI / JSON Schema, multipleOf must be > 0. A spec
+		// containing 0 or a negative value is invalid; skip rather than
+		// panic. Letting 0 through reaches lcm(0, 0) → divide by zero.
+		if v == nil || *v <= 0 {
 			continue
 		}
 		values = append(values, *v)

--- a/flatten/allof/merge_allof_test.go
+++ b/flatten/allof/merge_allof_test.go
@@ -2780,3 +2780,56 @@ func TestMerge_DependentRequired_AllUnset(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, merged.DependentRequired)
 }
+
+// Per OpenAPI / JSON Schema, multipleOf must be > 0. A spec containing
+// 0 or a negative value is invalid. Before #889 the code reached
+// lcm(0, 0) and panicked with "integer divide by zero"; now invalid
+// values are skipped.
+func TestMerge_MultipleOf_ZeroIsSkipped(t *testing.T) {
+	zero := 0.0
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{MultipleOf: &zero}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{MultipleOf: &zero}},
+				},
+			},
+		})
+	require.NoError(t, err)
+	require.Nil(t, merged.MultipleOf)
+}
+
+// One valid + one zero multipleOf → the valid one wins, zero is dropped.
+func TestMerge_MultipleOf_ZeroDroppedAlongsideValid(t *testing.T) {
+	zero := 0.0
+	five := 5.0
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{MultipleOf: &zero}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{MultipleOf: &five}},
+				},
+			},
+		})
+	require.NoError(t, err)
+	require.NotNil(t, merged.MultipleOf)
+	require.Equal(t, 5.0, *merged.MultipleOf)
+}
+
+// Negative multipleOf is also invalid per spec; treat the same as zero.
+func TestMerge_MultipleOf_NegativeIsSkipped(t *testing.T) {
+	negative := -3.0
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{MultipleOf: &negative}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{MultipleOf: &negative}},
+				},
+			},
+		})
+	require.NoError(t, err)
+	require.Nil(t, merged.MultipleOf)
+}


### PR DESCRIPTION
Closes #889.

Two `allOf` siblings with `MultipleOf: 0` reach `lcm(0, 0) = 0*0 / gcd(0,0) = 0/0` and panic with `runtime error: integer divide by zero`. Per the OpenAPI / JSON Schema spec, `multipleOf` must be `> 0`, so 0 (and negative values) are invalid input — the right response is to skip them, not crash.

## Change

In `resolveMultipleOf`, extend the existing nil-skip loop to also skip non-positive values:

```go
if v == nil || *v <= 0 {
    continue
}
```

## Tests

Three new tests:

- `MultipleOf_ZeroIsSkipped` — two zero values: merged result has `MultipleOf: nil` instead of panicking
- `MultipleOf_ZeroDroppedAlongsideValid` — one zero + one valid: valid one wins, zero is dropped
- `MultipleOf_NegativeIsSkipped` — negative values treated the same as zero

All pre-existing `MultipleOf` tests still pass.

## Verified

The original repro from the issue (two `MultipleOf: &zero` siblings) now returns cleanly with `merged.MultipleOf == nil` and `err == nil`.
