### PR TITLE
fix(flatten/allof): guard recursion sites against cyclic schemas (#890)

### DIFF
--- a/flatten/allof/merge_allof.go
+++ b/flatten/allof/merge_allof.go
@@ -75,6 +75,13 @@ type state struct {
 
 	// after mergeInternal is executed, circularAllOf contains all SchemaRefs which have circular allof.
 	circularAllOf openapi3.SchemaRefs
+
+	// flattening tracks input schemas currently being processed by
+	// flattenSchemas, mapping each to the result Value being populated
+	// for that call. Re-entry with an in-flight schema short-circuits
+	// to that result Value, which breaks recursion through cyclic
+	// Properties / Items / Contains / PropertyNames sub-schemas (#890).
+	flattening map[*openapi3.Schema]*openapi3.Schema
 }
 
 func newState() *state {
@@ -82,6 +89,7 @@ func newState() *state {
 		mergedSchemas: map[*openapi3.Schema]*openapi3.Schema{},
 		refs:          map[string]bool{},
 		circularAllOf: openapi3.SchemaRefs{},
+		flattening:    map[*openapi3.Schema]*openapi3.Schema{},
 	}
 }
 
@@ -385,6 +393,46 @@ func mergeSchemaRefs(state *state, srefs openapi3.SchemaRefs) (openapi3.SchemaRe
 // Given a list of schemas that are free of AllOf or nested AllOf components as input,
 // the function produces a single equivalent schema in the resultRef parameter.
 func flattenSchemas(state *state, result *openapi3.SchemaRef, schemas []*openapi3.SchemaRef) error {
+
+	// Tier 1: pointer-dedup the input. The same *Schema appearing
+	// multiple times contributes nothing extra to the merge and, when
+	// the input set reduces to schemas already in flight (Tier 2),
+	// trims work the cycle guard would otherwise have to do.
+	schemas = dedupSchemaRefsByValue(schemas)
+
+	// Tier 2: cycle guard. If any input schema is already being
+	// flattened higher in the call stack, point our result Value at
+	// that in-flight Value and return — the cyclic Properties / Items
+	// / Contains / PropertyNames link in the input is preserved as a
+	// cyclic link in the merged output, without infinite recursion.
+	for _, s := range schemas {
+		if s == nil || s.Value == nil {
+			continue
+		}
+		if inFlight, ok := state.flattening[s.Value]; ok {
+			result.Value = inFlight
+			return nil
+		}
+	}
+
+	// Mark each non-nil input schema as in-flight, mapped to the
+	// result Value being populated for this call. Cleared on return so
+	// sibling flattenSchemas calls (different sub-schemas, same
+	// inputs) don't see stale markers.
+	for _, s := range schemas {
+		if s == nil || s.Value == nil {
+			continue
+		}
+		state.flattening[s.Value] = result.Value
+	}
+	defer func() {
+		for _, s := range schemas {
+			if s == nil || s.Value == nil {
+				continue
+			}
+			delete(state.flattening, s.Value)
+		}
+	}()
 
 	collection := collect(schemas)
 	var err error
@@ -1327,6 +1375,29 @@ func filterEmptySchemaRefs(groups []openapi3.SchemaRefs) []openapi3.SchemaRefs {
 		if len(group) > 0 {
 			result = append(result, group)
 		}
+	}
+	return result
+}
+
+// dedupSchemaRefsByValue returns schemas with duplicate Value pointers
+// removed (first occurrence kept). Refs with nil or nil Value flow
+// through unchanged so callers see the same nil-handling shape.
+func dedupSchemaRefsByValue(schemas openapi3.SchemaRefs) openapi3.SchemaRefs {
+	if len(schemas) < 2 {
+		return schemas
+	}
+	seen := make(map[*openapi3.Schema]struct{}, len(schemas))
+	result := make(openapi3.SchemaRefs, 0, len(schemas))
+	for _, s := range schemas {
+		if s == nil || s.Value == nil {
+			result = append(result, s)
+			continue
+		}
+		if _, ok := seen[s.Value]; ok {
+			continue
+		}
+		seen[s.Value] = struct{}{}
+		result = append(result, s)
 	}
 	return result
 }

--- a/flatten/allof/merge_allof_test.go
+++ b/flatten/allof/merge_allof_test.go
@@ -3036,3 +3036,74 @@ func TestMerge_PropertyNames_AllUnset(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, merged.PropertyNames)
 }
+
+// Cycle through Properties — the user-reported reproducer in #890.
+// Tree-node-shaped schema where Properties["child"] points back to the
+// same *Schema. The same node appears twice under allOf.
+func TestMerge_Cycle_PropertiesSameNodeTwice(t *testing.T) {
+	node := &openapi3.Schema{Type: &openapi3.Types{"object"}}
+	node.Properties = openapi3.Schemas{
+		"child": &openapi3.SchemaRef{Value: node},
+	}
+	merged, err := allof.Merge(openapi3.SchemaRef{
+		Value: &openapi3.Schema{
+			AllOf: openapi3.SchemaRefs{
+				&openapi3.SchemaRef{Value: node},
+				&openapi3.SchemaRef{Value: node},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, merged.Properties["child"])
+	// Cycle preserved in the merged output: child points back to the
+	// merged result Value.
+	require.Same(t, merged, merged.Properties["child"].Value)
+}
+
+// Cycle through Properties — two distinct cyclic *Schema pointers
+// (a.child = a, b.child = b) merged under allOf. Pointer-dedup alone
+// can't help here (a and b are different pointers); the in-flight
+// guard breaks the recursion.
+func TestMerge_Cycle_PropertiesTwoDistinctNodes(t *testing.T) {
+	a := &openapi3.Schema{Type: &openapi3.Types{"object"}}
+	a.Properties = openapi3.Schemas{
+		"child": &openapi3.SchemaRef{Value: a},
+	}
+	b := &openapi3.Schema{Type: &openapi3.Types{"object"}}
+	b.Properties = openapi3.Schemas{
+		"child": &openapi3.SchemaRef{Value: b},
+	}
+	merged, err := allof.Merge(openapi3.SchemaRef{
+		Value: &openapi3.Schema{
+			AllOf: openapi3.SchemaRefs{
+				&openapi3.SchemaRef{Value: a},
+				&openapi3.SchemaRef{Value: b},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, merged.Properties["child"])
+	require.Same(t, merged, merged.Properties["child"].Value)
+}
+
+// Cycle through Items — two distinct cyclic *Schema pointers
+// (a.items = a, b.items = b) merged under allOf. With two items in
+// the merge, resolveItems recurses via flattenSchemas, exercising the
+// cycle guard.
+func TestMerge_Cycle_ItemsTwoDistinctNodes(t *testing.T) {
+	a := &openapi3.Schema{Type: &openapi3.Types{"array"}}
+	a.Items = &openapi3.SchemaRef{Value: a}
+	b := &openapi3.Schema{Type: &openapi3.Types{"array"}}
+	b.Items = &openapi3.SchemaRef{Value: b}
+	merged, err := allof.Merge(openapi3.SchemaRef{
+		Value: &openapi3.Schema{
+			AllOf: openapi3.SchemaRefs{
+				&openapi3.SchemaRef{Value: a},
+				&openapi3.SchemaRef{Value: b},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, merged.Items)
+	require.Same(t, merged, merged.Items.Value)
+}


### PR DESCRIPTION
## Repro

```go
node := &openapi3.Schema{Type: &openapi3.Types{"object"}}
node.Properties = openapi3.Schemas{
    "child": &openapi3.SchemaRef{Value: node},
}
allof.Merge(openapi3.SchemaRef{
    Value: &openapi3.Schema{
        AllOf: openapi3.SchemaRefs{
            &openapi3.SchemaRef{Value: node},
            &openapi3.SchemaRef{Value: node},
        },
    },
})
// → fatal error: stack overflow
```

## Root cause

`mergeInternal` caches per `*Schema` in `state.mergedSchemas`, which protects re-entry through itself. But the recursion sites — `mergeProps`, `resolveItems`, `resolveContains`, `resolvePropertyNames` — call `flattenSchemas` directly with no equivalent guard. When the input schema's sub-schemas cycle back, the call stack repeats:

```
flattenSchemas → resolveProperties → mergeProps → flattenSchemas → resolveProperties → mergeProps → ...
```

## Fix — two tiers, both at the top of `flattenSchemas`

**Tier 1: pointer-dedup.** The same `*Schema` appearing multiple times in the input slice contributes nothing to the merge and trims the work Tier 2 would otherwise have to do.

**Tier 2: in-flight cycle guard.** New `state.flattening` map of `*Schema → *Schema` (input → in-flight result Value). Each input is marked before recursing; a recursive call with an in-flight schema points its result Value at the in-flight Value and returns. The cyclic link in the input becomes a cyclic link in the merged output. Markers cleared on return so sibling calls don't see stale state.

## Tests

- `TestMerge_Cycle_PropertiesSameNodeTwice` — user-reported reproducer, same self-referential node appears twice under allOf
- `TestMerge_Cycle_PropertiesTwoDistinctNodes` — `a.child=a, b.child=b` case where pointer-dedup alone can't help; exercises Tier 2
- `TestMerge_Cycle_ItemsTwoDistinctNodes` — same shape on the Items recursion site

`go test ./...` clean.

Closes #890.