### PR TITLE
chore(checker): migrate Config to functional options (#864)

### DIFF
--- a/checker/attributes_test.go
+++ b/checker/attributes_test.go
@@ -17,7 +17,7 @@ func TestBreaking_Attributes(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	errs := checker.CheckBackwardCompatibility(allChecksConfig().WithAttributes([]string{"x-test"}), d, osm)
+	errs := checker.CheckBackwardCompatibility(allChecksConfig(checker.WithAttributes([]string{"x-test"})), d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 2)
 
@@ -34,7 +34,7 @@ func TestBreaking_AttributesNone(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	errs := checker.CheckBackwardCompatibility(allChecksConfig().WithAttributes([]string{"x-other"}), d, osm)
+	errs := checker.CheckBackwardCompatibility(allChecksConfig(checker.WithAttributes([]string{"x-other"})), d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 2)
 
@@ -51,7 +51,7 @@ func TestBreaking_AttributesReverse(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	errs := checker.CheckBackwardCompatibility(allChecksConfig().WithAttributes([]string{"x-test"}), d, osm)
+	errs := checker.CheckBackwardCompatibility(allChecksConfig(checker.WithAttributes([]string{"x-test"})), d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 2)
 
@@ -68,7 +68,7 @@ func TestBreaking_AttributesTwo(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	errs := checker.CheckBackwardCompatibility(allChecksConfig().WithAttributes([]string{"x-test", "x-test2"}), d, osm)
+	errs := checker.CheckBackwardCompatibility(allChecksConfig(checker.WithAttributes([]string{"x-test", "x-test2"})), d, osm)
 	require.Len(t, errs, 2)
 
 	require.Equal(t, map[string]any{"x-test": []any{"xyz", float64(456)}}, errs[0].GetAttributes())

--- a/checker/check_api_deprecation_test.go
+++ b/checker/check_api_deprecation_test.go
@@ -23,7 +23,7 @@ func TestBreaking_DeprecationWithInvalidSunset(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	c := singleCheckConfig(checker.APIDeprecationCheck).WithDeprecation(0, 10)
+	c := singleCheckConfig(checker.APIDeprecationCheck, checker.WithDeprecation(0, 10))
 	errs := checker.CheckBackwardCompatibility(c, d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
@@ -42,7 +42,7 @@ func TestBreaking_DeprecationWithInvalidStabilityLevel(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	c := singleCheckConfig(checker.APIDeprecationCheck).WithDeprecation(0, 10)
+	c := singleCheckConfig(checker.APIDeprecationCheck, checker.WithDeprecation(0, 10))
 	errs := checker.CheckBackwardCompatibility(c, d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
@@ -62,7 +62,7 @@ func TestBreaking_DeprecationWithoutSunsetNoPolicy(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	c := singleCheckConfig(checker.APIDeprecationCheck).WithDeprecation(0, 0)
+	c := singleCheckConfig(checker.APIDeprecationCheck, checker.WithDeprecation(0, 0))
 	errs := checker.CheckBackwardCompatibility(c, d, osm)
 	require.Empty(t, errs)
 }
@@ -78,7 +78,7 @@ func TestBreaking_DeprecationWithoutSunsetWithPolicy(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	c := singleCheckConfig(checker.APIDeprecationCheck).WithDeprecation(30, 100)
+	c := singleCheckConfig(checker.APIDeprecationCheck, checker.WithDeprecation(30, 100))
 	errs := checker.CheckBackwardCompatibility(c, d, osm)
 	require.Len(t, errs, 1)
 	require.Equal(t, checker.APIDeprecatedSunsetMissingId, errs[0].GetId())
@@ -152,7 +152,7 @@ func TestBreaking_DeprecationWithEarlySunset(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	c := singleCheckConfig(checker.APIDeprecationCheck).WithDeprecation(0, 10)
+	c := singleCheckConfig(checker.APIDeprecationCheck, checker.WithDeprecation(0, 10))
 	errs := checker.CheckBackwardCompatibility(c, d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
@@ -172,7 +172,7 @@ func TestBreaking_DeprecationWithProperSunset(t *testing.T) {
 	s2.Spec.Paths.Value("/api/test").Get.Extensions[diff.SunsetExtension] = toJson(t, civil.DateOf(time.Now()).AddDays(10).String())
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
-	c := singleCheckConfig(checker.APIDeprecationCheck).WithDeprecation(0, 10)
+	c := singleCheckConfig(checker.APIDeprecationCheck, checker.WithDeprecation(0, 10))
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(c, d, osm, checker.INFO)
 	require.Len(t, errs, 1)
@@ -342,7 +342,7 @@ func TestBreaking_DeprecationWithRFC3339Sunset(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	c := singleCheckConfig(checker.APIDeprecationCheck).WithDeprecation(0, 10)
+	c := singleCheckConfig(checker.APIDeprecationCheck, checker.WithDeprecation(0, 10))
 	errs := checker.CheckBackwardCompatibilityUntilLevel(c, d, osm, checker.INFO)
 	require.Len(t, errs, 1)
 	// only a non-breaking change detected
@@ -363,7 +363,7 @@ func TestBreaking_DeprecationWithInvalidJsonSunset(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	c := singleCheckConfig(checker.APIDeprecationCheck).WithDeprecation(0, 10)
+	c := singleCheckConfig(checker.APIDeprecationCheck, checker.WithDeprecation(0, 10))
 	errs := checker.CheckBackwardCompatibility(c, d, osm)
 	require.Len(t, errs, 1)
 	require.Equal(t, checker.APIDeprecatedSunsetParseId, errs[0].GetId())
@@ -385,7 +385,7 @@ func TestEndpointDeprecation_MessageWithSunsetDate(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	c := singleCheckConfig(checker.APIDeprecationCheck).WithDeprecation(0, 10)
+	c := singleCheckConfig(checker.APIDeprecationCheck, checker.WithDeprecation(0, 10))
 	errs := checker.CheckBackwardCompatibilityUntilLevel(c, d, osm, checker.INFO)
 
 	// Find the endpoint-deprecated-with-sunset change

--- a/checker/check_api_sunset_changed_test.go
+++ b/checker/check_api_sunset_changed_test.go
@@ -37,7 +37,7 @@ func TestBreaking_SunsetModifiedForDeprecatedEndpoint(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	errs := checker.CheckBackwardCompatibility(singleCheckConfig(checker.APISunsetChangedCheck).WithDeprecation(31, 180), d, osm)
+	errs := checker.CheckBackwardCompatibility(singleCheckConfig(checker.APISunsetChangedCheck, checker.WithDeprecation(31, 180)), d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
 	require.Equal(t, checker.APISunsetDateChangedTooSmallId, errs[0].GetId())

--- a/checker/check_breaking_test.go
+++ b/checker/check_breaking_test.go
@@ -228,7 +228,7 @@ func TestBreaking_ResponseNonSuccessStatusUpdated(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	errs := checker.CheckBackwardCompatibility(allChecksConfig().WithOptionalCheck(checker.ResponseNonSuccessStatusRemovedId), d, osm)
+	errs := checker.CheckBackwardCompatibility(allChecksConfig(checker.WithOptionalCheck(checker.ResponseNonSuccessStatusRemovedId)), d, osm)
 	for _, err := range errs {
 		require.Equal(t, checker.ERR, err.GetLevel())
 	}
@@ -248,7 +248,7 @@ func TestBreaking_OperationIdRemoved(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 
-	errs := checker.CheckBackwardCompatibility(allChecksConfig().WithOptionalCheck(checker.APIOperationIdRemovedId), d, osm)
+	errs := checker.CheckBackwardCompatibility(allChecksConfig(checker.WithOptionalCheck(checker.APIOperationIdRemovedId)), d, osm)
 	for _, err := range errs {
 		require.Equal(t, checker.ERR, err.GetLevel())
 	}
@@ -272,7 +272,7 @@ func TestBreaking_RequestBodyEnumRemoved(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 
-	errs := checker.CheckBackwardCompatibility(allChecksConfig().WithOptionalCheck(checker.RequestBodyEnumValueRemovedId), d, osm)
+	errs := checker.CheckBackwardCompatibility(allChecksConfig(checker.WithOptionalCheck(checker.RequestBodyEnumValueRemovedId)), d, osm)
 	for _, err := range errs {
 		require.Equal(t, checker.ERR, err.GetLevel())
 	}
@@ -290,7 +290,7 @@ func TestBreaking_ResponsePropertyEnumRemoved(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 
-	errs := checker.CheckBackwardCompatibility(allChecksConfig().WithOptionalCheck(checker.ResponsePropertyEnumValueRemovedId), d, osm)
+	errs := checker.CheckBackwardCompatibility(allChecksConfig(checker.WithOptionalCheck(checker.ResponsePropertyEnumValueRemovedId)), d, osm)
 	for _, err := range errs {
 		require.Equal(t, checker.ERR, err.GetLevel())
 	}
@@ -309,7 +309,7 @@ func TestBreaking_TagRemoved(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	errs := checker.CheckBackwardCompatibility(allChecksConfig().WithOptionalCheck(checker.APITagRemovedId), d, osm)
+	errs := checker.CheckBackwardCompatibility(allChecksConfig(checker.WithOptionalCheck(checker.APITagRemovedId)), d, osm)
 	for _, err := range errs {
 		require.Equal(t, checker.ERR, err.GetLevel())
 	}
@@ -329,7 +329,7 @@ func TestBreaking_ResponseMediaTypeEnumRemoved(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	errs := checker.CheckBackwardCompatibility(allChecksConfig().WithOptionalCheck(checker.ResponseMediaTypeEnumValueRemovedId), d, osm)
+	errs := checker.CheckBackwardCompatibility(allChecksConfig(checker.WithOptionalCheck(checker.ResponseMediaTypeEnumValueRemovedId)), d, osm)
 	for _, err := range errs {
 		require.Equal(t, checker.ERR, err.GetLevel())
 	}
@@ -605,7 +605,7 @@ func TestBreaking_SchemaRemoved(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	checks := allChecksConfig().WithOptionalCheck(checker.APISchemasRemovedId)
+	checks := allChecksConfig(checker.WithOptionalCheck(checker.APISchemasRemovedId))
 	errs := checker.CheckBackwardCompatibility(checks, d, osm)
 	for _, err := range errs {
 		require.Equal(t, checker.ERR, err.GetLevel())

--- a/checker/check_request_parameter_deprecation_test.go
+++ b/checker/check_request_parameter_deprecation_test.go
@@ -22,7 +22,7 @@ func TestBreaking_ParameterDeprecationWithInvalidSunset(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	c := singleCheckConfig(checker.RequestParameterDeprecationCheck).WithDeprecation(0, 10)
+	c := singleCheckConfig(checker.RequestParameterDeprecationCheck, checker.WithDeprecation(0, 10))
 	errs := checker.CheckBackwardCompatibility(c, d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
@@ -41,7 +41,7 @@ func TestBreaking_ParameterDeprecationWithoutSunsetNoPolicy(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	c := singleCheckConfig(checker.RequestParameterDeprecationCheck).WithDeprecation(0, 0)
+	c := singleCheckConfig(checker.RequestParameterDeprecationCheck, checker.WithDeprecation(0, 0))
 	errs := checker.CheckBackwardCompatibility(c, d, osm)
 	require.Empty(t, errs)
 }
@@ -57,7 +57,7 @@ func TestBreaking_ParameterDeprecationWithoutSunsetWithPolicy(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	c := singleCheckConfig(checker.RequestParameterDeprecationCheck).WithDeprecation(30, 100)
+	c := singleCheckConfig(checker.RequestParameterDeprecationCheck, checker.WithDeprecation(30, 100))
 	errs := checker.CheckBackwardCompatibility(c, d, osm)
 	require.Len(t, errs, 1)
 	require.Equal(t, checker.RequestParameterDeprecatedSunsetMissingId, errs[0].GetId())
@@ -108,7 +108,7 @@ func TestBreaking_ParameterDeprecationWithEarlySunset(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	c := singleCheckConfig(checker.RequestParameterDeprecationCheck).WithDeprecation(0, 10)
+	c := singleCheckConfig(checker.RequestParameterDeprecationCheck, checker.WithDeprecation(0, 10))
 	errs := checker.CheckBackwardCompatibility(c, d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
@@ -128,7 +128,7 @@ func TestBreaking_ParameterDeprecationWithProperSunset(t *testing.T) {
 	s2.Spec.Paths.Value("/api/test").GetOperation("GET").Parameters.GetByInAndName("query", "id").Extensions[diff.SunsetExtension] = toJson(t, civil.DateOf(time.Now()).AddDays(10).String())
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
-	c := singleCheckConfig(checker.RequestParameterDeprecationCheck).WithDeprecation(0, 10)
+	c := singleCheckConfig(checker.RequestParameterDeprecationCheck, checker.WithDeprecation(0, 10))
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(c, d, osm, checker.INFO)
 	require.Len(t, errs, 1)

--- a/checker/check_request_parameter_sunset_changed_test.go
+++ b/checker/check_request_parameter_sunset_changed_test.go
@@ -55,7 +55,7 @@ func TestBreaking_SunsetModifiedForDeprecatedParameter(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	errs := checker.CheckBackwardCompatibility(singleCheckConfig(checker.RequestParameterSunsetChangedCheck).WithDeprecation(31, 180), d, osm)
+	errs := checker.CheckBackwardCompatibility(singleCheckConfig(checker.RequestParameterSunsetChangedCheck, checker.WithDeprecation(31, 180)), d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
 	require.Equal(t, checker.RequestParameterSunsetDateChangedTooSmallId, errs[0].GetId())

--- a/checker/check_request_property_deprecation_test.go
+++ b/checker/check_request_property_deprecation_test.go
@@ -91,7 +91,7 @@ func TestRequestPropertyDeprecation_WithoutSunsetWithPolicy(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	c := singleCheckConfig(checker.RequestPropertyDeprecationCheck).WithDeprecation(30, 100)
+	c := singleCheckConfig(checker.RequestPropertyDeprecationCheck, checker.WithDeprecation(30, 100))
 	errs := checker.CheckBackwardCompatibility(c, d, osm)
 	require.Len(t, errs, 1)
 	require.Equal(t, checker.RequestPropertyDeprecatedSunsetMissingId, errs[0].GetId())
@@ -125,7 +125,7 @@ func TestRequestPropertyDeprecation_WithEarlySunset(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	c := singleCheckConfig(checker.RequestPropertyDeprecationCheck).WithDeprecation(0, 10)
+	c := singleCheckConfig(checker.RequestPropertyDeprecationCheck, checker.WithDeprecation(0, 10))
 	errs := checker.CheckBackwardCompatibility(c, d, osm)
 	require.Len(t, errs, 1)
 	require.Equal(t, checker.RequestPropertySunsetDateTooSmallId, errs[0].GetId())
@@ -146,7 +146,7 @@ func TestRequestPropertyDeprecation_WithProperSunset(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	c := singleCheckConfig(checker.RequestPropertyDeprecationCheck).WithDeprecation(0, 10)
+	c := singleCheckConfig(checker.RequestPropertyDeprecationCheck, checker.WithDeprecation(0, 10))
 	errs := checker.CheckBackwardCompatibilityUntilLevel(c, d, osm, checker.INFO)
 	require.Len(t, errs, 1)
 	require.Equal(t, checker.RequestPropertyDeprecatedWithSunsetId, errs[0].GetId())
@@ -241,7 +241,7 @@ func TestRequestPropertyDeprecation_MessageWithSunsetDate(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 
-	c := singleCheckConfig(checker.RequestPropertyDeprecationCheck).WithDeprecation(0, 10)
+	c := singleCheckConfig(checker.RequestPropertyDeprecationCheck, checker.WithDeprecation(0, 10))
 	errs := checker.CheckBackwardCompatibilityUntilLevel(c, d, osm, checker.INFO)
 	require.Len(t, errs, 1)
 	require.Equal(t, checker.RequestPropertyDeprecatedWithSunsetId, errs[0].GetId())

--- a/checker/check_response_property_deprecation_test.go
+++ b/checker/check_response_property_deprecation_test.go
@@ -91,7 +91,7 @@ func TestResponsePropertyDeprecation_WithoutSunsetWithPolicy(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	c := singleCheckConfig(checker.ResponsePropertyDeprecationCheck).WithDeprecation(30, 100)
+	c := singleCheckConfig(checker.ResponsePropertyDeprecationCheck, checker.WithDeprecation(30, 100))
 	errs := checker.CheckBackwardCompatibility(c, d, osm)
 	require.Len(t, errs, 1)
 	require.Equal(t, checker.ResponsePropertyDeprecatedSunsetMissingId, errs[0].GetId())
@@ -125,7 +125,7 @@ func TestResponsePropertyDeprecation_WithEarlySunset(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	c := singleCheckConfig(checker.ResponsePropertyDeprecationCheck).WithDeprecation(0, 10)
+	c := singleCheckConfig(checker.ResponsePropertyDeprecationCheck, checker.WithDeprecation(0, 10))
 	errs := checker.CheckBackwardCompatibility(c, d, osm)
 	require.Len(t, errs, 1)
 	require.Equal(t, checker.ResponsePropertySunsetDateTooSmallId, errs[0].GetId())
@@ -145,7 +145,7 @@ func TestResponsePropertyDeprecation_WithProperSunset(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	c := singleCheckConfig(checker.ResponsePropertyDeprecationCheck).WithDeprecation(0, 10)
+	c := singleCheckConfig(checker.ResponsePropertyDeprecationCheck, checker.WithDeprecation(0, 10))
 	errs := checker.CheckBackwardCompatibilityUntilLevel(c, d, osm, checker.INFO)
 	require.Len(t, errs, 1)
 	require.Equal(t, checker.ResponsePropertyDeprecatedWithSunsetId, errs[0].GetId())
@@ -185,7 +185,7 @@ func TestResponsePropertyDeprecation_WithInvalidSunset(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	c := singleCheckConfig(checker.ResponsePropertyDeprecationCheck).WithDeprecation(0, 10)
+	c := singleCheckConfig(checker.ResponsePropertyDeprecationCheck, checker.WithDeprecation(0, 10))
 	errs := checker.CheckBackwardCompatibility(c, d, osm)
 	require.Len(t, errs, 1)
 	require.Equal(t, checker.ResponsePropertyDeprecatedInvalidId, errs[0].GetId())
@@ -240,7 +240,7 @@ func TestResponsePropertyDeprecation_MessageWithSunsetDate(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 
-	c := singleCheckConfig(checker.ResponsePropertyDeprecationCheck).WithDeprecation(0, 10)
+	c := singleCheckConfig(checker.ResponsePropertyDeprecationCheck, checker.WithDeprecation(0, 10))
 	errs := checker.CheckBackwardCompatibilityUntilLevel(c, d, osm, checker.INFO)
 	require.Len(t, errs, 1)
 	require.Equal(t, checker.ResponsePropertyDeprecatedWithSunsetId, errs[0].GetId())

--- a/checker/config.go
+++ b/checker/config.go
@@ -15,59 +15,77 @@ const (
 	DefaultStableDeprecationDays = uint(0)
 )
 
-// NewConfig creates a new configuration with default values.
-func NewConfig(checks BackwardCompatibilityChecks) *Config {
-	return &Config{
+// Option configures a Config during NewConfig. Options compose: each
+// receives the Config after defaults and prior options have been
+// applied. Use the With* constructors below to obtain Options.
+type Option func(*Config)
+
+// NewConfig creates a new configuration with default values, then
+// applies the given options in order.
+func NewConfig(checks BackwardCompatibilityChecks, opts ...Option) *Config {
+	c := &Config{
 		Checks:              checks,
 		LogLevels:           GetCheckLevels(),
 		MinSunsetBetaDays:   DefaultBetaDeprecationDays,
 		MinSunsetStableDays: DefaultStableDeprecationDays,
 	}
-}
-
-// WithOptionalCheck adds a check to the list of optional checks.
-func (config *Config) WithOptionalCheck(id string) *Config {
-	return config.WithOptionalChecks([]string{id})
-}
-
-// WithOptionalChecks overrides the log level of the given checks to ERR so they will appear in `oasdiff breaking`
-func (config *Config) WithOptionalChecks(ids []string) *Config {
-	for _, id := range ids {
-		config.setLogLevel(id, ERR)
+	for _, opt := range opts {
+		opt(c)
 	}
-	return config
+	return c
 }
 
-func (config *Config) WithSeverityLevels(severityLevels map[string]Level) *Config {
-	for id, level := range severityLevels {
-		config.setLogLevel(id, level)
-	}
+// WithOptionalCheck adds a single check to the list of optional checks.
+func WithOptionalCheck(id string) Option {
+	return WithOptionalChecks([]string{id})
+}
 
-	return config
+// WithOptionalChecks overrides the log level of the given checks to ERR
+// so they will appear in `oasdiff breaking`.
+func WithOptionalChecks(ids []string) Option {
+	return func(c *Config) {
+		for _, id := range ids {
+			c.setLogLevel(id, ERR)
+		}
+	}
+}
+
+// WithSeverityLevels overrides per-check log levels from the given map.
+func WithSeverityLevels(severityLevels map[string]Level) Option {
+	return func(c *Config) {
+		for id, level := range severityLevels {
+			c.setLogLevel(id, level)
+		}
+	}
 }
 
 // WithDeprecation sets the number of days before sunset for deprecation warnings.
-func (config *Config) WithDeprecation(deprecationDaysBeta uint, deprecationDaysStable uint) *Config {
-	config.MinSunsetBetaDays = deprecationDaysBeta
-	config.MinSunsetStableDays = deprecationDaysStable
-	return config
+func WithDeprecation(deprecationDaysBeta uint, deprecationDaysStable uint) Option {
+	return func(c *Config) {
+		c.MinSunsetBetaDays = deprecationDaysBeta
+		c.MinSunsetStableDays = deprecationDaysStable
+	}
 }
 
-// WithSingleCheck sets a single check to be used.
-func (config *Config) WithSingleCheck(check BackwardCompatibilityCheck) *Config {
-	return config.WithChecks(BackwardCompatibilityChecks{check})
+// WithSingleCheck sets a single check to be used (replaces the
+// constructor's checks argument).
+func WithSingleCheck(check BackwardCompatibilityCheck) Option {
+	return WithChecks(BackwardCompatibilityChecks{check})
 }
 
-// WithChecks sets a list of checks to be used.
-func (config *Config) WithChecks(checks BackwardCompatibilityChecks) *Config {
-	config.Checks = checks
-	return config
+// WithChecks sets the list of checks to be used (replaces the
+// constructor's checks argument).
+func WithChecks(checks BackwardCompatibilityChecks) Option {
+	return func(c *Config) {
+		c.Checks = checks
+	}
 }
 
-// WithAttributes sets a list of attributes to be used.
-func (config *Config) WithAttributes(attributes []string) *Config {
-	config.Attributes = attributes
-	return config
+// WithAttributes sets the list of attributes to be used.
+func WithAttributes(attributes []string) Option {
+	return func(c *Config) {
+		c.Attributes = attributes
+	}
 }
 
 func (config *Config) getLogLevel(checkId string) Level {

--- a/checker/config_test.go
+++ b/checker/config_test.go
@@ -21,7 +21,7 @@ func TestNewConfig(t *testing.T) {
 }
 
 func TestNewConfigWithDeprecation(t *testing.T) {
-	config := allChecksConfig().WithDeprecation(10, 20)
+	config := allChecksConfig(checker.WithDeprecation(10, 20))
 	require.Len(t, config.Checks, numOfChecks)
 	require.Len(t, config.LogLevels, numOfIds)
 	require.Equal(t, uint(10), config.MinSunsetBetaDays)
@@ -30,12 +30,12 @@ func TestNewConfigWithDeprecation(t *testing.T) {
 
 func TestNewConfigWithOptionalCheck(t *testing.T) {
 	const id = checker.RequestPropertyDefaultValueChangedId
-	config := allChecksConfig().WithOptionalCheck(id)
+	config := allChecksConfig(checker.WithOptionalCheck(id))
 	require.Equal(t, checker.ERR, config.LogLevels[id])
 }
 
 func TestNewConfigWithSeverityLevels(t *testing.T) {
 	const id = checker.RequestPropertyDefaultValueChangedId
-	config := allChecksConfig().WithSeverityLevels(map[string]checker.Level{id: checker.ERR})
+	config := allChecksConfig(checker.WithSeverityLevels(map[string]checker.Level{id: checker.ERR}))
 	require.Equal(t, checker.ERR, config.LogLevels[id])
 }

--- a/checker/helpers_test.go
+++ b/checker/helpers_test.go
@@ -75,12 +75,12 @@ func getParameterDeprecationFile(file string) string {
 	return fmt.Sprintf("../data/param-deprecation/%s", file)
 }
 
-func singleCheckConfig(c checker.BackwardCompatibilityCheck) *checker.Config {
-	return checker.NewConfig(checker.BackwardCompatibilityChecks{c}).WithSingleCheck(c)
+func singleCheckConfig(c checker.BackwardCompatibilityCheck, opts ...checker.Option) *checker.Config {
+	return checker.NewConfig(checker.BackwardCompatibilityChecks{c}, append([]checker.Option{checker.WithSingleCheck(c)}, opts...)...)
 }
 
-func allChecksConfig() *checker.Config {
-	return checker.NewConfig(checker.GetAllChecks())
+func allChecksConfig(opts ...checker.Option) *checker.Config {
+	return checker.NewConfig(checker.GetAllChecks(), opts...)
 }
 
 func containsId(errs checker.Changes, id string) bool {

--- a/checker/ignore_test.go
+++ b/checker/ignore_test.go
@@ -59,7 +59,7 @@ func TestIgnoreComponent(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	errs := checker.CheckBackwardCompatibility(allChecksConfig().WithOptionalCheck(checker.APISchemasRemovedId), d, osm)
+	errs := checker.CheckBackwardCompatibility(allChecksConfig(checker.WithOptionalCheck(checker.APISchemasRemovedId)), d, osm)
 	require.Equal(t, 8, len(errs))
 
 	errs, err = checker.ProcessIgnoredBackwardCompatibilityErrors(checker.ERR, errs, "../data/ignore-err-example.txt", checker.NewDefaultLocalizer())

--- a/internal/changelog.go
+++ b/internal/changelog.go
@@ -58,7 +58,13 @@ func getChangelog(flags *Flags, stdout io.Writer, level checker.Level, isBreakin
 
 	errs, returnErr := filterIgnored(
 		checker.CheckBackwardCompatibilityUntilLevel(
-			checker.NewConfig(checker.GetAllChecks()).WithOptionalChecks(flags.getIncludeChecks()).WithSeverityLevels(severityLevels).WithDeprecation(flags.getDeprecationDaysBeta(), flags.getDeprecationDaysStable()).WithAttributes(flags.getAttributes()),
+			checker.NewConfig(
+				checker.GetAllChecks(),
+				checker.WithOptionalChecks(flags.getIncludeChecks()),
+				checker.WithSeverityLevels(severityLevels),
+				checker.WithDeprecation(flags.getDeprecationDaysBeta(), flags.getDeprecationDaysStable()),
+				checker.WithAttributes(flags.getAttributes()),
+			),
 			diffResult.diffReport,
 			diffResult.operationsSources,
 			level),


### PR DESCRIPTION
Per #864, migrate the 7 fluent `With*` methods on `*Config` to the standard Go functional-options pattern.

## Before

```go
bcConfig := checker.NewConfig(checker.GetAllChecks()).
    WithOptionalChecks(flags.getIncludeChecks()).
    WithSeverityLevels(severityLevels).
    WithDeprecation(...).
    WithAttributes(flags.getAttributes())
```

## After

```go
bcConfig := checker.NewConfig(checker.GetAllChecks(),
    checker.WithOptionalChecks(flags.getIncludeChecks()),
    checker.WithSeverityLevels(severityLevels),
    checker.WithDeprecation(...),
    checker.WithAttributes(flags.getAttributes()),
)
```

## Why

- Options are values: storable, composable, passable independently of a receiver.
- `NewConfig` controls mutation order (defaults applied first, then each option in order).
- No field mutation outside the constructor; `Config` can stay read-only after construction.
- Matches Go community convention (`grpc.DialOption`, `http.Server` middlewares, etc.).
- Closes the gap that prompted #864: `internal/changelog.go:61` had been bypassing the fluent chain with direct field assignment because `WithStabilityLevel` hadn't been added yet — with options as first-class values, this reach-around stops being necessary.

## Scope

- 7 methods converted: `WithOptionalCheck`, `WithOptionalChecks`, `WithSeverityLevels`, `WithDeprecation`, `WithSingleCheck`, `WithChecks`, `WithAttributes`.
- Old chained-method versions removed entirely (per the issue's "avoid ambiguity" call).
- ~50 call sites migrated across `internal/` and `checker/` tests.
- Test helpers (`allChecksConfig`, `singleCheckConfig`) now accept `...checker.Option` so the existing test ergonomics stay similar.

## Verification

Pure API-shape change, no behavior change. `go vet ./...` clean, `go test ./...` all packages green.

Closes #864.