### PR TITLE
fix(config): resolve relative paths in config files against config dir, not cwd

### DIFF
--- a/docs/CONFIG-FILES.md
+++ b/docs/CONFIG-FILES.md
@@ -39,3 +39,6 @@ Notes:
     - `err-ignore`:              configuration file for ignoring errors
     - `severity-levels`:         configuration file for custom severity levels
     - `warn-ignore`:             configuration file for ignoring warnings
+    - `template`:                custom Go template file for changelog generation
+
+   **Relative paths in these flags are resolved against the config file's directory**, not the process's current working directory. So when you write `err-ignore: rules.txt` in `path/to/.oasdiff.yaml`, oasdiff reads `path/to/rules.txt`. Absolute paths and paths set via CLI flag are not rewritten.

--- a/internal/viper.go
+++ b/internal/viper.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/oasdiff/oasdiff/checker"
@@ -19,11 +20,25 @@ import (
 // config-file lookup. Lower precedence than the --config flag.
 const EnvConfigPath = "OASDIFF_CONFIG"
 
+// configRelativePathKeys lists viper keys whose values are file paths.
+// When read from a config file, relative values in these keys are
+// resolved against the config file's own directory. Absolute values
+// and values explicitly set via CLI flag are left alone.
+var configRelativePathKeys = []string{
+	"err-ignore",
+	"warn-ignore",
+	"severity-levels",
+	"template",
+}
+
 type IViper interface {
 	SetConfigName(in string)
 	SetConfigFile(in string)
 	AddConfigPath(in string)
 	ReadInConfig() error
+	ConfigFileUsed() string
+	GetString(key string) string
+	Set(key string, value any)
 	BindPFlag(key string, flag *pflag.Flag) error
 	UnmarshalExact(rawVal any, opts ...viper.DecoderConfigOption) error
 }
@@ -41,7 +56,46 @@ func RunViper(cmd *cobra.Command, v IViper) *ReturnError {
 		return getErrConfigFileProblem(err)
 	}
 
+	// After CLI flags are bound, rewrite path-valued config-file values
+	// to be relative to the config file's directory (vs. cwd). Skips
+	// values where the user explicitly set the corresponding CLI flag —
+	// those mean what the user typed.
+	resolveConfigRelativePaths(cmd, v)
+
 	return nil
+}
+
+// resolveConfigRelativePaths walks the documented path-valued config
+// keys and rewrites relative values to be anchored at the config file's
+// directory. A config file is self-contained — relative paths in it
+// refer to siblings of the config, not arbitrary files at the process's
+// cwd.
+//
+// Skipped per key:
+//   - The corresponding CLI flag was explicitly set by the user
+//     (Changed=true). Their typed path means what they typed.
+//   - The value is empty, or already absolute.
+//
+// Skipped overall when no config file was loaded.
+func resolveConfigRelativePaths(cmd *cobra.Command, v IViper) {
+	configFile := v.ConfigFileUsed()
+	if configFile == "" {
+		return
+	}
+	configDir := filepath.Dir(configFile)
+
+	for _, key := range configRelativePathKeys {
+		if cmd != nil {
+			if flag := cmd.Flag(key); flag != nil && flag.Changed {
+				continue
+			}
+		}
+		val := v.GetString(key)
+		if val == "" || filepath.IsAbs(val) {
+			continue
+		}
+		v.Set(key, filepath.Join(configDir, val))
+	}
 }
 
 // readConfFile loads the oasdiff configuration file. Resolution order:
@@ -152,6 +206,7 @@ type Config struct {
 	StripPrefixRevision    string   `mapstructure:"strip-prefix-revision"`
 	IncludePathParams      bool     `mapstructure:"include-path-params"`
 	AllowExternalRefs      bool     `mapstructure:"allow-external-refs"`
+	Template               string   `mapstructure:"template"`
 }
 
 // validate checks that each of the provided configuration values is one of the generally accepted values

--- a/internal/viper_test.go
+++ b/internal/viper_test.go
@@ -308,6 +308,160 @@ func TestViper_ConfigEnvVar(t *testing.T) {
 		"failed to load config file: invalid lang \"invalid\", allowed values: en, ru, pt-br, es")
 }
 
