### PR TITLE
feat(flatten/allof): handle OpenAPI 3.1 propertyNames

### DIFF
--- a/flatten/allof/merge_allof.go
+++ b/flatten/allof/merge_allof.go
@@ -59,6 +59,7 @@ type SchemaCollection struct {
 	MinContains          []*uint64
 	MaxContains          []*uint64
 	Contains             []*openapi3.SchemaRef
+	PropertyNames        []*openapi3.SchemaRef
 	ContentMediaType     []string
 	ContentEncoding      []string
 	DependentRequired    []map[string][]string
@@ -225,6 +226,7 @@ func mergeInternal(state *state, base *openapi3.SchemaRef) (*openapi3.SchemaRef,
 		result.Value.MaxContains = new(*base.Value.MaxContains)
 	}
 	result.Value.Contains = base.Value.Contains
+	result.Value.PropertyNames = base.Value.PropertyNames
 	result.Value.ContentMediaType = base.Value.ContentMediaType
 	result.Value.ContentEncoding = base.Value.ContentEncoding
 	result.Value.DependentRequired = base.Value.DependentRequired
@@ -439,6 +441,10 @@ func flattenSchemas(state *state, result *openapi3.SchemaRef, schemas []*openapi
 		return err
 	}
 	result.Value, err = resolveContains(state, result.Value, &collection)
+	if err != nil {
+		return err
+	}
+	result.Value, err = resolvePropertyNames(state, result.Value, &collection)
 	if err != nil {
 		return err
 	}
@@ -676,6 +682,40 @@ func resolveContains(state *state, schema *openapi3.Schema, collection *SchemaCo
 		return nil, err
 	}
 	schema.Contains = result
+	return schema, nil
+}
+
+// resolvePropertyNames merges OpenAPI 3.1 / JSON Schema 2020-12
+// `propertyNames` subschemas across allOf siblings. `propertyNames`
+// constrains every property name in an object to validate against the
+// subschema. Unlike `contains`, this is a universal quantifier ("every
+// name matches"), so the strict allOf semantics are exact: a name must
+// match X AND match Y, which is the same as matching Merge(X, Y). We
+// recursively flatten X and Y as if wrapped in allOf and emit a single
+// `propertyNames`. No over-constraint — the merge is semantically
+// faithful.
+func resolvePropertyNames(state *state, schema *openapi3.Schema, collection *SchemaCollection) (*openapi3.Schema, error) {
+
+	names := openapi3.SchemaRefs{}
+	for _, sref := range collection.PropertyNames {
+		if sref != nil {
+			names = append(names, sref)
+		}
+	}
+	if len(names) == 0 {
+		schema.PropertyNames = nil
+		return schema, nil
+	}
+	if len(names) == 1 {
+		schema.PropertyNames = names[0]
+		return schema, nil
+	}
+	result := openapi3.NewSchemaRef("", openapi3.NewSchema())
+	err := flattenSchemas(state, result, names)
+	if err != nil {
+		return nil, err
+	}
+	schema.PropertyNames = result
 	return schema, nil
 }
 
@@ -1212,6 +1252,7 @@ func collect(schemas []*openapi3.SchemaRef) SchemaCollection {
 		collection.MinContains = append(collection.MinContains, s.Value.MinContains)
 		collection.MaxContains = append(collection.MaxContains, s.Value.MaxContains)
 		collection.Contains = append(collection.Contains, s.Value.Contains)
+		collection.PropertyNames = append(collection.PropertyNames, s.Value.PropertyNames)
 		collection.ContentMediaType = append(collection.ContentMediaType, s.Value.ContentMediaType)
 		collection.ContentEncoding = append(collection.ContentEncoding, s.Value.ContentEncoding)
 		collection.DependentRequired = append(collection.DependentRequired, s.Value.DependentRequired)

--- a/flatten/allof/merge_allof_test.go
+++ b/flatten/allof/merge_allof_test.go
@@ -2934,3 +2934,105 @@ func TestMerge_Contains_AllUnset(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, merged.Contains)
 }
