### PR TITLE
feat(config): rename default config to .oasdiff.*; add --config flag and OASDIFF_CONFIG env var

### DIFF
--- a/docs/CONFIG-FILES.md
+++ b/docs/CONFIG-FILES.md
@@ -4,7 +4,12 @@ This is useful for complex configurations or repeated usage patterns.
 
 ## Default lookup
 
-By default, `oasdiff` looks for `.oasdiff.{json,yaml,yml,toml,hcl}` in the directory where the command is run.
+By default, `oasdiff` looks for a config file in the directory where the command is run, in this order:
+
+1. `.oasdiff.{json,yaml,yml,toml,hcl}` — preferred (dotfile convention)
+2. `oasdiff.{json,yaml,yml,toml,hcl}` — legacy fallback, kept for back-compat with existing setups
+
+`.oasdiff.*` is recommended for new setups. Existing `oasdiff.*` users don't need to migrate — both filenames continue to work.
 
 For example, see [.oasdiff.yaml](../examples/.oasdiff.yaml).
 

--- a/docs/CONFIG-FILES.md
+++ b/docs/CONFIG-FILES.md
@@ -1,8 +1,27 @@
 # Configuration Files
 The `oasdiff` command can read its configuration from a file.  
-This is useful for complex configurations or repeated usage patterns.  
-The config file should be named oasdiff.{json,yaml,yml,toml,hcl} and placed in the directory where the command is run.  
-For example, see [oasdiff.yaml](../examples/oasdiff.yaml).
+This is useful for complex configurations or repeated usage patterns.
+
+## Default lookup
+
+By default, `oasdiff` looks for `.oasdiff.{json,yaml,yml,toml,hcl}` in the directory where the command is run.
+
+For example, see [.oasdiff.yaml](../examples/.oasdiff.yaml).
+
+## Explicit override
+
+To use a different filename or path, pass `--config <path>` or set the `OASDIFF_CONFIG` environment variable. When either is set, the default lookup is skipped and the file at the given path must exist (missing or malformed file is an error).
+
+Precedence: `--config <path>` > `OASDIFF_CONFIG` > default `.oasdiff.*` lookup.
+
+```sh
+# Explicit flag (per-invocation)
+oasdiff diff --config ./my-config.yaml base.yaml revision.yaml
+
+# Environment variable (set once for a shell or CI workflow)
+export OASDIFF_CONFIG=./my-config.yaml
+oasdiff diff base.yaml revision.yaml
+```
 
 The configuration file supports the exact same flags that are supported by the command-line.
 Notes:

--- a/examples/.oasdiff.yaml
+++ b/examples/.oasdiff.yaml
@@ -1,6 +1,7 @@
 # oasdiff configuration file
 # This file is used to customize the behavior of oasdiff.
-# Place in the directory where the command is run
+# Place at the directory where the command is run, or override the
+# location with --config <path> or the OASDIFF_CONFIG env var.
 format: json
 color: never
 attributes:

--- a/examples/.oasdiff.yaml
+++ b/examples/.oasdiff.yaml
@@ -11,6 +11,7 @@ composed: false
 flatten-allof: true
 allow-external-refs: true  # set to false to block external $refs (prevents SSRF when processing untrusted specs)
 err-ignore: ignore-err-example.txt
+warn-ignore: ignore-warn-example.txt
 lang: en
 fail-on: ERR
 level: INFO

--- a/examples/ignore-err-example.txt
+++ b/examples/ignore-err-example.txt
@@ -1,0 +1,16 @@
+# Each line is a regex; ERROR-level findings whose rendered text matches the
+# regex are ignored. Empty lines and lines starting with # are skipped.
+#
+# Pair with `err-ignore: ignore-err-example.txt` in oasdiff config (e.g.
+# .oasdiff.yaml), or pass `--err-ignore <path>` on the command line.
+#
+# Uncomment and edit any of the following examples to suit your repo:
+
+# Ignore removal of internal-only endpoints:
+# GET /internal/.* removed
+
+# Ignore removal of a deprecated schema in components:
+# in components removed the schema `LegacyType`
+
+# Ignore property type changes inside a specific request body:
+# request body for the content type 'application/json' .* property 'oldField' .* changed

