### PR TITLE
fix(formatters): make Change.Fingerprint stable across copy edits

### DIFF
--- a/formatters/changes.go
+++ b/formatters/changes.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"strings"
 
 	"github.com/oasdiff/oasdiff/checker"
 )
@@ -33,11 +34,10 @@ func NewChanges(originalChanges checker.Changes, l checker.Localizer) Changes {
 		id := change.GetId()
 		operation := change.GetOperation()
 		path := change.GetPath()
-		text := change.GetUncolorizedText(l)
 		changes[i] = Change{
 			Section:        change.GetSection(),
 			Id:             id,
-			Text:           text,
+			Text:           change.GetUncolorizedText(l),
 			Comment:        change.GetComment(l),
 			Level:          change.GetLevel(),
 			Operation:      operation,
@@ -47,14 +47,36 @@ func NewChanges(originalChanges checker.Changes, l checker.Localizer) Changes {
 			Attributes:     change.GetAttributes(),
 			BaseSource:     change.GetBaseSource(),
 			RevisionSource: change.GetRevisionSource(),
-			Fingerprint:    computeFingerprint(id, operation, path, text),
+			Fingerprint:    computeFingerprint(id, operation, path, change.GetArgs()),
 		}
 	}
 	return changes
 }
 
-func computeFingerprint(id, operation, path, text string) string {
-	h := fmt.Sprintf("%s:%s:%s:%s", id, operation, path, text)
+// computeFingerprint produces a short, stable identifier for a change. It is
+// used to match the same logical change across spec versions (carry-forward of
+// review state in oasdiff-service) and to look up review records at view time.
+//
+// Inputs are the structured rule arguments rather than the rendered text:
+// rendered text varies with locale and copy edits to the message templates,
+// which would silently invalidate every stored fingerprint. The args carry the
+// same per-change disambiguation power without that fragility.
+func computeFingerprint(id, operation, path string, args []any) string {
+	h := fmt.Sprintf("%s:%s:%s:%s", id, operation, path, serializeArgs(args))
 	sum := sha256.Sum256([]byte(h))
 	return hex.EncodeToString(sum[:])[:12]
+}
+
+// serializeArgs joins the change args into a deterministic string. fmt's `%v`
+// verb sorts map keys (Go 1.12+) so nested maps remain stable; primitives and
+// slices are stable by definition.
+func serializeArgs(args []any) string {
+	if len(args) == 0 {
+		return ""
+	}
+	parts := make([]string, len(args))
+	for i, a := range args {
+		parts[i] = fmt.Sprintf("%v", a)
+	}
+	return strings.Join(parts, ";")
 }

--- a/formatters/changes_test.go
+++ b/formatters/changes_test.go
@@ -1,0 +1,104 @@
+package formatters_test
+
+import (
+	"testing"
+
+	"github.com/oasdiff/oasdiff/checker"
+	"github.com/oasdiff/oasdiff/formatters"
+	"github.com/oasdiff/oasdiff/load"
+	"github.com/stretchr/testify/require"
+)
+
+// fingerprintOf is a small helper that runs a single change through NewChanges
+// and returns the resulting fingerprint. The MockLocalizer keeps the rendered
+// text constant so any drift the test catches is in the fingerprint logic
+// itself, not the message catalogue.
+func fingerprintOf(c checker.Change) string {
+	return formatters.NewChanges(checker.Changes{c}, MockLocalizer)[0].Fingerprint
+}
+
+// Pin the current fingerprint format so a future change to the algorithm
+// (e.g. switching hash, truncation length, or the order of inputs) becomes a
+// loud test failure rather than a silent invalidation of every stored
+// pr_changes row in oasdiff-service.
+func TestNewChanges_FingerprintFormat(t *testing.T) {
+	got := fingerprintOf(checker.ApiChange{
+		Id:        "change_id",
+		Level:     checker.ERR,
+		Operation: "GET",
+		Path:      "/users",
+		Source:    &load.Source{},
+		Args:      []any{"name", 42},
+	})
+	require.Equal(t, "39d9aa2ed55d", got)
+	require.Len(t, got, 12)
+}
+
+// Args go through fmt's %v verb, so different values must hash differently.
+// This is the disambiguation property: two changes from the same rule on the
+// same operation with different parameters must not collide.
+func TestNewChanges_FingerprintDistinguishesArgs(t *testing.T) {
+	a := fingerprintOf(checker.ApiChange{
+		Id: "change_id", Level: checker.ERR, Operation: "GET", Path: "/u",
+		Source: &load.Source{}, Args: []any{"alpha"},
+	})
+	b := fingerprintOf(checker.ApiChange{
+		Id: "change_id", Level: checker.ERR, Operation: "GET", Path: "/u",
+		Source: &load.Source{}, Args: []any{"beta"},
+	})
+	require.NotEqual(t, a, b)
+}
+
+// The whole point of the change: the fingerprint must not depend on the
+// rendered text. This is the regression guard for the April 9 backticks
+// incident — a copy edit to the localized message would silently invalidate
+// every stored fingerprint under the old text-based algorithm.
+//
+// We compare two changes that produce the same args+id+op+path but render
+// different text (different rule families with overlapping localization keys
+// would differ on text alone). Using the same change but a different
+// Localizer gives us a tighter, locale-only test.
+func TestNewChanges_FingerprintIndependentOfLocale(t *testing.T) {
+	change := checker.ApiChange{
+		Id: "change_id", Level: checker.ERR, Operation: "POST", Path: "/x",
+		Source: &load.Source{}, Args: []any{"v1"},
+	}
+	english := formatters.NewChanges(checker.Changes{change}, MockLocalizer)[0]
+	other := formatters.NewChanges(checker.Changes{change}, func(originalKey string, args ...interface{}) string {
+		return "completely different rendering: " + originalKey
+	})[0]
+
+	require.NotEqual(t, english.Text, other.Text, "test setup: locales must render differently")
+	require.Equal(t, english.Fingerprint, other.Fingerprint,
+		"fingerprint must not depend on rendered text — copy edits and locale switches would invalidate every stored pr_changes row in oasdiff-service")
+}
+
+// Two changes that differ only in BaseSource line/column must share a
+// fingerprint so review state survives unrelated whitespace edits to the spec
+// (the carry-forward use case in oasdiff-service/internal/pr_comment.go).
+func TestNewChanges_FingerprintIndependentOfSourceLocation(t *testing.T) {
+	a := fingerprintOf(checker.ApiChange{
+		Id: "change_id", Level: checker.ERR, Operation: "GET", Path: "/u",
+		Source: &load.Source{}, Args: []any{"p"},
+		CommonChange: checker.CommonChange{
+			BaseSource: checker.NewSource("base.yaml", 10, 5),
+		},
+	})
+	b := fingerprintOf(checker.ApiChange{
+		Id: "change_id", Level: checker.ERR, Operation: "GET", Path: "/u",
+		Source: &load.Source{}, Args: []any{"p"},
+		CommonChange: checker.CommonChange{
+			BaseSource: checker.NewSource("base.yaml", 99, 5),
+		},
+	})
+	require.Equal(t, a, b)
+}
+
+// A change with no args gets an empty arg segment, not a panic.
+func TestNewChanges_FingerprintNoArgs(t *testing.T) {
+	got := fingerprintOf(checker.ApiChange{
+		Id: "change_id", Level: checker.ERR, Operation: "GET", Path: "/u",
+		Source: &load.Source{},
+	})
+	require.Len(t, got, 12)
+}

--- a/formatters/format_json_test.go
+++ b/formatters/format_json_test.go
@@ -29,7 +29,7 @@ func TestJsonFormatter_RenderChangelog(t *testing.T) {
 
 	out, err := jsonFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts(), "", "")
 	require.NoError(t, err)
-	require.Equal(t, "[{\"id\":\"change_id\",\"text\":\"This is a breaking change.\",\"level\":3,\"section\":\"components\",\"fingerprint\":\"d22c5b8b9cec\"}]", string(out))
+	require.Equal(t, "[{\"id\":\"change_id\",\"text\":\"This is a breaking change.\",\"level\":3,\"section\":\"components\",\"fingerprint\":\"f8cd9af6b117\"}]", string(out))
 }
 
 func TestJsonFormatter_RenderChecks(t *testing.T) {
@@ -87,6 +87,6 @@ func TestJsonFormatter_RenderChangelog_WithSources(t *testing.T) {
 	require.NoError(t, err)
 
 	// Parse and check that baseSource is included but revisionSource is not (due to omitempty)
-	expected := `[{"id":"change_id","text":"This is a breaking change.","level":3,"operation":"GET","path":"/test","section":"paths","baseSource":{"file":"base.yaml","line":10,"column":5},"fingerprint":"ebee3a862e95"}]`
+	expected := `[{"id":"change_id","text":"This is a breaking change.","level":3,"operation":"GET","path":"/test","section":"paths","baseSource":{"file":"base.yaml","line":10,"column":5},"fingerprint":"80a8c624dc40"}]`
 	require.Equal(t, expected, string(out))
 }

--- a/formatters/format_yaml_test.go
+++ b/formatters/format_yaml_test.go
@@ -30,7 +30,7 @@ func TestYamlFormatter_RenderChangelog(t *testing.T) {
 
 	out, err := yamlFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts(), "", "")
 	require.NoError(t, err)
-	require.Equal(t, "- id: change_id\n  text: This is a breaking change.\n  level: 3\n  section: components\n  fingerprint: d22c5b8b9cec\n", string(out))
+	require.Equal(t, "- id: change_id\n  text: This is a breaking change.\n  level: 3\n  section: components\n  fingerprint: f8cd9af6b117\n", string(out))
 }
 
 func TestYamlFormatter_RenderChangelogWithWrapInObject(t *testing.T) {
@@ -114,7 +114,7 @@ func TestYamlFormatter_RenderChangelog_WithSources(t *testing.T) {
     file: revision.yaml
     line: 12
     column: 7
-  fingerprint: 50fb7e2d3284
+  fingerprint: f5b4600674e9
 `
 	require.Equal(t, expected, string(out))
 }


### PR DESCRIPTION
## Summary
`Change.Fingerprint` is meant to give downstream tools a short, stable identifier for the same logical change across spec versions (e.g. carry-forward of review state, view-time matching). Today it's computed from the rendered text:

```go
sha256(id:operation:path:text)[:12]
```

`text` is the localized message after `%s` substitution, so any copy edit to a message template, any locale switch, and any change to how arg values are rendered (single quotes to backticks, for example) silently invalidates every previously-computed fingerprint. PR #836's switch from `'%s'` to `` `%s` `` in `checker/colorize.go` did exactly that.

## What this changes
Hash the structured args instead of the rendered text:

```go
sha256(id:operation:path:serialize(args))[:12]
```

Args are the upstream stable form of the same per-change information that `text` carries; switching to them gives the same disambiguation power without locale or template fragility.

## Test plan
- [x] New `formatters/changes_test.go` covers:
  - Format pin (current value asserted, length asserted) so a future change to the algorithm is a loud failure.
  - Independence from rendered text (different locales produce the same fingerprint).
  - Independence from source location (line/column shifts in unrelated whitespace produce the same fingerprint).
  - Args still disambiguate (`["alpha"]` vs `["beta"]` produce different fingerprints).
  - No-args case doesn't panic.
- [x] Hardcoded fingerprint values in `format_json_test.go` and `format_yaml_test.go` updated to the new algorithm.
- [x] `go test ./...` passes.

## Note on migration
This is a one-way migration. Any external system that stored fingerprints under the previous algorithm will see them no longer match recomputed values. That is the cost of moving to a stable scheme; keeping the old algorithm guarantees the same problem will recur on the next message edit.
