### PR TITLE
chore(checker): use opInfo for the 5 diff-helper functions (#865)

### DIFF
--- a/checker/check_request_parameter_enum_value_updated.go
+++ b/checker/check_request_parameter_enum_value_updated.go
@@ -29,6 +29,7 @@ func RequestParameterEnumValueUpdatedCheck(diffReport *diff.Diff, operationsSour
 			if operationItem.ParametersDiff.Modified == nil {
 				continue
 			}
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 			for paramLocation, paramItems := range operationItem.ParametersDiff.Modified {
 				for paramName, paramItem := range paramItems {
 					if paramItem.SchemaDiff == nil {
@@ -36,18 +37,19 @@ func RequestParameterEnumValueUpdatedCheck(diffReport *diff.Diff, operationsSour
 					}
 
 					result = append(result, checkParameterEnumDiff(
+						opInfo,
 						paramItem.SchemaDiff.EnumDiff,
 						paramItem.SchemaDiff,
 						RequestParameterEnumValueRemovedId,
 						RequestParameterEnumValueAddedId,
 						func(enumVal any) []any { return []any{enumVal, paramLocation, paramName} },
-						operationsSources, operationItem, config, operation, path,
 					)...)
 
 					CheckModifiedPropertiesDiff(
 						paramItem.SchemaDiff,
 						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
 							result = append(result, checkParameterEnumDiff(
+								opInfo,
 								propertyDiff.EnumDiff,
 								propertyDiff,
 								RequestParameterPropertyEnumValueRemovedId,
@@ -55,7 +57,6 @@ func RequestParameterEnumValueUpdatedCheck(diffReport *diff.Diff, operationsSour
 								func(enumVal any) []any {
 									return []any{enumVal, propertyFullName(propertyPath, propertyName), paramLocation, paramName}
 								},
-								operationsSources, operationItem, config, operation, path,
 							)...)
 						})
 				}
@@ -66,14 +67,11 @@ func RequestParameterEnumValueUpdatedCheck(diffReport *diff.Diff, operationsSour
 }
 
 func checkParameterEnumDiff(
+	opInfo opInfo,
 	enumDiff *diff.EnumDiff,
 	schemaDiff *diff.SchemaDiff,
 	removedId, addedId string,
 	makeArgs func(enumVal any) []any,
-	operationsSources *diff.OperationsSourcesMap,
-	operationItem *diff.MethodDiff,
-	config *Config,
-	operation, path string,
 ) Changes {
 	result := make(Changes, 0)
 	if enumDiff == nil {
@@ -81,30 +79,30 @@ func checkParameterEnumDiff(
 	}
 
 	for _, enumVal := range enumDiff.Deleted {
-		baseSource, revisionSource := SchemaDeletedItemSources(operationsSources, operationItem, schemaDiff, "enum", fmt.Sprintf("%v", enumVal))
+		baseSource, revisionSource := SchemaDeletedItemSources(opInfo.operationsSources, opInfo.methodDiff, schemaDiff, "enum", fmt.Sprintf("%v", enumVal))
 		result = append(result, NewApiChange(
 			removedId,
-			config,
+			opInfo.config,
 			makeArgs(enumVal),
 			"",
-			operationsSources,
-			operationItem.Revision,
-			operation,
-			path,
+			opInfo.operationsSources,
+			opInfo.operation,
+			opInfo.method,
+			opInfo.path,
 		).WithSources(baseSource, revisionSource))
 	}
 
 	for _, enumVal := range enumDiff.Added {
-		baseSource, revisionSource := SchemaAddedItemSources(operationsSources, operationItem, schemaDiff, "enum", fmt.Sprintf("%v", enumVal))
+		baseSource, revisionSource := SchemaAddedItemSources(opInfo.operationsSources, opInfo.methodDiff, schemaDiff, "enum", fmt.Sprintf("%v", enumVal))
 		result = append(result, NewApiChange(
 			addedId,
-			config,
+			opInfo.config,
 			makeArgs(enumVal),
 			"",
-			operationsSources,
-			operationItem.Revision,
-			operation,
-			path,
+			opInfo.operationsSources,
+			opInfo.operation,
+			opInfo.method,
+			opInfo.path,
 		).WithSources(baseSource, revisionSource))
 	}
 

--- a/checker/check_request_parameter_list_of_types_changed.go
+++ b/checker/check_request_parameter_list_of_types_changed.go
@@ -24,6 +24,7 @@ func RequestParameterListOfTypesChangedCheck(diffReport *diff.Diff, operationsSo
 			if operationItem.ParametersDiff == nil {
 				continue
 			}
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 
 			// Check modified parameters
 			for _, paramDiffs := range operationItem.ParametersDiff.Modified {
@@ -35,13 +36,9 @@ func RequestParameterListOfTypesChangedCheck(diffReport *diff.Diff, operationsSo
 
 					// Check parameter schema
 					changes := checkParameterListOfTypesChange(
+						opInfo,
 						paramDiff,
 						param,
-						config,
-						operationsSources,
-						operationItem,
-						operation,
-						path,
 					)
 					result = append(result, changes...)
 
@@ -51,15 +48,11 @@ func RequestParameterListOfTypesChangedCheck(diffReport *diff.Diff, operationsSo
 							paramDiff.SchemaDiff,
 							func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
 								changes := checkParameterPropertyListOfTypesChange(
+									opInfo,
 									propertyPath,
 									propertyName,
 									propertyDiff,
 									param,
-									config,
-									operationsSources,
-									operationItem,
-									operation,
-									path,
 								)
 								result = append(result, changes...)
 							})

--- a/checker/check_request_property_list_of_types_changed.go
+++ b/checker/check_request_property_list_of_types_changed.go
@@ -39,7 +39,7 @@ func RequestPropertyListOfTypesChangedCheck(diffReport *diff.Diff, operationsSou
 					opInfo,
 					mediaTypeDiff.SchemaDiff,
 					mediaType,
-					"", // responseStatus not applicable for requests
+					"",   // responseStatus not applicable for requests
 					true, // isRequest
 				)
 				result = append(result, changes...)
@@ -61,7 +61,7 @@ func RequestPropertyListOfTypesChangedCheck(diffReport *diff.Diff, operationsSou
 							propertyName,
 							propertyDiff,
 							mediaType,
-							"", // responseStatus not applicable for requests
+							"",   // responseStatus not applicable for requests
 							true, // isRequest
 						)
 						result = append(result, changes...)

--- a/checker/check_request_property_list_of_types_changed.go
+++ b/checker/check_request_property_list_of_types_changed.go
@@ -26,6 +26,7 @@ func RequestPropertyListOfTypesChangedCheck(diffReport *diff.Diff, operationsSou
 				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
 				continue
 			}
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 
 			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
 			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
@@ -35,14 +36,10 @@ func RequestPropertyListOfTypesChangedCheck(diffReport *diff.Diff, operationsSou
 
 				// Check request body schema
 				changes := checkBodyListOfTypesChange(
+					opInfo,
 					mediaTypeDiff.SchemaDiff,
 					mediaType,
 					"", // responseStatus not applicable for requests
-					config,
-					operationsSources,
-					operationItem,
-					operation,
-					path,
 					true, // isRequest
 				)
 				result = append(result, changes...)
@@ -59,16 +56,12 @@ func RequestPropertyListOfTypesChangedCheck(diffReport *diff.Diff, operationsSou
 						}
 
 						changes := checkPropertyListOfTypesChange(
+							opInfo,
 							propertyPath,
 							propertyName,
 							propertyDiff,
 							mediaType,
 							"", // responseStatus not applicable for requests
-							config,
-							operationsSources,
-							operationItem,
-							operation,
-							path,
 							true, // isRequest
 						)
 						result = append(result, changes...)

--- a/checker/check_response_property_list_of_types_changed.go
+++ b/checker/check_response_property_list_of_types_changed.go
@@ -24,6 +24,7 @@ func ResponsePropertyListOfTypesChangedCheck(diffReport *diff.Diff, operationsSo
 			if operationItem.ResponsesDiff == nil || operationItem.ResponsesDiff.Modified == nil {
 				continue
 			}
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 
 			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
 				if responseDiff.ContentDiff == nil ||
@@ -39,14 +40,10 @@ func ResponsePropertyListOfTypesChangedCheck(diffReport *diff.Diff, operationsSo
 
 					// Check response body schema
 					changes := checkBodyListOfTypesChange(
+						opInfo,
 						mediaTypeDiff.SchemaDiff,
 						mediaType,
 						responseStatus,
-						config,
-						operationsSources,
-						operationItem,
-						operation,
-						path,
 						false, // isRequest
 					)
 					result = append(result, changes...)
@@ -60,16 +57,12 @@ func ResponsePropertyListOfTypesChangedCheck(diffReport *diff.Diff, operationsSo
 							}
 
 							changes := checkPropertyListOfTypesChange(
+								opInfo,
 								propertyPath,
 								propertyName,
 								propertyDiff,
 								mediaType,
 								responseStatus,
-								config,
-								operationsSources,
-								operationItem,
-								operation,
-								path,
 								false, // isRequest
 							)
 							result = append(result, changes...)

--- a/checker/list_of_types_core.go
+++ b/checker/list_of_types_core.go
@@ -8,9 +8,8 @@ import (
 // Core logic functions for ListOfTypes checking that can be reused by both full checkers and suppression functions
 
 // checkPropertyListOfTypesChange checks if a property change involves list-of-types patterns and returns breaking changes
-func checkPropertyListOfTypesChange(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff,
-	mediaType string, responseStatus string, config *Config, operationsSources *diff.OperationsSourcesMap,
-	operationItem *diff.MethodDiff, operation string, path string, isRequest bool) Changes {
+func checkPropertyListOfTypesChange(opInfo opInfo, propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff,
+	mediaType string, responseStatus string, isRequest bool) Changes {
 
 	result := make(Changes, 0)
 
@@ -44,25 +43,24 @@ func checkPropertyListOfTypesChange(propertyPath string, propertyName string, pr
 		}
 	}
 
-	baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "type")
+	baseSource, revisionSource := SchemaFieldSources(opInfo.operationsSources, opInfo.methodDiff, propertyDiff, "type")
 	result = append(result, NewApiChange(
 		messageId,
-		config,
+		opInfo.config,
 		args,
 		"",
-		operationsSources,
-		operationItem.Revision,
-		operation,
-		path,
+		opInfo.operationsSources,
+		opInfo.operation,
+		opInfo.method,
+		opInfo.path,
 	).WithSources(baseSource, revisionSource))
 
 	return result
 }
 
 // checkBodyListOfTypesChange checks if a request/response body change involves list-of-types patterns and returns breaking changes
-func checkBodyListOfTypesChange(schemaDiff *diff.SchemaDiff, mediaType string, responseStatus string,
-	config *Config, operationsSources *diff.OperationsSourcesMap, operationItem *diff.MethodDiff,
-	operation string, path string, isRequest bool) Changes {
+func checkBodyListOfTypesChange(opInfo opInfo, schemaDiff *diff.SchemaDiff, mediaType string, responseStatus string,
+	isRequest bool) Changes {
 
 	result := make(Changes, 0)
 
@@ -96,25 +94,23 @@ func checkBodyListOfTypesChange(schemaDiff *diff.SchemaDiff, mediaType string, r
 		}
 	}
 
-	baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, schemaDiff, "type")
+	baseSource, revisionSource := SchemaFieldSources(opInfo.operationsSources, opInfo.methodDiff, schemaDiff, "type")
 	result = append(result, NewApiChange(
 		messageId,
-		config,
+		opInfo.config,
 		args,
 		"",
-		operationsSources,
-		operationItem.Revision,
-		operation,
-		path,
+		opInfo.operationsSources,
+		opInfo.operation,
+		opInfo.method,
+		opInfo.path,
 	).WithSources(baseSource, revisionSource))
 
 	return result
 }
 
 // checkParameterListOfTypesChange checks if a parameter change involves list-of-types patterns and returns breaking changes
-func checkParameterListOfTypesChange(paramDiff *diff.ParameterDiff, param *openapi3.Parameter,
-	config *Config, operationsSources *diff.OperationsSourcesMap, operationItem *diff.MethodDiff,
-	operation string, path string) Changes {
+func checkParameterListOfTypesChange(opInfo opInfo, paramDiff *diff.ParameterDiff, param *openapi3.Parameter) Changes {
 
 	result := make(Changes, 0)
 
@@ -136,25 +132,24 @@ func checkParameterListOfTypesChange(paramDiff *diff.ParameterDiff, param *opena
 		args = []any{param.In, param.Name, joinTypes(listDiff.Added)}
 	}
 
-	baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, paramDiff.SchemaDiff, "type")
+	baseSource, revisionSource := SchemaFieldSources(opInfo.operationsSources, opInfo.methodDiff, paramDiff.SchemaDiff, "type")
 	result = append(result, NewApiChange(
 		messageId,
-		config,
+		opInfo.config,
 		args,
 		"",
-		operationsSources,
-		operationItem.Revision,
-		operation,
-		path,
+		opInfo.operationsSources,
+		opInfo.operation,
+		opInfo.method,
+		opInfo.path,
 	).WithSources(baseSource, revisionSource))
 
 	return result
 }
 
 // checkParameterPropertyListOfTypesChange checks if a parameter property change involves list-of-types patterns and returns breaking changes
-func checkParameterPropertyListOfTypesChange(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff,
-	param *openapi3.Parameter, config *Config, operationsSources *diff.OperationsSourcesMap,
-	operationItem *diff.MethodDiff, operation string, path string) Changes {
+func checkParameterPropertyListOfTypesChange(opInfo opInfo, propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff,
+	param *openapi3.Parameter) Changes {
 
 	result := make(Changes, 0)
 
@@ -176,16 +171,16 @@ func checkParameterPropertyListOfTypesChange(propertyPath string, propertyName s
 		args = []any{propertyFullName(propertyPath, propertyName), param.In, param.Name, joinTypes(listDiff.Added)}
 	}
 
-	baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "type")
+	baseSource, revisionSource := SchemaFieldSources(opInfo.operationsSources, opInfo.methodDiff, propertyDiff, "type")
 	result = append(result, NewApiChange(
 		messageId,
-		config,
+		opInfo.config,
 		args,
 		"",
-		operationsSources,
-		operationItem.Revision,
-		operation,
-		path,
+		opInfo.operationsSources,
+		opInfo.operation,
+		opInfo.method,
+		opInfo.path,
 	).WithSources(baseSource, revisionSource))
 
 	return result

--- a/checker/op_info.go
+++ b/checker/op_info.go
@@ -5,13 +5,24 @@ import (
 	"github.com/oasdiff/oasdiff/diff"
 )
 
-// opInfo is used as an argument in helper functions in order to simplify the function signature.
+// opInfo bundles the per-operation plumbing that every helper needs
+// (config, operation, operationsSources, method, path) so signatures
+// stay focused on what actually varies. Used as an argument in helper
+// functions in order to simplify the function signature.
+//
+// methodDiff is set only when the helper is operating on a diff
+// (base vs revision MethodDiff). Single-side checks like sunset leave
+// it nil and use `operation` directly.
 type opInfo struct {
 	config            *Config
 	operation         *openapi3.Operation
 	operationsSources *diff.OperationsSourcesMap
 	method            string
 	path              string
+	// methodDiff is the diff record for this operation (base vs
+	// revision). Set by newOpInfoFromDiff; nil when the helper is
+	// operating on a single openapi3.Operation rather than a diff.
+	methodDiff *diff.MethodDiff
 }
 
 func newOpInfo(config *Config, operation *openapi3.Operation, operationsSources *diff.OperationsSourcesMap, method, path string) opInfo {
@@ -21,5 +32,21 @@ func newOpInfo(config *Config, operation *openapi3.Operation, operationsSources 
 		operationsSources: operationsSources,
 		method:            method,
 		path:              path,
+	}
+}
+
+// newOpInfoFromDiff is the diff-helper constructor: takes the
+// MethodDiff and uses its Revision side as the underlying
+// *openapi3.Operation (matching the existing convention used by the
+// list-of-types and enum-diff helpers, which always pass
+// operationItem.Revision to NewApiChange).
+func newOpInfoFromDiff(config *Config, methodDiff *diff.MethodDiff, operationsSources *diff.OperationsSourcesMap, method, path string) opInfo {
+	return opInfo{
+		config:            config,
+		operation:         methodDiff.Revision,
+		operationsSources: operationsSources,
+		method:            method,
+		path:              path,
+		methodDiff:        methodDiff,
 	}
 }


### PR DESCRIPTION
Per #865, the diff-helper functions in `checker/` had a recurring 5-parameter plumbing tail (`config`, `operationsSources`, `operationItem`, `operation`, `path`) that's constant per operation iteration and gets passed unchanged through every nested helper.

The codebase already has the `opInfo` struct for this exact concern (with a TODO calling out wider rollout). This PR aligns: extends `opInfo` with an optional `methodDiff *diff.MethodDiff` field via a new `newOpInfoFromDiff` constructor, so it can carry what the diff helpers need (for `SchemaFieldSources` etc.) without breaking the existing single-operation use in sunset checks.

## Migrated helpers (5)

- `checkParameterEnumDiff`
- `checkPropertyListOfTypesChange`
- `checkBodyListOfTypesChange`
- `checkParameterListOfTypesChange`
- `checkParameterPropertyListOfTypesChange`

Each lost 5 plumbing parameters and now takes an `opInfo`. Call sites build the `opInfo` once at the operation-iteration boundary and pass it down unchanged.

## What's intentionally not in this PR

The TODO in `checker/api_change.go:36` (`NewApiChange` itself accepting `opInfo`) — has 355 call sites across `checker/` and is best done as a single mechanical follow-up so the diff stays scoped and reviewable. Tracked separately.

## Verification

- Pure plumbing refactor, no behavior change.
- `go build ./...` clean.
- `go test ./checker/ ./internal/` green.

Closes #865 partially (the 5 helpers); the `NewApiChange` migration ships in a follow-up PR.