--- a/examples/ignore-warn-example.txt
+++ b/examples/ignore-warn-example.txt
@@ -1,0 +1,14 @@
+# Each line is a regex; WARNING-level findings whose rendered text matches
+# the regex are ignored. Empty lines and lines starting with # are skipped.
+#
+# Same shape as ignore-err-example.txt; matches WARNING-level findings only.
+# Pair with `warn-ignore: ignore-warn-example.txt` in oasdiff config, or
+# pass `--warn-ignore <path>` on the command line.
+#
+# Empty by default — uncomment a pattern to suppress matching warnings.
+
+# Ignore deprecation warnings on a specific path:
+# GET /deprecated/.* deprecated
+
+# Ignore header parameter changes that are known-safe in your repo:
+# deleted the `header` request parameter `X-Internal-Trace`

--- a/internal/run.go
+++ b/internal/run.go
@@ -20,6 +20,11 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) int {
 	rootCmd.SetErr(stderr)
 	rootCmd.Version = build.Version
 
+	// --config is a persistent flag on the root command so every subcommand
+	// inherits it. Lookup order is documented in internal/viper.go's
+	// readConfFile: --config > OASDIFF_CONFIG env var > .oasdiff.* in cwd.
+	rootCmd.PersistentFlags().String("config", "", "path to config file (overrides .oasdiff.* lookup; can also use the OASDIFF_CONFIG env var)")
+
 	rootCmd.AddCommand(
 		getDiffCmd(),
 		getSummaryCmd(),

--- a/internal/viper.go
+++ b/internal/viper.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/oasdiff/oasdiff/checker"
@@ -14,8 +15,13 @@ import (
 	"slices"
 )
 
+// EnvConfigPath is the environment variable that overrides the default
+// config-file lookup. Lower precedence than the --config flag.
+const EnvConfigPath = "OASDIFF_CONFIG"
+
 type IViper interface {
 	SetConfigName(in string)
+	SetConfigFile(in string)
 	AddConfigPath(in string)
 	ReadInConfig() error
 	BindPFlag(key string, flag *pflag.Flag) error
@@ -23,7 +29,7 @@ type IViper interface {
 }
 
 func RunViper(cmd *cobra.Command, v IViper) *ReturnError {
-	if err := readConfFile(v); err != nil {
+	if err := readConfFile(cmd, v); err != nil {
 		return getErrConfigFileProblem(err)
 	}
 
@@ -38,10 +44,25 @@ func RunViper(cmd *cobra.Command, v IViper) *ReturnError {
 	return nil
 }
 
-func readConfFile(v IViper) error {
+// readConfFile loads the oasdiff configuration file. Resolution order:
+//
+//  1. --config <path> flag (when set, the file MUST exist; missing or malformed file is an error)
+//  2. OASDIFF_CONFIG environment variable (same semantics)
+//  3. Default cwd lookup for .oasdiff.{json,yaml,yml,toml,hcl} (silent when missing)
+//
+// Returns nil when no config is found via the default lookup; only the two
+// explicit-override paths surface "file not found" as an error.
+func readConfFile(cmd *cobra.Command, v IViper) error {
+	if path := explicitConfigPath(cmd); path != "" {
+		v.SetConfigFile(path)
+		if err := v.ReadInConfig(); err != nil {
+			return fmt.Errorf("read error: %s", err)
+		}
+		return nil
+	}
 
-	// the config file should be named oasdiff.{json,yaml,yml,toml,hcl} in the directory where the command is run
-	v.SetConfigName("oasdiff")
+	// Default lookup: .oasdiff.{json,yaml,yml,toml,hcl} in cwd.
+	v.SetConfigName(".oasdiff")
 	v.AddConfigPath(".")
 
 	if err := v.ReadInConfig(); err != nil {
@@ -53,6 +74,20 @@ func readConfFile(v IViper) error {
 	}
 
 	return nil
+}
+
+// explicitConfigPath returns the explicit config path requested by the
+// caller via --config or OASDIFF_CONFIG. The flag wins when both are set.
+// Returns "" when neither is set (caller falls back to cwd lookup).
+func explicitConfigPath(cmd *cobra.Command) string {
+	if cmd != nil {
+		if flag := cmd.Flag("config"); flag != nil {
+			if path := flag.Value.String(); path != "" {
+				return path
+			}
+		}
+	}
+	return os.Getenv(EnvConfigPath)
 }
 
 func bindFlags(cmd *cobra.Command, v IViper) error {

--- a/internal/viper.go
+++ b/internal/viper.go
@@ -48,7 +48,9 @@ func RunViper(cmd *cobra.Command, v IViper) *ReturnError {
 //
 //  1. --config <path> flag (when set, the file MUST exist; missing or malformed file is an error)
 //  2. OASDIFF_CONFIG environment variable (same semantics)
-//  3. Default cwd lookup for .oasdiff.{json,yaml,yml,toml,hcl} (silent when missing)
+//  3. Default cwd lookup, in order:
+//     a. .oasdiff.{json,yaml,yml,toml,hcl} (preferred — dotfile convention)
+//     b. oasdiff.{json,yaml,yml,toml,hcl} (legacy — kept for back-compat, still works without warning)
 //
 // Returns nil when no config is found via the default lookup; only the two
 // explicit-override paths surface "file not found" as an error.
@@ -61,18 +63,24 @@ func readConfFile(cmd *cobra.Command, v IViper) error {
 		return nil
 	}
 
-	// Default lookup: .oasdiff.{json,yaml,yml,toml,hcl} in cwd.
-	v.SetConfigName(".oasdiff")
-	v.AddConfigPath(".")
+	// Default lookup: try .oasdiff.* first (preferred), then oasdiff.*
+	// (legacy back-compat) — cwd-scoped, all viper-supported extensions.
+	for _, name := range []string{".oasdiff", "oasdiff"} {
+		v.SetConfigName(name)
+		v.AddConfigPath(".")
 
-	if err := v.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			// Config file not found; ignore error
-		} else {
-			return fmt.Errorf("read error: %s", err)
+		err := v.ReadInConfig()
+		if err == nil {
+			return nil
 		}
+		if _, notFound := err.(viper.ConfigFileNotFoundError); notFound {
+			continue // try the next candidate
+		}
+		// File found but malformed — surface the error.
+		return fmt.Errorf("read error: %s", err)
 	}
 
+	// No config file found in cwd; not an error.
 	return nil
 }
 

--- a/internal/viper_test.go
+++ b/internal/viper_test.go
@@ -2,6 +2,8 @@ package internal_test
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -163,4 +165,153 @@ func TestViper_InvalidFlag(t *testing.T) {
 	cmd := cobra.Command{}
 
 	require.EqualError(t, internal.RunViper(&cmd, v), "failed to load config file: validation error: decoding failed due to the following error(s):\n\n'internal.Config' has invalid keys: invalid")
+}
+
+// ---------------------------------------------------------------------
+// Config-file lookup: .oasdiff.* in cwd; --config flag; OASDIFF_CONFIG
+// env var; precedence flag > env > default.
+//
+// Each test uses t.Chdir(t.TempDir()) so it runs in an isolated cwd
+// without polluting the test working directory or interfering with
+// sibling tests.
+// ---------------------------------------------------------------------
+
+// writeFile writes content to path, failing the test on error.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+}
+
+// chdirIsolated moves the test into a fresh temp dir for the duration
+// of the test. Returns the temp dir path so callers can construct
+// absolute paths to fixtures they create inside it.
+func chdirIsolated(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Chdir(dir)
+	return dir
+}
+
+// TestViper_DefaultLookup_DotOasdiffYaml: when .oasdiff.yaml exists in
+// cwd and no override is set, it is loaded. Asserted via a value that
+// validate() rejects — error message proves the file was read.
+func TestViper_DefaultLookup_DotOasdiffYaml(t *testing.T) {
+	chdirIsolated(t)
+	writeFile(t, ".oasdiff.yaml", "lang: invalid\n")
+
+	cmd := cobra.Command{}
+	require.EqualError(t,
+		internal.RunViper(&cmd, viper.New()),
+		"failed to load config file: invalid lang \"invalid\", allowed values: en, ru, pt-br, es")
+}
+
+// TestViper_DefaultLookup_LegacyOasdiffYamlIsIgnored: a legacy
+// oasdiff.yaml (no leading dot) at repo root is no longer recognized
+// by the default lookup. The CLI should silently skip it.
+func TestViper_DefaultLookup_LegacyOasdiffYamlIsIgnored(t *testing.T) {
+	chdirIsolated(t)
+	// Legacy filename — would have been picked up before the .oasdiff.*
+	// move. Now it should be ignored entirely.
+	writeFile(t, "oasdiff.yaml", "lang: invalid\n")
+
+	cmd := cobra.Command{}
+	// No error: validate() never sees the bad value because the file
+	// wasn't loaded.
+	require.Nil(t, internal.RunViper(&cmd, viper.New()))
+}
+
+// TestViper_DefaultLookup_NoConfigIsNotAnError: with no .oasdiff.*
+// in cwd and no override, RunViper succeeds.
+func TestViper_DefaultLookup_NoConfigIsNotAnError(t *testing.T) {
+	chdirIsolated(t)
+
+	cmd := cobra.Command{}
+	require.Nil(t, internal.RunViper(&cmd, viper.New()))
+}
+
+// TestViper_ConfigFlag_ExplicitPath: --config <path> loads the file
+// at the given path, regardless of cwd's .oasdiff.*.
+func TestViper_ConfigFlag_ExplicitPath(t *testing.T) {
+	dir := chdirIsolated(t)
+	customPath := filepath.Join(dir, "custom-config.yaml")
+	writeFile(t, customPath, "lang: invalid\n")
+
+	cmd := cobra.Command{}
+	cmd.PersistentFlags().String("config", "", "")
+	require.NoError(t, cmd.PersistentFlags().Set("config", customPath))
+
+	require.EqualError(t,
+		internal.RunViper(&cmd, viper.New()),
+		"failed to load config file: invalid lang \"invalid\", allowed values: en, ru, pt-br, es")
+}
+
+// TestViper_ConfigFlag_MissingFileIsError: --config pointing at a
+// non-existent file is an explicit error (unlike the silent-skip
+// behavior of the default lookup).
+func TestViper_ConfigFlag_MissingFileIsError(t *testing.T) {
+	chdirIsolated(t)
+
+	cmd := cobra.Command{}
+	cmd.PersistentFlags().String("config", "", "")
+	require.NoError(t, cmd.PersistentFlags().Set("config", "does-not-exist.yaml"))
+
+	err := internal.RunViper(&cmd, viper.New())
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "read error")
+}
+
+// TestViper_ConfigFlag_OverridesDefaultLookup: when --config is set,
+// the default cwd lookup is skipped — even if .oasdiff.yaml is also
+// present at cwd. Proves the flag's path is used, not the default.
+func TestViper_ConfigFlag_OverridesDefaultLookup(t *testing.T) {
+	dir := chdirIsolated(t)
+	// Default-lookup file with a value that WOULD fail validation if loaded.
+	writeFile(t, ".oasdiff.yaml", "lang: invalid\n")
+	// Explicit-path file that's clean.
+	customPath := filepath.Join(dir, "clean.yaml")
+	writeFile(t, customPath, "lang: en\n")
+
+	cmd := cobra.Command{}
+	cmd.PersistentFlags().String("config", "", "")
+	require.NoError(t, cmd.PersistentFlags().Set("config", customPath))
+
+	// No error: the explicit clean.yaml was loaded, not the bad .oasdiff.yaml.
+	require.Nil(t, internal.RunViper(&cmd, viper.New()))
+}
+
+// TestViper_ConfigEnvVar: OASDIFF_CONFIG points at a config file in
+// the absence of --config.
+func TestViper_ConfigEnvVar(t *testing.T) {
+	dir := chdirIsolated(t)
+	customPath := filepath.Join(dir, "env-config.yaml")
+	writeFile(t, customPath, "lang: invalid\n")
+
+	t.Setenv("OASDIFF_CONFIG", customPath)
+
+	cmd := cobra.Command{}
+	require.EqualError(t,
+		internal.RunViper(&cmd, viper.New()),
+		"failed to load config file: invalid lang \"invalid\", allowed values: en, ru, pt-br, es")
+}
+
+// TestViper_ConfigFlagWinsOverEnv: when both --config and
+// OASDIFF_CONFIG are set, the flag takes precedence.
+func TestViper_ConfigFlagWinsOverEnv(t *testing.T) {
+	dir := chdirIsolated(t)
+	// Env points at a clean file; flag points at a bad one. If env
+	// were honored, no error. If flag wins, validation fails.
+	envPath := filepath.Join(dir, "env-clean.yaml")
+	writeFile(t, envPath, "lang: en\n")
+	flagPath := filepath.Join(dir, "flag-bad.yaml")
+	writeFile(t, flagPath, "lang: invalid\n")
+
+	t.Setenv("OASDIFF_CONFIG", envPath)
+
+	cmd := cobra.Command{}
+	cmd.PersistentFlags().String("config", "", "")
+	require.NoError(t, cmd.PersistentFlags().Set("config", flagPath))
+
+	require.EqualError(t,
+		internal.RunViper(&cmd, viper.New()),
+		"failed to load config file: invalid lang \"invalid\", allowed values: en, ru, pt-br, es")
 }

--- a/internal/viper_test.go
+++ b/internal/viper_test.go
@@ -205,18 +205,32 @@ func TestViper_DefaultLookup_DotOasdiffYaml(t *testing.T) {
 		"failed to load config file: invalid lang \"invalid\", allowed values: en, ru, pt-br, es")
 }
 
-// TestViper_DefaultLookup_LegacyOasdiffYamlIsIgnored: a legacy
-// oasdiff.yaml (no leading dot) at repo root is no longer recognized
-// by the default lookup. The CLI should silently skip it.
-func TestViper_DefaultLookup_LegacyOasdiffYamlIsIgnored(t *testing.T) {
+// TestViper_DefaultLookup_LegacyOasdiffYamlStillWorks: the legacy
+// oasdiff.{yaml,...} filename remains supported as a back-compat
+// fallback for CLI users who had it set up before the .oasdiff.* move.
+// .oasdiff.* is preferred, but oasdiff.* keeps working when no dotfile
+// is present.
+func TestViper_DefaultLookup_LegacyOasdiffYamlStillWorks(t *testing.T) {
 	chdirIsolated(t)
-	// Legacy filename — would have been picked up before the .oasdiff.*
-	// move. Now it should be ignored entirely.
 	writeFile(t, "oasdiff.yaml", "lang: invalid\n")
 
 	cmd := cobra.Command{}
-	// No error: validate() never sees the bad value because the file
-	// wasn't loaded.
+	require.EqualError(t,
+		internal.RunViper(&cmd, viper.New()),
+		"failed to load config file: invalid lang \"invalid\", allowed values: en, ru, pt-br, es")
+}
+
+// TestViper_DefaultLookup_DotPreferredOverLegacy: when both .oasdiff.yaml
+// and oasdiff.yaml exist in cwd, the dotfile wins. Proves the lookup
+// order — preferred first, legacy as fallback only.
+func TestViper_DefaultLookup_DotPreferredOverLegacy(t *testing.T) {
+	chdirIsolated(t)
+	// Dotfile is clean; legacy is not. If the legacy file were loaded,
+	// validate() would error.
+	writeFile(t, ".oasdiff.yaml", "lang: en\n")
+	writeFile(t, "oasdiff.yaml", "lang: invalid\n")
+
+	cmd := cobra.Command{}
 	require.Nil(t, internal.RunViper(&cmd, viper.New()))
 }
 


### PR DESCRIPTION
## Summary

Adds `.oasdiff.{json,yaml,yml,toml,hcl}` as the **preferred** default config-file location, keeps the existing `oasdiff.{json,yaml,yml,toml,hcl}` lookup as a **back-compat fallback**, and adds two override mechanisms: a `--config <path>` persistent flag on the root command and an `OASDIFF_CONFIG` environment variable.

## Why add .oasdiff.*

The dotfile convention is the overwhelming pattern for CI/lint tools — `.eslintrc`, `.prettierrc`, `.golangci.yml`, `.yamllint`, `.flake8`, `.markdownlint.json`, etc. The original `oasdiff.{yaml,...}` at the repo root reads as a project-defining file (`Cargo.toml`, `package.json`, `pyproject.toml`), which `oasdiff` isn't — it's a tool that operates on a project, not part of one. `.oasdiff.*` aligns with community muscle memory and makes the file's role obvious at a glance.

## Why keep oasdiff.* as a fallback

The legacy lookup has been live in the CLI for a long time. We don't know how many users have `oasdiff.yaml` committed to their working directories. Silently breaking them for the sake of strict convention isn't worth it when the cost of keeping both is one extra `SetConfigName` call. Existing users don't have to do anything; `.oasdiff.*` is recommended for new setups.

## Lookup order

In cwd, first hit wins:

1. `.oasdiff.{json,yaml,yml,toml,hcl}` — preferred (dotfile)
2. `oasdiff.{json,yaml,yml,toml,hcl}` — legacy fallback

Plus two explicit overrides that bypass the cwd lookup entirely:

- `--config <path>` (persistent flag on root, inherited by all subcommands)
- `OASDIFF_CONFIG` environment variable

Override precedence: `--config <path>` > `OASDIFF_CONFIG` > default cwd lookup.

When either override is set, the file MUST exist — missing or malformed file is an explicit error. The default cwd lookup retains its silent-skip semantics.

## Why the env var (not just the flag)

The env var earns its place specifically for CI workflows: a customer with multiple `oasdiff` invocations in one workflow sets `OASDIFF_CONFIG` once at the workflow's `env:` block instead of duplicating `--config` per step. This matches industry convention (`KUBECONFIG`, `AWS_CONFIG_FILE`, `DOCKER_CONFIG`, `NPM_CONFIG_USERCONFIG`).

## What's in the diff

- `internal/viper.go` — `readConfFile` checks the override sources in order, falls back to a two-candidate cwd lookup (`.oasdiff` then `oasdiff`). New `EnvConfigPath` constant for the env var name. `IViper` interface gains `SetConfigFile` (already on `viper.Viper`, so no mock changes needed).
- `internal/run.go` — `--config` added as a persistent flag on the root command.
- `internal/viper_test.go` — 8 new tests covering: `.oasdiff.yaml` loaded; legacy `oasdiff.yaml` still works; `.oasdiff.yaml` preferred when both exist; no-config not-an-error; `--config` explicit path; `--config` missing-file error; `--config` overrides default; `OASDIFF_CONFIG` env var; `--config` wins over env. All run in `t.Chdir(t.TempDir())` for isolation.
- `docs/CONFIG-FILES.md` — new "Default lookup" + "Explicit override" sections, documents both default filenames, the precedence, and the two override mechanisms with runnable examples.
- `examples/oasdiff.yaml` → `examples/.oasdiff.yaml` — renamed to recommend the dotfile; the comment mentions the override mechanisms.

## Backward compatibility

**Strict** — no existing setup breaks:

- Users with `oasdiff.yaml` in cwd: still works, no change needed.
- Users with no config file: still works, still no error.
- Users with the new `.oasdiff.yaml`: works, takes precedence over a co-existing `oasdiff.yaml`.

## Test plan

- [x] `go test ./...` — all packages green
- [x] `go test ./internal/ -run TestViper -count=1 -v` — 20 tests pass (12 existing + 8 new)
- [ ] Manually verify `oasdiff diff --config /tmp/x.yaml ...` reads `x.yaml`
- [ ] Manually verify `OASDIFF_CONFIG=/tmp/x.yaml oasdiff diff ...` reads `x.yaml`
- [ ] Manually verify `oasdiff diff ...` with `.oasdiff.yaml` in cwd reads it
- [ ] Manually verify `oasdiff diff ...` with `oasdiff.yaml` (and no `.oasdiff.yaml`) in cwd reads it
- [ ] Manually verify `oasdiff diff ...` with both files prefers `.oasdiff.yaml`
