### PR TITLE
docs: revert action cross-link from CONFIG-FILES.md pending move to .oasdiff.*

### DIFF
--- a/docs/CONFIG-FILES.md
+++ b/docs/CONFIG-FILES.md
@@ -4,8 +4,6 @@ This is useful for complex configurations or repeated usage patterns.
 The config file should be named oasdiff.{json,yaml,yml,toml,hcl} and placed in the directory where the command is run.  
 For example, see [oasdiff.yaml](../examples/oasdiff.yaml).
 
-This config file also works with the [oasdiff GitHub Actions](https://github.com/oasdiff/oasdiff-action) — drop it at your repo root and the `breaking`, `changelog`, and `diff` actions pick it up automatically.
-
 The configuration file supports the exact same flags that are supported by the command-line.
 Notes:
 1. Command-line flags take precedence over configuration file settings.


### PR DESCRIPTION
## Summary

Reverts the one-line cross-link to `oasdiff/oasdiff-action` added in #897.

The documented filename (`oasdiff.yaml` at repo root) is unconventional for a CI/lint tool. The recommended path is being reconsidered — the CLI's config-file lookup will move to `.oasdiff.*` in a follow-up. The cross-link to `oasdiff-action` will return then.

Companion reverts: `oasdiff/oasdiff-action` README, `oasdiff/w3` `/docs/github-action` page.

## Test plan

- [ ] Read the rendered file on GitHub; cross-link to `oasdiff-action` is gone, the rest of the doc is unchanged.