+
+// OpenAPI 3.1 / JSON Schema 2020-12 `propertyNames`: every property name in
+// an object must validate against the subschema. Unlike `contains`,
+// the strict allOf semantics ("every name matches X AND every name
+// matches Y") are exactly equivalent to "every name matches Merge(X, Y)",
+// so the recursive merge is semantically faithful — no over-constraint.
+
+// Single subschema with `propertyNames` flows through unchanged.
+func TestMerge_PropertyNames_SinglePass(t *testing.T) {
+	names := &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"string"}, MinLength: 3}}
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{PropertyNames: names},
+		})
+	require.NoError(t, err)
+	require.NotNil(t, merged.PropertyNames)
+	require.Equal(t, &openapi3.Types{"string"}, merged.PropertyNames.Value.Type)
+	require.EqualValues(t, 3, merged.PropertyNames.Value.MinLength)
+}
+
+// `propertyNames` set on one subschema, absent on another — the present
+// subschema flows through.
+func TestMerge_PropertyNames_WithAbsentSibling(t *testing.T) {
+	names := &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"string"}}}
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{PropertyNames: names}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"object"}}},
+				},
+			},
+		})
+	require.NoError(t, err)
+	require.NotNil(t, merged.PropertyNames)
+	require.Equal(t, &openapi3.Types{"string"}, merged.PropertyNames.Value.Type)
+}
+
+// Two subschemas with compatible `propertyNames` are recursively merged
+// into one. This is faithful: every name must match the merged subschema,
+// which is the same as matching both originals.
+func TestMerge_PropertyNames_TwoCompatibleAreMerged(t *testing.T) {
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{
+						PropertyNames: &openapi3.SchemaRef{Value: &openapi3.Schema{
+							Type:      &openapi3.Types{"string"},
+							MinLength: 3,
+						}},
+					}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{
+						PropertyNames: &openapi3.SchemaRef{Value: &openapi3.Schema{
+							Type:      &openapi3.Types{"string"},
+							MaxLength: new(uint64(10)),
+						}},
+					}},
+				},
+			},
+		})
+	require.NoError(t, err)
+	require.NotNil(t, merged.PropertyNames)
+	require.Equal(t, &openapi3.Types{"string"}, merged.PropertyNames.Value.Type)
+	require.EqualValues(t, 3, merged.PropertyNames.Value.MinLength)
+	require.NotNil(t, merged.PropertyNames.Value.MaxLength)
+	require.EqualValues(t, 10, *merged.PropertyNames.Value.MaxLength)
+}
+
+// Two subschemas with `propertyNames` whose Types disagree → recursive
+// merge surfaces the underlying conflict as an error.
+func TestMerge_PropertyNames_ConflictBubblesUp(t *testing.T) {
+	_, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{
+						PropertyNames: &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"string"}}},
+					}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{
+						PropertyNames: &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"integer"}}},
+					}},
+				},
+			},
+		})
+	require.EqualError(t, err, allof.TypeErrorMessage)
+}
+
+// No subschema sets `propertyNames` → merged value stays nil.
+func TestMerge_PropertyNames_AllUnset(t *testing.T) {
+	merged, err := allof.Merge(
+		openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				AllOf: openapi3.SchemaRefs{
+					&openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"object"}}},
+					&openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"object"}}},
+				},
+			},
+		})
+	require.NoError(t, err)
+	require.Nil(t, merged.PropertyNames)
+}


### PR DESCRIPTION
Adds the second medium-bucket #878 keyword: `propertyNames`. Same shape as `resolveContains` (#888) — schema-valued, recursive merge across `allOf` siblings — but semantically simpler.

## Semantics

`propertyNames: X` means *"every property name in this object must validate against X"*. The strict `allOf` interpretation of `propertyNames: X + propertyNames: Y` is *"every name matches X AND every name matches Y"*, which is **exactly equivalent** to *"every name matches `Merge(X, Y)`"* because the quantifier is **universal**.

Contrast with `contains` (#888), which has an **existential** quantifier (`≥1 item matches X`). For `contains`, "≥1 matches X AND ≥1 matches Y" allows two distinct items to satisfy the conjunction, so merging into one subschema *over-constrains*. For `propertyNames`, no such gap — the merge is semantically faithful.

## Implementation

`resolvePropertyNames` mirrors `resolveContains` in shape; the docstring calls out the existential-vs-universal difference explicitly. Five mechanical edits:

1. `SchemaCollection.PropertyNames []*openapi3.SchemaRef` field
2. Single-schema flow-through (`result.Value.PropertyNames = base.Value.PropertyNames`) — without this, a Merge on a schema with no allOf would silently drop `propertyNames`
3. Collection population in `flattenSchemas`
4. `resolvePropertyNames` function
5. Pipeline wiring in `mergeInternal` (after `resolveContains`)

## Tests

Five tests, mirroring the `Contains` set:

- `TestMerge_PropertyNames_SinglePass` — single subschema flows through unchanged
- `TestMerge_PropertyNames_WithAbsentSibling` — present subschema flows through when sibling has no `propertyNames`
- `TestMerge_PropertyNames_TwoCompatibleAreMerged` — round-trip through `Merge` with `MinLength` + `MaxLength` siblings; both bounds preserved in the merged result
- `TestMerge_PropertyNames_ConflictBubblesUp` — recursive Type conflict surfaces as the existing `TypeErrorMessage`
- `TestMerge_PropertyNames_AllUnset` — merged value stays nil when no subschema sets it

All pre-existing `flatten/allof` tests still pass.

## What's not in the diff

No `docs/ALLOF.md` update — the over-constrain caveat that lives there is specific to `contains` (existential). `propertyNames` is faithful, no caveat needed.

Refs #878.