+// ---------------------------------------------------------------------
+// Relative-path resolution: path-valued config keys (err-ignore,
+// warn-ignore, severity-levels, template) should resolve against the
+// config file's directory, not the process's cwd. Matches behaviour
+// of ESLint, Prettier, golangci-lint, etc.
+// ---------------------------------------------------------------------
+
+// TestViper_RelativePath_ResolvesAgainstConfigDir: when the config
+// file lives in a subdirectory and references a sibling file via a
+// relative path, the path is rewritten to be anchored at the config's
+// directory.
+func TestViper_RelativePath_ResolvesAgainstConfigDir(t *testing.T) {
+	root := chdirIsolated(t)
+	configDir := filepath.Join(root, "subdir")
+	require.NoError(t, os.Mkdir(configDir, 0700))
+
+	configPath := filepath.Join(configDir, "cfg.yaml")
+	writeFile(t, configPath, "err-ignore: ignore-rules.txt\n")
+	// Sibling file next to the config — what the relative path should
+	// resolve to.
+	ignorePath := filepath.Join(configDir, "ignore-rules.txt")
+	writeFile(t, ignorePath, "")
+
+	cmd := cobra.Command{}
+	cmd.PersistentFlags().String("config", "", "")
+	cmd.PersistentFlags().String("err-ignore", "", "")
+	require.NoError(t, cmd.PersistentFlags().Set("config", configPath))
+
+	v := viper.New()
+	require.Nil(t, internal.RunViper(&cmd, v))
+	require.Equal(t, ignorePath, v.GetString("err-ignore"))
+}
+
+// TestViper_RelativePath_AbsoluteValueUnchanged: an absolute path in
+// the config file is left alone, regardless of where the config lives.
+func TestViper_RelativePath_AbsoluteValueUnchanged(t *testing.T) {
+	root := chdirIsolated(t)
+	configDir := filepath.Join(root, "subdir")
+	require.NoError(t, os.Mkdir(configDir, 0700))
+
+	absoluteIgnore := filepath.Join(root, "elsewhere.txt")
+	writeFile(t, absoluteIgnore, "")
+
+	configPath := filepath.Join(configDir, "cfg.yaml")
+	writeFile(t, configPath, "err-ignore: "+absoluteIgnore+"\n")
+
+	cmd := cobra.Command{}
+	cmd.PersistentFlags().String("config", "", "")
+	cmd.PersistentFlags().String("err-ignore", "", "")
+	require.NoError(t, cmd.PersistentFlags().Set("config", configPath))
+
+	v := viper.New()
+	require.Nil(t, internal.RunViper(&cmd, v))
+	require.Equal(t, absoluteIgnore, v.GetString("err-ignore"))
+}
+
+// TestViper_RelativePath_CLIFlagOverridesConfig: when the CLI flag
+// is explicitly set by the user, its value wins over the config and
+// is NOT rewritten — the user's path means what they typed.
+func TestViper_RelativePath_CLIFlagOverridesConfig(t *testing.T) {
+	root := chdirIsolated(t)
+	configDir := filepath.Join(root, "subdir")
+	require.NoError(t, os.Mkdir(configDir, 0700))
+
+	configPath := filepath.Join(configDir, "cfg.yaml")
+	writeFile(t, configPath, "err-ignore: from-config.txt\n")
+
+	cmd := cobra.Command{}
+	cmd.PersistentFlags().String("config", "", "")
+	cmd.PersistentFlags().String("err-ignore", "", "")
+	require.NoError(t, cmd.PersistentFlags().Set("config", configPath))
+	// User explicitly passes --err-ignore; this should win and stay
+	// as typed (not rewritten relative to configDir).
+	require.NoError(t, cmd.PersistentFlags().Set("err-ignore", "from-cli.txt"))
+
+	v := viper.New()
+	require.Nil(t, internal.RunViper(&cmd, v))
+	require.Equal(t, "from-cli.txt", v.GetString("err-ignore"))
+}
+
+// TestViper_RelativePath_AllPathKeysHandled: each documented path-valued
+// config key gets the same rewrite treatment.
+func TestViper_RelativePath_AllPathKeysHandled(t *testing.T) {
+	root := chdirIsolated(t)
+	configDir := filepath.Join(root, "subdir")
+	require.NoError(t, os.Mkdir(configDir, 0700))
+
+	// One YAML setting all four path-valued keys with relative values.
+	configPath := filepath.Join(configDir, "cfg.yaml")
+	writeFile(t, configPath, `
+err-ignore: err.txt
+warn-ignore: warn.txt
+severity-levels: sev.txt
+template: tmpl.tmpl
+`)
+
+	cmd := cobra.Command{}
+	cmd.PersistentFlags().String("config", "", "")
+	for _, k := range []string{"err-ignore", "warn-ignore", "severity-levels", "template"} {
+		cmd.PersistentFlags().String(k, "", "")
+	}
+	require.NoError(t, cmd.PersistentFlags().Set("config", configPath))
+
+	v := viper.New()
+	require.Nil(t, internal.RunViper(&cmd, v))
+
+	for k, expected := range map[string]string{
+		"err-ignore":      filepath.Join(configDir, "err.txt"),
+		"warn-ignore":     filepath.Join(configDir, "warn.txt"),
+		"severity-levels": filepath.Join(configDir, "sev.txt"),
+		"template":        filepath.Join(configDir, "tmpl.tmpl"),
+	} {
+		require.Equal(t, expected, v.GetString(k), "key %q", k)
+	}
+}
+
+// TestViper_RelativePath_DefaultLookup_ConfigInCwd: when the config
+// file is loaded from cwd via the default lookup (.oasdiff.yaml),
+// relative paths still work — they get rewritten to absolute paths
+// anchored at cwd, which is functionally equivalent to the
+// pre-existing cwd-relative behaviour. No behaviour change for the
+// default case.
+func TestViper_RelativePath_DefaultLookup_ConfigInCwd(t *testing.T) {
+	root := chdirIsolated(t)
+	writeFile(t, ".oasdiff.yaml", "err-ignore: ignore-rules.txt\n")
+
+	cmd := cobra.Command{}
+	cmd.PersistentFlags().String("err-ignore", "", "")
+
+	v := viper.New()
+	require.Nil(t, internal.RunViper(&cmd, v))
+	// Path is rewritten to an absolute path under cwd. Functionally
+	// equivalent to "ignore-rules.txt" relative to cwd.
+	require.Equal(t, filepath.Join(root, "ignore-rules.txt"), v.GetString("err-ignore"))
+}
+
+// TestViper_RelativePath_BackCompat_LegacyOasdiffYamlInCwd: explicitly
+// covers the population this fix could conceivably regress —
+// long-standing CLI users with the legacy `oasdiff.yaml` filename in
+// cwd referencing a sibling file via a relative path. They were
+// reading <cwd>/<file>; after the fix, the path is rewritten to
+// <abs cwd>/<file>. Same file, same behaviour.
+func TestViper_RelativePath_BackCompat_LegacyOasdiffYamlInCwd(t *testing.T) {
+	root := chdirIsolated(t)
+	writeFile(t, "oasdiff.yaml", "err-ignore: my-rules.txt\n")
+
+	cmd := cobra.Command{}
+	cmd.PersistentFlags().String("err-ignore", "", "")
+
+	v := viper.New()
+	require.Nil(t, internal.RunViper(&cmd, v))
+	require.Equal(t, filepath.Join(root, "my-rules.txt"), v.GetString("err-ignore"))
+}
+
 // TestViper_ConfigFlagWinsOverEnv: when both --config and
 // OASDIFF_CONFIG are set, the flag takes precedence.
 func TestViper_ConfigFlagWinsOverEnv(t *testing.T) {


### PR DESCRIPTION
Closes #900.

## Summary

Path-valued config keys (`err-ignore`, `warn-ignore`, `severity-levels`, `template`) referenced from a config file now resolve **relative to the config file's directory**, not the process's current working directory. A config file is self-contained: relative paths in it refer to siblings of the config, not arbitrary files at the process's cwd.

## Why

Without this fix, the workflow that #899 enables (`--config <path>` and `OASDIFF_CONFIG`) silently breaks for path-valued flags as soon as the config file isn't in cwd. The bug as originally reported in #900:

```sh
$ oasdiff breaking base.yaml revision.yaml --config examples/.oasdiff.yaml
Error: can't process err ignore file: open ignore-err-example.txt: no such file or directory
```

The config file referenced `ignore-err-example.txt`, the file existed at `examples/ignore-err-example.txt`, but the CLI looked at `<cwd>/ignore-err-example.txt`. After this fix, the file is found correctly.

## What's in the diff

- `internal/viper.go::resolveConfigRelativePaths` — new function called from `RunViper` after `bindFlags`. For each key in `configRelativePathKeys` (the four path-valued keys), if the value is non-empty, relative, and not user-set on the CLI, it gets rewritten to `filepath.Join(configDir, value)`.
- `Config` struct gains a `Template string` field so `validate()`'s `UnmarshalExact` recognises the key. (Previously absent from the struct, which would have caused a "has invalid keys" error in any test that referenced it.)
- `IViper` interface gains `ConfigFileUsed`, `GetString`, `Set` — all already on `viper.Viper`, so the test mock works unchanged.
- 6 new tests in `internal/viper_test.go` covering: relative path resolves against config dir; absolute paths unchanged; CLI flag overrides config and isn't rewritten; all four path keys handled; default cwd lookup unchanged; explicit back-compat for legacy `oasdiff.yaml` in cwd.
- `docs/CONFIG-FILES.md` documents the new resolution semantics.

## Backward compatibility

**Strict.** Existing setups continue to work identically:

| Setup | Before | After | Δ |
|---|---|---|---|
| `.oasdiff.yaml` in cwd, relative path | `<cwd>/<file>` | `<abs cwd>/<file>` | Functionally identical |
| `oasdiff.yaml` in cwd, relative path (legacy users) | `<cwd>/<file>` | `<abs cwd>/<file>` | Functionally identical |
| Any config file, absolute path inside | absolute path | absolute path | Skipped by rewrite |
| User passes `--err-ignore foo.txt` on CLI | `<cwd>/foo.txt` | `<cwd>/foo.txt` | Skipped (Changed=true) |
| `--config <subdir>/cfg.yaml`, relative path inside | broken (cwd-rel, fails) | works (config-dir-rel) | Bug fix |

The only "regression" surface is the theoretical user who relied on `--config` + cwd-relative-not-config-relative paths. `--config` is a few hours old (#899 merged today); meaningful adoption hasn't happened.

## Test plan

- [x] `go test ./...` — all packages green
- [x] `go test ./internal/ -run TestViper -count=1 -v` — 26 tests pass (12 original + 8 from #899 + 6 new)
- [ ] Manually verify the original repro (`--config examples/.oasdiff.yaml` from repo root) now succeeds
- [ ] Manually verify legacy `oasdiff.yaml` in cwd with relative `err-ignore` still works
