### PR TITLE
fix: walk additionalProperties in processDeleted/AddedPropertiesDiff

### DIFF
--- a/checker/check_sub_schema_traversal_test.go
+++ b/checker/check_sub_schema_traversal_test.go
@@ -56,6 +56,40 @@ func TestSubSchemaTraversalDeletedProperty(t *testing.T) {
 	require.True(t, containsId(errs, checker.RequestPropertyRemovedId), "expected request-property-removed via sub-schema traversal")
 }
 
+// CL: exercise processDeletedPropertiesDiff traversal through additionalProperties.
+// Regression: prior to the fix, processDeletedPropertiesDiff and
+// processAddedPropertiesDiff did not recurse through AdditionalPropertiesDiff
+// (only processModifiedPropertiesDiff did), so removing a required property from
+// the value-type of a `dict[str, X]`-style schema went undetected.
+func TestAdditionalPropertiesTraversalDeletedRequiredProperty(t *testing.T) {
+	s1, err := open("../data/checker/additional_properties_traversal_base.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/checker/additional_properties_traversal_revision.yaml")
+	require.NoError(t, err)
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponseRequiredPropertyUpdatedCheck), d, osm, checker.INFO)
+	require.NotEmpty(t, errs)
+	require.True(t, containsId(errs, checker.ResponseRequiredPropertyRemovedId), "expected response-required-property-removed via additionalProperties traversal")
+}
+
+// CL: exercise processAddedPropertiesDiff traversal through additionalProperties.
+// Symmetric to the deletion test above — swapping base/revision exercises the
+// added-required-property path through AdditionalPropertiesDiff.
+func TestAdditionalPropertiesTraversalAddedRequiredProperty(t *testing.T) {
+	s1, err := open("../data/checker/additional_properties_traversal_revision.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/checker/additional_properties_traversal_base.yaml")
+	require.NoError(t, err)
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponseRequiredPropertyUpdatedCheck), d, osm, checker.INFO)
+	require.NotEmpty(t, errs)
+	require.True(t, containsId(errs, checker.ResponseRequiredPropertyAddedId), "expected response-required-property-added via additionalProperties traversal")
+}
+
 // CL: exercise processModifiedPropertiesDiff traversal for minimum changes through if/then sub-schemas
 func TestSubSchemaTraversalMinChanged(t *testing.T) {
 	s1, err := open("../data/checker/sub_schema_traversal_base.yaml")

--- a/checker/checks-utils.go
+++ b/checker/checks-utils.go
@@ -217,6 +217,10 @@ func processAddedPropertiesDiff(propertyPath string, propertyName string, schema
 		}
 	}
 
