### PR TITLE
chore(diff): migrate Config to functional options

### DIFF
--- a/diff/config.go
+++ b/diff/config.go
@@ -38,22 +38,39 @@ func GetExcludeDiffOptions() []string {
 	}
 }
 
-// NewConfig returns a default configuration
-func NewConfig() *Config {
-	return &Config{
+// Option configures a Config during NewConfig. Options compose: each
+// receives the Config after defaults and prior options have been
+// applied.
+type Option func(*Config)
+
+// NewConfig returns a default configuration, then applies the given
+// options in order.
+func NewConfig(opts ...Option) *Config {
+	c := &Config{
 		ExcludeElements:   utils.StringSet{},
 		ExcludeExtensions: utils.StringSet{},
 	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
 }
 
-func (config *Config) WithExcludeElements(excludeElements []string) *Config {
-	config.ExcludeElements = utils.StringSetFromSlice(excludeElements)
-	return config
+// WithExcludeElements sets the elements (description, summary,
+// endpoints, examples, extensions, title) to omit from the diff.
+func WithExcludeElements(excludeElements []string) Option {
+	return func(c *Config) {
+		c.ExcludeElements = utils.StringSetFromSlice(excludeElements)
+	}
 }
 
-func (config *Config) WithExcludeExtensions(excludeExtensions []string) *Config {
-	config.ExcludeExtensions = utils.StringSetFromSlice(excludeExtensions)
-	return config
+// WithExcludeExtensions sets specific OpenAPI extension names to omit
+// from the diff (only takes effect when "extensions" is also in
+// ExcludeElements).
+func WithExcludeExtensions(excludeExtensions []string) Option {
+	return func(c *Config) {
+		c.ExcludeExtensions = utils.StringSetFromSlice(excludeExtensions)
+	}
 }
 
 func (config *Config) IsExcludeExamples() bool {

--- a/diff/config_test.go
+++ b/diff/config_test.go
@@ -17,7 +17,7 @@ func TestConfig_Default(t *testing.T) {
 }
 
 func TestConfig_ExcludeElements(t *testing.T) {
-	c := diff.NewConfig().WithExcludeElements(diff.GetExcludeDiffOptions())
+	c := diff.NewConfig(diff.WithExcludeElements(diff.GetExcludeDiffOptions()))
 	require.True(t, c.IsExcludeExamples())
 	require.True(t, c.IsExcludeDescription())
 	require.True(t, c.IsExcludeEndpoints())

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -105,7 +105,7 @@ func TestModifiedExtension(t *testing.T) {
 }
 
 func TestExcludedExtension(t *testing.T) {
-	require.Nil(t, d(t, diff.NewConfig().WithExcludeElements([]string{diff.ExcludeExtensionsOption}), 1, 3).ExtensionsDiff)
+	require.Nil(t, d(t, diff.NewConfig(diff.WithExcludeElements([]string{diff.ExcludeExtensionsOption})), 1, 3).ExtensionsDiff)
 }
 
 func TestDiff_AddedGlobalTag(t *testing.T) {
@@ -945,7 +945,7 @@ func TestDiff_ExtensionsExcluded(t *testing.T) {
 	s2, err := load.NewSpecInfo(loader, load.NewSource("../data/extensions/revision.yaml"))
 	require.NoError(t, err)
 
-	d, _, err := diff.GetWithOperationsSourcesMap(diff.NewConfig().WithExcludeElements([]string{diff.ExcludeExtensionsOption}), s1, s2)
+	d, _, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(diff.WithExcludeElements([]string{diff.ExcludeExtensionsOption})), s1, s2)
 	require.NoError(t, err)
 	require.Empty(t, d)
 }
@@ -960,7 +960,7 @@ func TestDiff_ExtensionsExcludeSpecificName(t *testing.T) {
 	require.NoError(t, err)
 
 	// Exclude the specific extension that has changes
-	d, _, err := diff.GetWithOperationsSourcesMap(diff.NewConfig().WithExcludeExtensions([]string{"x-amazon-apigateway-integration"}), s1, s2)
+	d, _, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(diff.WithExcludeExtensions([]string{"x-amazon-apigateway-integration"})), s1, s2)
 	require.NoError(t, err)
 	require.Empty(t, d)
 }
@@ -975,7 +975,7 @@ func TestDiff_ExtensionsExcludeUnrelatedName(t *testing.T) {
 	require.NoError(t, err)
 
 	// Exclude a different extension name - should still show the diff for x-amazon-apigateway-integration
-	d, _, err := diff.GetWithOperationsSourcesMap(diff.NewConfig().WithExcludeExtensions([]string{"x-unrelated"}), s1, s2)
+	d, _, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(diff.WithExcludeExtensions([]string{"x-unrelated"})), s1, s2)
 	require.NoError(t, err)
 	dd := d.PathsDiff.Modified["/example/callback"].OperationsDiff.Modified["POST"].ExtensionsDiff.Modified["x-amazon-apigateway-integration"]
 	require.Len(t, dd, 2)

--- a/diff/diff_x_of_test.go
+++ b/diff/diff_x_of_test.go
@@ -194,7 +194,7 @@ func TestAnyOf_ExcludeDescriptions(t *testing.T) {
 	s2, err := loader.LoadFromFile(getXOfFile("anyof-rev-openapi.yml"))
 	require.NoError(t, err)
 
-	dd, err := diff.Get(diff.NewConfig().WithExcludeElements([]string{diff.ExcludeDescriptionOption}), s1, s2)
+	dd, err := diff.Get(diff.NewConfig(diff.WithExcludeElements([]string{diff.ExcludeDescriptionOption})), s1, s2)
 	require.NoError(t, err)
 	anyOfDiff := dd.PathsDiff.Modified["/test"].OperationsDiff.Modified["GET"].ResponsesDiff.Modified["200"].ContentDiff.MediaTypeModified["application/json"].SchemaDiff.AnyOfDiff
 	require.ElementsMatch(t, diff.Subschemas{

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -19,9 +19,10 @@ func NewFlags() *Flags {
 }
 
 func (flags *Flags) toConfig() *diff.Config {
-	config := diff.NewConfig().
-		WithExcludeElements(flags.getExcludeElements()).
-		WithExcludeExtensions(flags.getExcludeExtensions())
+	config := diff.NewConfig(
+		diff.WithExcludeElements(flags.getExcludeElements()),
+		diff.WithExcludeExtensions(flags.getExcludeExtensions()),
+	)
 	config.MatchPath = flags.v.GetString("match-path")
 	config.UnmatchPath = flags.v.GetString("unmatch-path")
 	config.FilterExtension = flags.v.GetString("filter-extension")


### PR DESCRIPTION
Follow-up to #911 (which migrated `checker.Config`). Same shape applied to `diff.Config`.

## Before

```go
diff.NewConfig().
    WithExcludeElements(elements).
    WithExcludeExtensions(extensions)
```

## After

```go
diff.NewConfig(
    diff.WithExcludeElements(elements),
    diff.WithExcludeExtensions(extensions),
)
```

## Scope

- 2 methods converted: `WithExcludeElements`, `WithExcludeExtensions`.
- Chained-method versions removed (consistent with #911).
- ~7 call sites migrated across `internal/flags.go` and the diff package tests.

## Why

Consistency with `checker.Config` (#911). Both packages now use the same Go-idiomatic options pattern, so contributors don't have to remember which package uses which style.

## Verification

Pure API-shape change, no behavior change. `go fmt ./...` and `go test ./...` clean.