### PR TITLE
docs: note oasdiff.yaml also works with the GitHub Actions

### DIFF
--- a/docs/CONFIG-FILES.md
+++ b/docs/CONFIG-FILES.md
@@ -4,6 +4,8 @@ This is useful for complex configurations or repeated usage patterns.
 The config file should be named oasdiff.{json,yaml,yml,toml,hcl} and placed in the directory where the command is run.  
 For example, see [oasdiff.yaml](../examples/oasdiff.yaml).
 
+This config file also works with the [oasdiff GitHub Actions](https://github.com/oasdiff/oasdiff-action) — drop it at your repo root and the `breaking`, `changelog`, and `diff` actions pick it up automatically.
+
 The configuration file supports the exact same flags that are supported by the command-line.
 Notes:
 1. Command-line flags take precedence over configuration file settings.


### PR DESCRIPTION
## Summary

One-line addition to `CONFIG-FILES.md` noting that the same config file is picked up by the GitHub Actions in [oasdiff/oasdiff-action](https://github.com/oasdiff/oasdiff-action) when placed at the repo root.

## Why

The actions are CLI wrappers and inherit the CLI's cwd-based config-file lookup automatically — but nothing in the docs surfaced this connection. CLI users who'd happily put `oasdiff.yaml` in their repo for local use didn't know it would also configure the `breaking`, `changelog`, and `diff` actions in CI.

## Test plan

- [ ] Read the rendered file on GitHub
- [ ] Verify the link to `oasdiff/oasdiff-action` resolves