+	if schemaDiff.AdditionalPropertiesDiff != nil {
+		processAddedPropertiesDiff(joinPath(propertyPath, "additionalProperties"), "", schemaDiff.AdditionalPropertiesDiff, processor)
+	}
+
 	// OpenAPI 3.1 / JSON Schema 2020-12 sub-schema fields
 	if schemaDiff.PrefixItemsDiff != nil {
 		for _, v := range schemaDiff.PrefixItemsDiff.Modified {
@@ -314,6 +318,10 @@ func processDeletedPropertiesDiff(propertyPath string, propertyName string, sche
 		for i, v := range schemaDiff.PropertiesDiff.Modified {
 			processDeletedPropertiesDiff(propertyPath, i, v, processor)
 		}
+	}
+
+	if schemaDiff.AdditionalPropertiesDiff != nil {
+		processDeletedPropertiesDiff(joinPath(propertyPath, "additionalProperties"), "", schemaDiff.AdditionalPropertiesDiff, processor)
 	}
 
 	// OpenAPI 3.1 / JSON Schema 2020-12 sub-schema fields

--- a/data/checker/additional_properties_traversal_base.yaml
+++ b/data/checker/additional_properties_traversal_base.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.3
+info:
+  title: Sample API
+  version: 1.0.0
+paths:
+  /entries:
+    get:
+      operationId: listEntries
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: object
+                  required:
+                    - id
+                    - kind
+                  properties:
+                    id:
+                      type: integer
+                    kind:
+                      type: string

--- a/data/checker/additional_properties_traversal_revision.yaml
+++ b/data/checker/additional_properties_traversal_revision.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.3
+info:
+  title: Sample API
+  version: 1.0.0
+paths:
+  /entries:
+    get:
+      operationId: listEntries
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: object
+                  required:
+                    - id
+                  properties:
+                    id:
+                      type: integer


### PR DESCRIPTION
## TL;DR

`processModifiedPropertiesDiff` recurses through `AdditionalPropertiesDiff`, but
its `Deleted`/`Added` siblings do not. This makes a whole class of breaking
changes silently invisible to `oasdiff breaking`: removing or adding a required
property inside the value-type of a `dict[str, X]`-style schema (i.e.
`additionalProperties: $ref`) goes unreported, even though clients of the API
will break. Fix is the symmetric recursion plus two regression tests.

## What's broken

In `checker/checks-utils.go`, the three traversal helpers diverge on which
schema sub-fields they recurse through:

| helper | `properties` | `items` | `anyOf`/`oneOf`/`allOf` | OpenAPI 3.1 fields | **`additionalProperties`** |
|---|---|---|---|---|---|
| `processModifiedPropertiesDiff` | ✓ | ✓ | ✓ | ✓ | **✓ (line 117)** |
| `processDeletedPropertiesDiff` | ✓ | ✓ | ✓ | ✓ | **✗** |
| `processAddedPropertiesDiff` | ✓ | ✓ | ✓ | ✓ | **✗** |

Rules that walk via `Check{Deleted,Added}PropertiesDiff` — most notably
`response-required-property-removed`/`added` and
`request-required-property-added` — inherit this gap. Concretely, given a
response shaped like

```yaml
schema:
  type: object
  additionalProperties:
    $ref: '#/components/schemas/Item'
```

removing a required property from `Item` is **not** reported, even though
changing the same property's *type* is correctly reported as
`response-property-type-changed at additionalProperties/<name>` (because the
type-change rule walks via the Modified processor).

## Reproduction (MRE)

`base.yaml`:

```yaml
openapi: 3.0.3
info: { title: Sample, version: 1.0.0 }
paths:
  /entries:
    get:
      responses:
        "200":
          description: OK
          content:
            application/json:
              schema:
                type: object
                additionalProperties:
                  type: object
                  required: [id, kind]
                  properties:
                    id:   { type: integer }
                    kind: { type: string }
```

`revision.yaml` — same, but `kind` removed from both `required` and `properties`:

```yaml
                additionalProperties:
                  type: object
                  required: [id]
                  properties:
                    id: { type: integer }
```

### Before this PR (built from`main`)

```
$ oasdiff breaking --fail-on ERR base.yaml revision.yaml
No breaking changes to report, but the specs are different
$ echo $?
0
```

`oasdiff diff` *does* report the deletion under
`additionalProperties.properties.deleted: [kind]` and
`additionalProperties.required.deleted: [kind]`, so the underlying diff engine
is correct — only the breaking-change rule traversal is asymmetric.

### After this PR

```
$ oasdiff breaking --fail-on ERR base.yaml revision.yaml
1 changes: 1 error, 0 warning, 0 info
error  [response-required-property-removed] at revision.yaml
       in API GET /entries
         removed the required property `additionalProperties/kind`
         from the response with the `200` status
$ echo $?
1
```

For comparison, on `main`, swapping `string` ↔ `integer` on `kind` (without
removing it) is *already* reported as
``response-property-type-changed at additionalProperties/kind` — confirming the
inconsistency this PR closes.

## Why this matters (Python / FastAPI / Pydantic)

This shape isn't exotic — it's exactly what Pydantic v2 + FastAPI emit for any
endpoint whose response is a map keyed by dynamic strings. Two common ways to
end up with `additionalProperties: $ref` in the generated OpenAPI:

```python
from fastapi import FastAPI
from pydantic import BaseModel, ConfigDict, RootModel

class Item(BaseModel):
    id: int
    kind: str

# Pattern 1: RootModel of a typed dict — pure dynamic-keyed map.
class EntriesResponseRoot(RootModel[dict[str, Item]]):
    pass

# Pattern 2: BaseModel with `extra="allow"` and typed `__pydantic_extra__`,
# for mixed static + dynamic keys. The annotation is injected after class
# creation so pyright doesn't trip over the invariant override of
# `BaseModel.__pydantic_extra__: dict[str, Any] | None` — Pydantic re-reads
# `__annotations__` on `model_rebuild` (see pydantic/pydantic#10758).
class EntriesResponseExtra(BaseModel):
    model_config = ConfigDict(extra="allow")
    total: int   # static — ends up in `properties`

EntriesResponseExtra.__annotations__["__pydantic_extra__"] = dict[str, Item]
EntriesResponseExtra.model_rebuild(force=True)

app = FastAPI()

@app.get("/entries-root", response_model=EntriesResponseRoot)
async def get_entries_root() -> EntriesResponseRoot: ...

@app.get("/entries-extra", response_model=EntriesResponseExtra)
async def get_entries_extra() -> EntriesResponseExtra: ...
```

`app.openapi()` for these handlers produces (verified with FastAPI 0.128.7
+ Pydantic 2.12.5):

```json
"EntriesResponseRoot": {
  "type": "object",
  "additionalProperties": { "$ref": "#/components/schemas/Item" }
}
```

```son
"EntriesResponseExtra": {
  "type": "object",
  "properties": { "total": { "type": "integer" } },
  "required": ["total"],
  "additionalProperties": { "$ref": "#/components/schemas/Item" }
}
```

```json
"Item": {
  "type": "object",
  "properties": {
    "id":   { "type": "integer" },
    "kind": { "type": "string" }
  },
  "required": ["id", "kind"]
}
```

With `oasdiff breaking --fail-on ERR` wired into CI as the breaking-change
gate (a typical setup), removing `Item.kind` ships green today — PR review
and CI both miss it, and the bug surfaces only when the frontend reads
`entries["foo"].kind` and gets `undefined`. The fix closes that gap for
both Pydantic patterns above (and any other generator emitting the same
`additionalProperties: $ref` shape).

## Fix

Add the symmetric `AdditionalPropertiesDiff` recursion to both `Deleted` and
`Added` processors, mirroring the existing block in `Modified`:

```go
if schemaDiff.AdditionalPropertiesDiff != nil {
    process{Deleted,Added}PropertiesDiff(
        joinPath(propertyPath, "additionalProperties"),
        "",
        schemaDiff.AdditionalPropertiesDiff,
        processor,
    )
}
```

Inserted right after the `PropertiesDiff` block in each function, so
`additionalProperties` is now traversed identically across all three helpers.

## What changed

### `checker/checks-utils.go`

8 lines added: the `AdditionalPropertiesDiff` recursion block in both
`processAddedPropertiesDiff` (after the `PropertiesDiff` loop) and
`processDeletedPropertiesDiff` (same position). No behavioural change to any
other path — purely additive.

### `checker/check_sub_schema_traversal_test.go`

Two new tests in the existing sub-schema traversal suite:

- `TestAdditionalPropertiesTraversalDeletedRequiredProperty` — expects
  `response-required-property-removed` when a required field is removed from
  the value-type of an `additionalProperties: $ref` schema.
- `TestAdditionalPropertiesTraversalAddedRequiredProperty` — symmetric add
  path by swapping base/revision.

### `data/checker/additional_properties_traversal_{base,revision}.yaml`

Minimal OpenAPI 3.0.3 fixtures matching the MRE above.

## Affected files

- `checker/checks-utils.go` — `+8 -0`
- `checker/check_sub_schema_traversal_test.go` — `+34 -0`
- `data/checker/additional_properties_traversal_base.yaml` *(new)* — `+25 -0`
- `data/checker/additional_properties_traversal_revision.yaml` *(new)* — `+22 -0`

## Verification

| Check | Result |
|---|---|
| `go test ./checker/ -run 'TestAdditionalPropertiesTraversal'` | 2/2 passed |
| `go test ./checker/ -run 'TestSubSchemaTraversal'` (regression) | 4/4 passed |
| `go test ./...` (full suite) | all packages `ok`, 0 failures |
| MRE before/after on locally built `main` vs branch binaries | matches the snippets above |

## Backward compatibility

Strictly additive: the new traversal only fires for schemas that have a non-nil
`AdditionalPropertiesDiff`, which previous versions silently skipped. Specs
that did not exercise this path see no change in output. Specs that did
exercise it now get the breaking change reported as it should have been all
along — this is a bug fix, not a contract change.
