### PR TITLE
fix(checker): clone PathsDiff before mutating it during checks (#904)

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -19,13 +19,19 @@ func CheckBackwardCompatibility(config *Config, diffReport *diff.Diff, operation
 	return CheckBackwardCompatibilityUntilLevel(config, diffReport, operationsSources, WARN)
 }
 
-// CheckBackwardCompatibilityUntilLevel runs the checks with level equal or higher than the given level
+// CheckBackwardCompatibilityUntilLevel runs the checks with level equal or higher than the given level.
+// The caller's diffReport is not mutated — internally we clone the
+// PathsDiff and the nested maps/slices that the check pipeline writes
+// to (the rest of the diff is shared by reference, since checks only
+// read it).
 func CheckBackwardCompatibilityUntilLevel(config *Config, diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, level Level) Changes {
 	result := make(Changes, 0)
 
 	if diffReport == nil {
 		return result
 	}
+
+	diffReport = clonePathsDiffForCheck(diffReport)
 
 	result = removeDraftAndAlphaOperationsDiffs(config, diffReport, result, operationsSources)
 
@@ -146,6 +152,53 @@ func getAPIInvalidStabilityLevel(config *Config, operation *openapi3.Operation, 
 		method,
 		path,
 	)
+}
+
+// clonePathsDiffForCheck returns a copy of diffReport whose PathsDiff —
+// and the specific nested fields the check pipeline writes to — are
+// separate allocations from the caller's. Everything outside that
+// mutation surface (WebhooksDiff, ComponentsDiff, etc., and the
+// MethodDiff/PathDiff values themselves, which are only read) is
+// shared by reference.
+//
+// Mutation surface (must be cloned):
+//   - PathsDiff struct itself (Deleted/Modified are reassigned)
+//   - PathsDiff.Deleted slice (truncated in-place)
+//   - PathsDiff.Modified map (webhook entries inserted, see
+//     mergeWebhookOperationsIntoPathsDiff)
+//   - For each PathDiff in PathsDiff.Modified: a fresh PathDiff
+//     because OperationsDiff.Deleted gets truncated and
+//     OperationsDiff.Modified has keys deleted.
+func clonePathsDiffForCheck(d *diff.Diff) *diff.Diff {
+	cloned := *d
+	if d.PathsDiff == nil {
+		return &cloned
+	}
+
+	pdCopy := *d.PathsDiff
+	cloned.PathsDiff = &pdCopy
+	cloned.PathsDiff.Deleted = slices.Clone(d.PathsDiff.Deleted)
+
+	if d.PathsDiff.Modified != nil {
+		cloned.PathsDiff.Modified = make(diff.ModifiedPaths, len(d.PathsDiff.Modified))
+		for k, v := range d.PathsDiff.Modified {
+			pdElem := *v
+			if v.OperationsDiff != nil {
+				odCopy := *v.OperationsDiff
+				pdElem.OperationsDiff = &odCopy
+				pdElem.OperationsDiff.Deleted = slices.Clone(v.OperationsDiff.Deleted)
+				if v.OperationsDiff.Modified != nil {
+					pdElem.OperationsDiff.Modified = make(diff.ModifiedOperations, len(v.OperationsDiff.Modified))
+					for ok, ov := range v.OperationsDiff.Modified {
+						pdElem.OperationsDiff.Modified[ok] = ov
+					}
+				}
+			}
+			cloned.PathsDiff.Modified[k] = &pdElem
+		}
+	}
+
+	return &cloned
 }
 
 // mergeWebhookOperationsIntoPathsDiff merges modified webhooks into PathsDiff.Modified with a "webhook:" prefix.

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -1,6 +1,7 @@
 package checker_test
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/oasdiff/oasdiff/checker"
@@ -94,4 +95,47 @@ func TestBreaking_InvalidNonJsonStabilityLevel(t *testing.T) {
 	require.Equal(t, checker.APIInvalidStabilityLevelId, errs[0].GetId())
 	require.Equal(t, "failed to parse stability level: `x-stability-level isn't a string nor valid json`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 	require.Equal(t, "../data/deprecation/base-invalid-stability-2.yaml", errs[0].GetSource())
+}
+
+// CheckBackwardCompatibilityUntilLevel must NOT mutate the caller's
+// diffReport. Two known mutation surfaces in the pipeline:
+//   - removeDraftAndAlphaOperationsDiffs filters PathsDiff.Deleted /
+//     OperationsDiff.Deleted / OperationsDiff.Modified.
+//   - mergeWebhookOperationsIntoPathsDiff inserts webhook entries
+//     under "webhook:..." keys into PathsDiff.Modified.
+//
+// Regression for #904.
+func TestBreaking_CheckDoesNotMutateCallerDiff(t *testing.T) {
+	s1, err := open("../data/checker/webhook_operation_base.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/checker/webhook_operation_revision.yaml")
+	require.NoError(t, err)
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	require.NotNil(t, d.WebhooksDiff)
+	require.NotEmpty(t, d.WebhooksDiff.Modified, "fixture must have modified webhooks to exercise the merge mutation site")
+
+	// Snapshot the parts of the diff that the check pipeline writes
+	// to.
+	beforeWebhooksLen := len(d.WebhooksDiff.Modified)
+	var beforePathsDeleted []string
+	var beforePathsModifiedLen int
+	if d.PathsDiff != nil {
+		beforePathsDeleted = slices.Clone(d.PathsDiff.Deleted)
+		beforePathsModifiedLen = len(d.PathsDiff.Modified)
+	}
+
+	_ = checker.CheckBackwardCompatibilityUntilLevel(allChecksConfig(), d, osm, checker.INFO)
+
+	// PathsDiff.Modified must NOT carry "webhook:..." keys after the
+	// call (the merge ran on a clone, not on the caller's PathsDiff).
+	if d.PathsDiff != nil {
+		for k := range d.PathsDiff.Modified {
+			require.NotContains(t, k, "webhook:", "webhook entry leaked back into caller's PathsDiff.Modified")
+		}
+		require.Equal(t, beforePathsModifiedLen, len(d.PathsDiff.Modified), "PathsDiff.Modified length changed")
+		require.Equal(t, beforePathsDeleted, d.PathsDiff.Deleted, "PathsDiff.Deleted slice changed")
+	}
+	require.Equal(t, beforeWebhooksLen, len(d.WebhooksDiff.Modified), "WebhooksDiff.Modified length changed")
 }


### PR DESCRIPTION
## Bug

`CheckBackwardCompatibilityUntilLevel` mutates the caller's `*diff.Diff` in place via two pipeline stages:

1. `removeDraftAndAlphaOperationsDiffs` — truncates `PathsDiff.Deleted`, truncates per-pathDiff `OperationsDiff.Deleted`, and deletes keys from `OperationsDiff.Modified` for draft/alpha operations.
2. `mergeWebhookOperationsIntoPathsDiff` — inserts `WebhooksDiff.Modified` entries into `PathsDiff.Modified` under `"webhook:..."` keys.

A caller that runs the checker and then inspects the diff sees truncated/modified state without warning. There was no documented contract about who owns the diff after the call.

## Fix

Clone `PathsDiff` and the nested fields the pipeline writes to at the top of `CheckBackwardCompatibilityUntilLevel`. The rest of the diff stays shared by reference because checks only read it.

Targeted clone — not a full deep-copy — keeps the surface small and the cost predictable. Documented inline with the precise mutation surface so future writes outside it are obvious.

## Test

`TestBreaking_CheckDoesNotMutateCallerDiff` snapshots `PathsDiff.Modified` / `.Deleted` / `WebhooksDiff.Modified` before the call and asserts they're unchanged after, including that no `"webhook:..."` key leaks back. Verified the test fails on main (without the fix) and passes after.

`go test ./...` clean.

Closes #904.