### PR TITLE
chore(checker): consolidate per-subdirectory test helpers (#906)

### DIFF
--- a/checker/check_api_deprecation_test.go
+++ b/checker/check_api_deprecation_test.go
@@ -15,10 +15,10 @@ import (
 // BC: deprecating an operation with a deprecation policy and an invalid sunset date is breaking
 func TestBreaking_DeprecationWithInvalidSunset(t *testing.T) {
 
-	s1, err := open(getDataFile("deprecation", "base.yaml"))
+	s1, err := open(deprecationFile("base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "deprecated-with-invalid-sunset.yaml"))
+	s2, err := open(deprecationFile("deprecated-with-invalid-sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -34,10 +34,10 @@ func TestBreaking_DeprecationWithInvalidSunset(t *testing.T) {
 // BC: deprecating an operation with a deprecation policy and an invalid stability level is breaking
 func TestBreaking_DeprecationWithInvalidStabilityLevel(t *testing.T) {
 
-	s1, err := open(getDataFile("deprecation", "base.yaml"))
+	s1, err := open(deprecationFile("base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "deprecated-with-invalid-stability.yaml"))
+	s2, err := open(deprecationFile("deprecated-with-invalid-stability.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -54,10 +54,10 @@ func TestBreaking_DeprecationWithInvalidStabilityLevel(t *testing.T) {
 // BC: deprecating an operation without a deprecation policy but without specifying sunset date is not breaking
 func TestBreaking_DeprecationWithoutSunsetNoPolicy(t *testing.T) {
 
-	s1, err := open(getDataFile("deprecation", "base.yaml"))
+	s1, err := open(deprecationFile("base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "deprecated-no-sunset.yaml"))
+	s2, err := open(deprecationFile("deprecated-no-sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -70,10 +70,10 @@ func TestBreaking_DeprecationWithoutSunsetNoPolicy(t *testing.T) {
 // BC: deprecating an operation with a deprecation policy but without specifying sunset date is breaking
 func TestBreaking_DeprecationWithoutSunsetWithPolicy(t *testing.T) {
 
-	s1, err := open(getDataFile("deprecation", "base.yaml"))
+	s1, err := open(deprecationFile("base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "deprecated-no-sunset.yaml"))
+	s2, err := open(deprecationFile("deprecated-no-sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -88,10 +88,10 @@ func TestBreaking_DeprecationWithoutSunsetWithPolicy(t *testing.T) {
 // BC: deprecating an operation with a default deprecation policy but without specifying sunset date is not breaking
 func TestBreaking_DeprecationWithoutSunset(t *testing.T) {
 
-	s1, err := open(getDataFile("deprecation", "base.yaml"))
+	s1, err := open(deprecationFile("base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "deprecated-no-sunset.yaml"))
+	s2, err := open(deprecationFile("deprecated-no-sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -104,10 +104,10 @@ func TestBreaking_DeprecationWithoutSunset(t *testing.T) {
 // BC: deprecating an operation without a deprecation policy and without specifying sunset date is not breaking for alpha level
 func TestBreaking_DeprecationForAlpha(t *testing.T) {
 
-	s1, err := open(getDataFile("deprecation", "base-alpha-stability.yaml"))
+	s1, err := open(deprecationFile("base-alpha-stability.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "deprecated-no-sunset-alpha-stability.yaml"))
+	s2, err := open(deprecationFile("deprecated-no-sunset-alpha-stability.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -118,12 +118,12 @@ func TestBreaking_DeprecationForAlpha(t *testing.T) {
 
 // BC: deprecating an operation without a deprecation policy and without specifying sunset date is not breaking for draft level
 func TestBreaking_DeprecationForDraft(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "base-alpha-stability.yaml"))
+	s1, err := open(deprecationFile("base-alpha-stability.yaml"))
 	require.NoError(t, err)
 	draft := toJson(t, checker.STABILITY_DRAFT)
 	s1.Spec.Paths.Value("/api/test").Get.Extensions["x-stability-level"] = draft
 
-	s2, err := open(getDataFile("deprecation", "deprecated-no-sunset-alpha-stability.yaml"))
+	s2, err := open(deprecationFile("deprecated-no-sunset-alpha-stability.yaml"))
 	require.NoError(t, err)
 	s2.Spec.Paths.Value("/api/test").Get.Extensions["x-stability-level"] = draft
 
@@ -142,10 +142,10 @@ func toJson(t *testing.T, value string) json.RawMessage {
 
 // BC: deprecating an operation with a deprecation policy and sunset date before required deprecation period is breaking
 func TestBreaking_DeprecationWithEarlySunset(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "base.yaml"))
+	s1, err := open(deprecationFile("base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "deprecated-future.yaml"))
+	s2, err := open(deprecationFile("deprecated-future.yaml"))
 	require.NoError(t, err)
 	sunsetDate := civil.DateOf(time.Now()).AddDays(9).String()
 	s2.Spec.Paths.Value("/api/test").Get.Extensions[diff.SunsetExtension] = toJson(t, sunsetDate)
@@ -163,10 +163,10 @@ func TestBreaking_DeprecationWithEarlySunset(t *testing.T) {
 // BC: deprecating an operation with a deprecation policy and sunset date after required deprecation period is not breaking
 func TestBreaking_DeprecationWithProperSunset(t *testing.T) {
 
-	s1, err := open(getDataFile("deprecation", "base.yaml"))
+	s1, err := open(deprecationFile("base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "deprecated-future.yaml"))
+	s2, err := open(deprecationFile("deprecated-future.yaml"))
 	require.NoError(t, err)
 
 	s2.Spec.Paths.Value("/api/test").Get.Extensions[diff.SunsetExtension] = toJson(t, civil.DateOf(time.Now()).AddDays(10).String())
@@ -184,10 +184,10 @@ func TestBreaking_DeprecationWithProperSunset(t *testing.T) {
 
 // CL: path operations that became deprecated
 func TestApiDeprecated_DetectsDeprecatedOperations(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "base.yaml"))
+	s1, err := open(deprecationFile("base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "deprecated-future.yaml"))
+	s2, err := open(deprecationFile("deprecated-future.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -207,10 +207,10 @@ func TestApiDeprecated_DetectsDeprecatedOperations(t *testing.T) {
 
 // CL: path operations that were re-activated
 func TestApiDeprecated_DetectsReactivatedOperations(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "deprecated-future.yaml"))
+	s1, err := open(deprecationFile("deprecated-future.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "base.yaml"))
+	s2, err := open(deprecationFile("base.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -230,10 +230,10 @@ func TestApiDeprecated_DetectsReactivatedOperations(t *testing.T) {
 
 func TestBreaking_InvaidStability(t *testing.T) {
 
-	s1, err := open(getDataFile("deprecation", "invalid-stability.yaml"))
+	s1, err := open(deprecationFile("invalid-stability.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "base-alpha-stability.yaml"))
+	s2, err := open(deprecationFile("base-alpha-stability.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -252,10 +252,10 @@ func TestBreaking_InvaidStability(t *testing.T) {
 
 // CL: message includes sunset details when endpoint deprecated with sunset date
 func TestApiDeprecated_MessageIncludesSunset(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "base.yaml"))
+	s1, err := open(deprecationFile("base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "deprecated-future.yaml"))
+	s2, err := open(deprecationFile("deprecated-future.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -271,10 +271,10 @@ func TestApiDeprecated_MessageIncludesSunset(t *testing.T) {
 
 // CL: message includes both sunset and stability when endpoint deprecated with both
 func TestApiDeprecated_MessageIncludesSunsetAndStability(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "base.yaml"))
+	s1, err := open(deprecationFile("base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "deprecated-future-beta-stability.yaml"))
+	s2, err := open(deprecationFile("deprecated-future-beta-stability.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -291,10 +291,10 @@ func TestApiDeprecated_MessageIncludesSunsetAndStability(t *testing.T) {
 
 // CL: message has no details when endpoint deprecated without sunset or stability
 func TestApiDeprecated_MessageWithoutDetails(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "base.yaml"))
+	s1, err := open(deprecationFile("base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "deprecated-no-sunset.yaml"))
+	s2, err := open(deprecationFile("deprecated-no-sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -310,10 +310,10 @@ func TestApiDeprecated_MessageWithoutDetails(t *testing.T) {
 
 // CL: message includes stability when endpoint deprecated with stability but no sunset
 func TestApiDeprecated_MessageIncludesStabilityOnly(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "base-beta-stability.yaml"))
+	s1, err := open(deprecationFile("base-beta-stability.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "deprecated-no-sunset-beta-stability.yaml"))
+	s2, err := open(deprecationFile("deprecated-no-sunset-beta-stability.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -329,10 +329,10 @@ func TestApiDeprecated_MessageIncludesStabilityOnly(t *testing.T) {
 
 // CL: deprecating an operation with a sunset date in RFC3339 format is properly parsed
 func TestBreaking_DeprecationWithRFC3339Sunset(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "base.yaml"))
+	s1, err := open(deprecationFile("base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "deprecated-future.yaml"))
+	s2, err := open(deprecationFile("deprecated-future.yaml"))
 	require.NoError(t, err)
 
 	// Use RFC3339 format (with time) instead of just date
@@ -352,10 +352,10 @@ func TestBreaking_DeprecationWithRFC3339Sunset(t *testing.T) {
 
 // BC: deprecating an operation with invalid JSON sunset date is breaking
 func TestBreaking_DeprecationWithInvalidJsonSunset(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "base.yaml"))
+	s1, err := open(deprecationFile("base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "deprecated-future.yaml"))
+	s2, err := open(deprecationFile("deprecated-future.yaml"))
 	require.NoError(t, err)
 
 	// Use invalid JSON that can't be unmarshaled to a string
@@ -372,10 +372,10 @@ func TestBreaking_DeprecationWithInvalidJsonSunset(t *testing.T) {
 
 // CL: endpoint deprecation message includes sunset date
 func TestEndpointDeprecation_MessageWithSunsetDate(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "base.yaml"))
+	s1, err := open(deprecationFile("base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "deprecated-future.yaml"))
+	s2, err := open(deprecationFile("deprecated-future.yaml"))
 	require.NoError(t, err)
 
 	// Use RFC3339 format (with time) instead of just date

--- a/checker/check_api_deprecation_test.go
+++ b/checker/check_api_deprecation_test.go
@@ -15,10 +15,10 @@ import (
 // BC: deprecating an operation with a deprecation policy and an invalid sunset date is breaking
 func TestBreaking_DeprecationWithInvalidSunset(t *testing.T) {
 
-	s1, err := open(getDeprecationFile("base.yaml"))
+	s1, err := open(getDataFile("deprecation", "base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("deprecated-with-invalid-sunset.yaml"))
+	s2, err := open(getDataFile("deprecation", "deprecated-with-invalid-sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -34,10 +34,10 @@ func TestBreaking_DeprecationWithInvalidSunset(t *testing.T) {
 // BC: deprecating an operation with a deprecation policy and an invalid stability level is breaking
 func TestBreaking_DeprecationWithInvalidStabilityLevel(t *testing.T) {
 
-	s1, err := open(getDeprecationFile("base.yaml"))
+	s1, err := open(getDataFile("deprecation", "base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("deprecated-with-invalid-stability.yaml"))
+	s2, err := open(getDataFile("deprecation", "deprecated-with-invalid-stability.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -54,10 +54,10 @@ func TestBreaking_DeprecationWithInvalidStabilityLevel(t *testing.T) {
 // BC: deprecating an operation without a deprecation policy but without specifying sunset date is not breaking
 func TestBreaking_DeprecationWithoutSunsetNoPolicy(t *testing.T) {
 
-	s1, err := open(getDeprecationFile("base.yaml"))
+	s1, err := open(getDataFile("deprecation", "base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("deprecated-no-sunset.yaml"))
+	s2, err := open(getDataFile("deprecation", "deprecated-no-sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -70,10 +70,10 @@ func TestBreaking_DeprecationWithoutSunsetNoPolicy(t *testing.T) {
 // BC: deprecating an operation with a deprecation policy but without specifying sunset date is breaking
 func TestBreaking_DeprecationWithoutSunsetWithPolicy(t *testing.T) {
 
-	s1, err := open(getDeprecationFile("base.yaml"))
+	s1, err := open(getDataFile("deprecation", "base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("deprecated-no-sunset.yaml"))
+	s2, err := open(getDataFile("deprecation", "deprecated-no-sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -88,10 +88,10 @@ func TestBreaking_DeprecationWithoutSunsetWithPolicy(t *testing.T) {
 // BC: deprecating an operation with a default deprecation policy but without specifying sunset date is not breaking
 func TestBreaking_DeprecationWithoutSunset(t *testing.T) {
 
-	s1, err := open(getDeprecationFile("base.yaml"))
+	s1, err := open(getDataFile("deprecation", "base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("deprecated-no-sunset.yaml"))
+	s2, err := open(getDataFile("deprecation", "deprecated-no-sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -104,10 +104,10 @@ func TestBreaking_DeprecationWithoutSunset(t *testing.T) {
 // BC: deprecating an operation without a deprecation policy and without specifying sunset date is not breaking for alpha level
 func TestBreaking_DeprecationForAlpha(t *testing.T) {
 
-	s1, err := open(getDeprecationFile("base-alpha-stability.yaml"))
+	s1, err := open(getDataFile("deprecation", "base-alpha-stability.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("deprecated-no-sunset-alpha-stability.yaml"))
+	s2, err := open(getDataFile("deprecation", "deprecated-no-sunset-alpha-stability.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -118,12 +118,12 @@ func TestBreaking_DeprecationForAlpha(t *testing.T) {
 
 // BC: deprecating an operation without a deprecation policy and without specifying sunset date is not breaking for draft level
 func TestBreaking_DeprecationForDraft(t *testing.T) {
-	s1, err := open(getDeprecationFile("base-alpha-stability.yaml"))
+	s1, err := open(getDataFile("deprecation", "base-alpha-stability.yaml"))
 	require.NoError(t, err)
 	draft := toJson(t, checker.STABILITY_DRAFT)
 	s1.Spec.Paths.Value("/api/test").Get.Extensions["x-stability-level"] = draft
 
-	s2, err := open(getDeprecationFile("deprecated-no-sunset-alpha-stability.yaml"))
+	s2, err := open(getDataFile("deprecation", "deprecated-no-sunset-alpha-stability.yaml"))
 	require.NoError(t, err)
 	s2.Spec.Paths.Value("/api/test").Get.Extensions["x-stability-level"] = draft
 
@@ -142,10 +142,10 @@ func toJson(t *testing.T, value string) json.RawMessage {
 
 // BC: deprecating an operation with a deprecation policy and sunset date before required deprecation period is breaking
 func TestBreaking_DeprecationWithEarlySunset(t *testing.T) {
-	s1, err := open(getDeprecationFile("base.yaml"))
+	s1, err := open(getDataFile("deprecation", "base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("deprecated-future.yaml"))
+	s2, err := open(getDataFile("deprecation", "deprecated-future.yaml"))
 	require.NoError(t, err)
 	sunsetDate := civil.DateOf(time.Now()).AddDays(9).String()
 	s2.Spec.Paths.Value("/api/test").Get.Extensions[diff.SunsetExtension] = toJson(t, sunsetDate)
@@ -163,10 +163,10 @@ func TestBreaking_DeprecationWithEarlySunset(t *testing.T) {
 // BC: deprecating an operation with a deprecation policy and sunset date after required deprecation period is not breaking
 func TestBreaking_DeprecationWithProperSunset(t *testing.T) {
 
-	s1, err := open(getDeprecationFile("base.yaml"))
+	s1, err := open(getDataFile("deprecation", "base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("deprecated-future.yaml"))
+	s2, err := open(getDataFile("deprecation", "deprecated-future.yaml"))
 	require.NoError(t, err)
 
 	s2.Spec.Paths.Value("/api/test").Get.Extensions[diff.SunsetExtension] = toJson(t, civil.DateOf(time.Now()).AddDays(10).String())
@@ -184,10 +184,10 @@ func TestBreaking_DeprecationWithProperSunset(t *testing.T) {
 
 // CL: path operations that became deprecated
 func TestApiDeprecated_DetectsDeprecatedOperations(t *testing.T) {
-	s1, err := open(getDeprecationFile("base.yaml"))
+	s1, err := open(getDataFile("deprecation", "base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("deprecated-future.yaml"))
+	s2, err := open(getDataFile("deprecation", "deprecated-future.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -207,10 +207,10 @@ func TestApiDeprecated_DetectsDeprecatedOperations(t *testing.T) {
 
 // CL: path operations that were re-activated
 func TestApiDeprecated_DetectsReactivatedOperations(t *testing.T) {
-	s1, err := open(getDeprecationFile("deprecated-future.yaml"))
+	s1, err := open(getDataFile("deprecation", "deprecated-future.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("base.yaml"))
+	s2, err := open(getDataFile("deprecation", "base.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -230,10 +230,10 @@ func TestApiDeprecated_DetectsReactivatedOperations(t *testing.T) {
 
 func TestBreaking_InvaidStability(t *testing.T) {
 
-	s1, err := open(getDeprecationFile("invalid-stability.yaml"))
+	s1, err := open(getDataFile("deprecation", "invalid-stability.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("base-alpha-stability.yaml"))
+	s2, err := open(getDataFile("deprecation", "base-alpha-stability.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -252,10 +252,10 @@ func TestBreaking_InvaidStability(t *testing.T) {
 
 // CL: message includes sunset details when endpoint deprecated with sunset date
 func TestApiDeprecated_MessageIncludesSunset(t *testing.T) {
-	s1, err := open(getDeprecationFile("base.yaml"))
+	s1, err := open(getDataFile("deprecation", "base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("deprecated-future.yaml"))
+	s2, err := open(getDataFile("deprecation", "deprecated-future.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -271,10 +271,10 @@ func TestApiDeprecated_MessageIncludesSunset(t *testing.T) {
 
 // CL: message includes both sunset and stability when endpoint deprecated with both
 func TestApiDeprecated_MessageIncludesSunsetAndStability(t *testing.T) {
-	s1, err := open(getDeprecationFile("base.yaml"))
+	s1, err := open(getDataFile("deprecation", "base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("deprecated-future-beta-stability.yaml"))
+	s2, err := open(getDataFile("deprecation", "deprecated-future-beta-stability.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -291,10 +291,10 @@ func TestApiDeprecated_MessageIncludesSunsetAndStability(t *testing.T) {
 
 // CL: message has no details when endpoint deprecated without sunset or stability
 func TestApiDeprecated_MessageWithoutDetails(t *testing.T) {
-	s1, err := open(getDeprecationFile("base.yaml"))
+	s1, err := open(getDataFile("deprecation", "base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("deprecated-no-sunset.yaml"))
+	s2, err := open(getDataFile("deprecation", "deprecated-no-sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -310,10 +310,10 @@ func TestApiDeprecated_MessageWithoutDetails(t *testing.T) {
 
 // CL: message includes stability when endpoint deprecated with stability but no sunset
 func TestApiDeprecated_MessageIncludesStabilityOnly(t *testing.T) {
-	s1, err := open(getDeprecationFile("base-beta-stability.yaml"))
+	s1, err := open(getDataFile("deprecation", "base-beta-stability.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("deprecated-no-sunset-beta-stability.yaml"))
+	s2, err := open(getDataFile("deprecation", "deprecated-no-sunset-beta-stability.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -329,10 +329,10 @@ func TestApiDeprecated_MessageIncludesStabilityOnly(t *testing.T) {
 
 // CL: deprecating an operation with a sunset date in RFC3339 format is properly parsed
 func TestBreaking_DeprecationWithRFC3339Sunset(t *testing.T) {
-	s1, err := open(getDeprecationFile("base.yaml"))
+	s1, err := open(getDataFile("deprecation", "base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("deprecated-future.yaml"))
+	s2, err := open(getDataFile("deprecation", "deprecated-future.yaml"))
 	require.NoError(t, err)
 
 	// Use RFC3339 format (with time) instead of just date
@@ -352,10 +352,10 @@ func TestBreaking_DeprecationWithRFC3339Sunset(t *testing.T) {
 
 // BC: deprecating an operation with invalid JSON sunset date is breaking
 func TestBreaking_DeprecationWithInvalidJsonSunset(t *testing.T) {
-	s1, err := open(getDeprecationFile("base.yaml"))
+	s1, err := open(getDataFile("deprecation", "base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("deprecated-future.yaml"))
+	s2, err := open(getDataFile("deprecation", "deprecated-future.yaml"))
 	require.NoError(t, err)
 
 	// Use invalid JSON that can't be unmarshaled to a string
@@ -372,10 +372,10 @@ func TestBreaking_DeprecationWithInvalidJsonSunset(t *testing.T) {
 
 // CL: endpoint deprecation message includes sunset date
 func TestEndpointDeprecation_MessageWithSunsetDate(t *testing.T) {
-	s1, err := open(getDeprecationFile("base.yaml"))
+	s1, err := open(getDataFile("deprecation", "base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("deprecated-future.yaml"))
+	s2, err := open(getDataFile("deprecation", "deprecated-future.yaml"))
 	require.NoError(t, err)
 
 	// Use RFC3339 format (with time) instead of just date

--- a/checker/check_api_removed_test.go
+++ b/checker/check_api_removed_test.go
@@ -41,10 +41,10 @@ func TestBreaking_DeletedOp(t *testing.T) {
 // BC: deleting an operation after sunset date is not breaking
 func TestBreaking_DeprecationPast(t *testing.T) {
 
-	s1, err := open(getDeprecationFile("deprecated-past.yaml"))
+	s1, err := open(getDataFile("deprecation", "deprecated-past.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("sunset.yaml"))
+	s2, err := open(getDataFile("deprecation", "sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -57,10 +57,10 @@ func TestBreaking_DeprecationPast(t *testing.T) {
 func TestBreaking_RemoveBeforeSunset(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
 
-	s1, err := open(getDeprecationFile("deprecated-future.yaml"), loader)
+	s1, err := open(getDataFile("deprecation", "deprecated-future.yaml"), loader)
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("sunset.yaml"), loader)
+	s2, err := open(getDataFile("deprecation", "sunset.yaml"), loader)
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -78,10 +78,10 @@ func TestBreaking_RemoveBeforeSunset(t *testing.T) {
 func TestBreaking_DeprecationNoSunset(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
 
-	s1, err := open(getDeprecationFile("deprecated-no-sunset.yaml"), loader)
+	s1, err := open(getDataFile("deprecation", "deprecated-no-sunset.yaml"), loader)
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("sunset.yaml"), loader)
+	s2, err := open(getDataFile("deprecation", "sunset.yaml"), loader)
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -97,13 +97,13 @@ func TestBreaking_DeprecationNoSunset(t *testing.T) {
 
 // BC: removing the path without a deprecation policy and without specifying sunset date is not breaking for alpha level
 func TestBreaking_RemovedPathForAlpha(t *testing.T) {
-	s1, err := open(getDeprecationFile("base-alpha-stability.yaml"))
+	s1, err := open(getDataFile("deprecation", "base-alpha-stability.yaml"))
 	require.NoError(t, err)
 	alpha := toJson(t, checker.STABILITY_ALPHA)
 	s1.Spec.Paths.Value("/api/test").Get.Extensions["x-stability-level"] = alpha
 	s1.Spec.Paths.Value("/api/test").Post.Extensions = map[string]any{"x-stability-level": alpha}
 
-	s2, err := open(getDeprecationFile("base-alpha-stability.yaml"))
+	s2, err := open(getDataFile("deprecation", "base-alpha-stability.yaml"))
 	require.NoError(t, err)
 
 	s2.Spec.Paths.Delete("/api/test")
@@ -116,13 +116,13 @@ func TestBreaking_RemovedPathForAlpha(t *testing.T) {
 
 // BC: removing the path without a deprecation policy and without specifying sunset date is not breaking for draft level
 func TestBreaking_RemovedPathForDraft(t *testing.T) {
-	s1, err := open(getDeprecationFile("base-alpha-stability.yaml"))
+	s1, err := open(getDataFile("deprecation", "base-alpha-stability.yaml"))
 	require.NoError(t, err)
 	draft := toJson(t, checker.STABILITY_DRAFT)
 	s1.Spec.Paths.Value("/api/test").Get.Extensions["x-stability-level"] = draft
 	s1.Spec.Paths.Value("/api/test").Post.Extensions = map[string]any{"x-stability-level": draft}
 
-	s2, err := open(getDeprecationFile("base-alpha-stability.yaml"))
+	s2, err := open(getDataFile("deprecation", "base-alpha-stability.yaml"))
 	require.NoError(t, err)
 
 	s2.Spec.Paths.Delete("/api/test")
@@ -136,10 +136,10 @@ func TestBreaking_RemovedPathForDraft(t *testing.T) {
 // BC: removing the path without a deprecation policy and without specifying sunset date is breaking for endpoints with non draft/alpha stability level
 func TestBreaking_RemovedPathForAlphaBreaking(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
-	s1, err := open(getDeprecationFile("base-alpha-stability.yaml"), loader)
+	s1, err := open(getDataFile("deprecation", "base-alpha-stability.yaml"), loader)
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("sunset-path.yaml"), loader)
+	s2, err := open(getDataFile("deprecation", "sunset-path.yaml"), loader)
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -155,10 +155,10 @@ func TestBreaking_RemovedPathForAlphaBreaking(t *testing.T) {
 // BC: removing the path without a deprecation policy and without specifying sunset date is breaking for endpoints with non draft/alpha stability level
 func TestBreaking_RemovedPathForDraftBreaking(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
-	s1, err := open(getDeprecationFile("base-draft-stability.yaml"), loader)
+	s1, err := open(getDataFile("deprecation", "base-draft-stability.yaml"), loader)
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("sunset-path.yaml"), loader)
+	s2, err := open(getDataFile("deprecation", "sunset-path.yaml"), loader)
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -174,10 +174,10 @@ func TestBreaking_RemovedPathForDraftBreaking(t *testing.T) {
 // BC: deleting a path after sunset date of all contained operations is not breaking
 func TestBreaking_DeprecationPathPast(t *testing.T) {
 
-	s1, err := open(getDeprecationFile("deprecated-path-past.yaml"))
+	s1, err := open(getDataFile("deprecation", "deprecated-path-past.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("sunset-path.yaml"))
+	s2, err := open(getDataFile("deprecation", "sunset-path.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -190,10 +190,10 @@ func TestBreaking_DeprecationPathPast(t *testing.T) {
 func TestBreaking_DeprecationPathMixed(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
 
-	s1, err := open(getDeprecationFile("deprecated-path-mixed.yaml"), loader)
+	s1, err := open(getDataFile("deprecation", "deprecated-path-mixed.yaml"), loader)
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("sunset-path.yaml"), loader)
+	s2, err := open(getDataFile("deprecation", "sunset-path.yaml"), loader)
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -211,10 +211,10 @@ func TestBreaking_DeprecationPathMixed(t *testing.T) {
 func TestBreaking_PathDeprecationNoSunset(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
 
-	s1, err := open(getDeprecationFile("deprecated-path-no-sunset.yaml"), loader)
+	s1, err := open(getDataFile("deprecation", "deprecated-path-no-sunset.yaml"), loader)
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("sunset-path.yaml"), loader)
+	s2, err := open(getDataFile("deprecation", "sunset-path.yaml"), loader)
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -235,10 +235,10 @@ func TestBreaking_PathDeprecationNoSunset(t *testing.T) {
 
 // BC: removing a deprecated enpoint with an invalid date is breaking
 func TestBreaking_RemoveEndpointWithInvalidSunset(t *testing.T) {
-	s1, err := open(getDeprecationFile("deprecated-invalid.yaml"), newLoaderWithOriginTracking())
+	s1, err := open(getDataFile("deprecation", "deprecated-invalid.yaml"), newLoaderWithOriginTracking())
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("deprecated-invalid.yaml"), newLoaderWithOriginTracking())
+	s2, err := open(getDataFile("deprecation", "deprecated-invalid.yaml"), newLoaderWithOriginTracking())
 	require.NoError(t, err)
 
 	s2.Spec.Paths.Find("/api/test").SetOperation("GET", nil)
@@ -259,10 +259,10 @@ func TestBreaking_RemoveEndpointWithInvalidSunset(t *testing.T) {
 func TestBreaking_DeprecationPathMixed_RFC3339_Sunset(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
 
-	s1, err := open(getDeprecationFile("deprecated-path-mixed-rfc3339-sunset.yaml"), loader)
+	s1, err := open(getDataFile("deprecation", "deprecated-path-mixed-rfc3339-sunset.yaml"), loader)
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("sunset-path.yaml"), loader)
+	s2, err := open(getDataFile("deprecation", "sunset-path.yaml"), loader)
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)

--- a/checker/check_api_removed_test.go
+++ b/checker/check_api_removed_test.go
@@ -41,10 +41,10 @@ func TestBreaking_DeletedOp(t *testing.T) {
 // BC: deleting an operation after sunset date is not breaking
 func TestBreaking_DeprecationPast(t *testing.T) {
 
-	s1, err := open(getDataFile("deprecation", "deprecated-past.yaml"))
+	s1, err := open(deprecationFile("deprecated-past.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "sunset.yaml"))
+	s2, err := open(deprecationFile("sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -57,10 +57,10 @@ func TestBreaking_DeprecationPast(t *testing.T) {
 func TestBreaking_RemoveBeforeSunset(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
 
-	s1, err := open(getDataFile("deprecation", "deprecated-future.yaml"), loader)
+	s1, err := open(deprecationFile("deprecated-future.yaml"), loader)
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "sunset.yaml"), loader)
+	s2, err := open(deprecationFile("sunset.yaml"), loader)
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -78,10 +78,10 @@ func TestBreaking_RemoveBeforeSunset(t *testing.T) {
 func TestBreaking_DeprecationNoSunset(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
 
-	s1, err := open(getDataFile("deprecation", "deprecated-no-sunset.yaml"), loader)
+	s1, err := open(deprecationFile("deprecated-no-sunset.yaml"), loader)
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "sunset.yaml"), loader)
+	s2, err := open(deprecationFile("sunset.yaml"), loader)
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -97,13 +97,13 @@ func TestBreaking_DeprecationNoSunset(t *testing.T) {
 
 // BC: removing the path without a deprecation policy and without specifying sunset date is not breaking for alpha level
 func TestBreaking_RemovedPathForAlpha(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "base-alpha-stability.yaml"))
+	s1, err := open(deprecationFile("base-alpha-stability.yaml"))
 	require.NoError(t, err)
 	alpha := toJson(t, checker.STABILITY_ALPHA)
 	s1.Spec.Paths.Value("/api/test").Get.Extensions["x-stability-level"] = alpha
 	s1.Spec.Paths.Value("/api/test").Post.Extensions = map[string]any{"x-stability-level": alpha}
 
-	s2, err := open(getDataFile("deprecation", "base-alpha-stability.yaml"))
+	s2, err := open(deprecationFile("base-alpha-stability.yaml"))
 	require.NoError(t, err)
 
 	s2.Spec.Paths.Delete("/api/test")
@@ -116,13 +116,13 @@ func TestBreaking_RemovedPathForAlpha(t *testing.T) {
 
 // BC: removing the path without a deprecation policy and without specifying sunset date is not breaking for draft level
 func TestBreaking_RemovedPathForDraft(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "base-alpha-stability.yaml"))
+	s1, err := open(deprecationFile("base-alpha-stability.yaml"))
 	require.NoError(t, err)
 	draft := toJson(t, checker.STABILITY_DRAFT)
 	s1.Spec.Paths.Value("/api/test").Get.Extensions["x-stability-level"] = draft
 	s1.Spec.Paths.Value("/api/test").Post.Extensions = map[string]any{"x-stability-level": draft}
 
-	s2, err := open(getDataFile("deprecation", "base-alpha-stability.yaml"))
+	s2, err := open(deprecationFile("base-alpha-stability.yaml"))
 	require.NoError(t, err)
 
 	s2.Spec.Paths.Delete("/api/test")
@@ -136,10 +136,10 @@ func TestBreaking_RemovedPathForDraft(t *testing.T) {
 // BC: removing the path without a deprecation policy and without specifying sunset date is breaking for endpoints with non draft/alpha stability level
 func TestBreaking_RemovedPathForAlphaBreaking(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
-	s1, err := open(getDataFile("deprecation", "base-alpha-stability.yaml"), loader)
+	s1, err := open(deprecationFile("base-alpha-stability.yaml"), loader)
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "sunset-path.yaml"), loader)
+	s2, err := open(deprecationFile("sunset-path.yaml"), loader)
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -155,10 +155,10 @@ func TestBreaking_RemovedPathForAlphaBreaking(t *testing.T) {
 // BC: removing the path without a deprecation policy and without specifying sunset date is breaking for endpoints with non draft/alpha stability level
 func TestBreaking_RemovedPathForDraftBreaking(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
-	s1, err := open(getDataFile("deprecation", "base-draft-stability.yaml"), loader)
+	s1, err := open(deprecationFile("base-draft-stability.yaml"), loader)
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "sunset-path.yaml"), loader)
+	s2, err := open(deprecationFile("sunset-path.yaml"), loader)
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -174,10 +174,10 @@ func TestBreaking_RemovedPathForDraftBreaking(t *testing.T) {
 // BC: deleting a path after sunset date of all contained operations is not breaking
 func TestBreaking_DeprecationPathPast(t *testing.T) {
 
-	s1, err := open(getDataFile("deprecation", "deprecated-path-past.yaml"))
+	s1, err := open(deprecationFile("deprecated-path-past.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "sunset-path.yaml"))
+	s2, err := open(deprecationFile("sunset-path.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -190,10 +190,10 @@ func TestBreaking_DeprecationPathPast(t *testing.T) {
 func TestBreaking_DeprecationPathMixed(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
 
-	s1, err := open(getDataFile("deprecation", "deprecated-path-mixed.yaml"), loader)
+	s1, err := open(deprecationFile("deprecated-path-mixed.yaml"), loader)
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "sunset-path.yaml"), loader)
+	s2, err := open(deprecationFile("sunset-path.yaml"), loader)
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -211,10 +211,10 @@ func TestBreaking_DeprecationPathMixed(t *testing.T) {
 func TestBreaking_PathDeprecationNoSunset(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
 
-	s1, err := open(getDataFile("deprecation", "deprecated-path-no-sunset.yaml"), loader)
+	s1, err := open(deprecationFile("deprecated-path-no-sunset.yaml"), loader)
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "sunset-path.yaml"), loader)
+	s2, err := open(deprecationFile("sunset-path.yaml"), loader)
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -235,10 +235,10 @@ func TestBreaking_PathDeprecationNoSunset(t *testing.T) {
 
 // BC: removing a deprecated enpoint with an invalid date is breaking
 func TestBreaking_RemoveEndpointWithInvalidSunset(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "deprecated-invalid.yaml"), newLoaderWithOriginTracking())
+	s1, err := open(deprecationFile("deprecated-invalid.yaml"), newLoaderWithOriginTracking())
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "deprecated-invalid.yaml"), newLoaderWithOriginTracking())
+	s2, err := open(deprecationFile("deprecated-invalid.yaml"), newLoaderWithOriginTracking())
 	require.NoError(t, err)
 
 	s2.Spec.Paths.Find("/api/test").SetOperation("GET", nil)
@@ -259,10 +259,10 @@ func TestBreaking_RemoveEndpointWithInvalidSunset(t *testing.T) {
 func TestBreaking_DeprecationPathMixed_RFC3339_Sunset(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
 
-	s1, err := open(getDataFile("deprecation", "deprecated-path-mixed-rfc3339-sunset.yaml"), loader)
+	s1, err := open(deprecationFile("deprecated-path-mixed-rfc3339-sunset.yaml"), loader)
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "sunset-path.yaml"), loader)
+	s2, err := open(deprecationFile("sunset-path.yaml"), loader)
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)

--- a/checker/check_api_sunset_changed_test.go
+++ b/checker/check_api_sunset_changed_test.go
@@ -11,10 +11,10 @@ import (
 // BC: deleting sunset header for a deprecated endpoint is breaking
 func TestBreaking_SunsetDeletedForDeprecatedEndpoint(t *testing.T) {
 
-	s1, err := open(getDeprecationFile("deprecated-with-sunset.yaml"))
+	s1, err := open(getDataFile("deprecation", "deprecated-with-sunset.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("deprecated-no-sunset.yaml"))
+	s2, err := open(getDataFile("deprecation", "deprecated-no-sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -29,10 +29,10 @@ func TestBreaking_SunsetDeletedForDeprecatedEndpoint(t *testing.T) {
 // BC: changing sunset to an earlier date for a deprecated endpoint with a deprecation policy is breaking
 func TestBreaking_SunsetModifiedForDeprecatedEndpoint(t *testing.T) {
 
-	s1, err := open(getDeprecationFile("deprecated-future.yaml"))
+	s1, err := open(getDataFile("deprecation", "deprecated-future.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("deprecated-past.yaml"))
+	s2, err := open(getDataFile("deprecation", "deprecated-past.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -47,10 +47,10 @@ func TestBreaking_SunsetModifiedForDeprecatedEndpoint(t *testing.T) {
 // BC: changing sunset to an invalid date for a deprecated endpoint is breaking
 func TestBreaking_SunsetModifiedToInvalidForDeprecatedEndpoint(t *testing.T) {
 
-	s1, err := open(getDeprecationFile("deprecated-future.yaml"))
+	s1, err := open(getDataFile("deprecation", "deprecated-future.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("deprecated-invalid.yaml"))
+	s2, err := open(getDataFile("deprecation", "deprecated-invalid.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -65,10 +65,10 @@ func TestBreaking_SunsetModifiedToInvalidForDeprecatedEndpoint(t *testing.T) {
 // BC: changing sunset from an invalid date for a deprecated endpoint is breaking
 func TestBreaking_SunsetModifiedFromInvalidForDeprecatedEndpoint(t *testing.T) {
 
-	s1, err := open(getDeprecationFile("deprecated-invalid.yaml"))
+	s1, err := open(getDataFile("deprecation", "deprecated-invalid.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("deprecated-future.yaml"))
+	s2, err := open(getDataFile("deprecation", "deprecated-future.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -84,10 +84,10 @@ func TestBreaking_SunsetModifiedFromInvalidForDeprecatedEndpoint(t *testing.T) {
 // BC: deleting other extension (not sunset) header for a deprecated endpoint is not breaking
 func TestBreaking_NonSunsetDeletedForDeprecatedEndpoint(t *testing.T) {
 
-	s1, err := open(getDeprecationFile("deprecated-with-other-extension.yaml"))
+	s1, err := open(getDataFile("deprecation", "deprecated-with-other-extension.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("deprecated-no-sunset.yaml"))
+	s2, err := open(getDataFile("deprecation", "deprecated-no-sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -99,10 +99,10 @@ func TestBreaking_NonSunsetDeletedForDeprecatedEndpoint(t *testing.T) {
 // BC: no change to headers for a deprecated endpoint is not breaking
 func TestBreaking_NoChangeToSunsetDeprecatedEndpoint(t *testing.T) {
 
-	s1, err := open(getDeprecationFile("deprecated-future.yaml"))
+	s1, err := open(getDataFile("deprecation", "deprecated-future.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("deprecated-future-2.yaml"))
+	s2, err := open(getDataFile("deprecation", "deprecated-future-2.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)

--- a/checker/check_api_sunset_changed_test.go
+++ b/checker/check_api_sunset_changed_test.go
@@ -11,10 +11,10 @@ import (
 // BC: deleting sunset header for a deprecated endpoint is breaking
 func TestBreaking_SunsetDeletedForDeprecatedEndpoint(t *testing.T) {
 
-	s1, err := open(getDataFile("deprecation", "deprecated-with-sunset.yaml"))
+	s1, err := open(deprecationFile("deprecated-with-sunset.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "deprecated-no-sunset.yaml"))
+	s2, err := open(deprecationFile("deprecated-no-sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -29,10 +29,10 @@ func TestBreaking_SunsetDeletedForDeprecatedEndpoint(t *testing.T) {
 // BC: changing sunset to an earlier date for a deprecated endpoint with a deprecation policy is breaking
 func TestBreaking_SunsetModifiedForDeprecatedEndpoint(t *testing.T) {
 
-	s1, err := open(getDataFile("deprecation", "deprecated-future.yaml"))
+	s1, err := open(deprecationFile("deprecated-future.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "deprecated-past.yaml"))
+	s2, err := open(deprecationFile("deprecated-past.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -47,10 +47,10 @@ func TestBreaking_SunsetModifiedForDeprecatedEndpoint(t *testing.T) {
 // BC: changing sunset to an invalid date for a deprecated endpoint is breaking
 func TestBreaking_SunsetModifiedToInvalidForDeprecatedEndpoint(t *testing.T) {
 
-	s1, err := open(getDataFile("deprecation", "deprecated-future.yaml"))
+	s1, err := open(deprecationFile("deprecated-future.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "deprecated-invalid.yaml"))
+	s2, err := open(deprecationFile("deprecated-invalid.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -65,10 +65,10 @@ func TestBreaking_SunsetModifiedToInvalidForDeprecatedEndpoint(t *testing.T) {
 // BC: changing sunset from an invalid date for a deprecated endpoint is breaking
 func TestBreaking_SunsetModifiedFromInvalidForDeprecatedEndpoint(t *testing.T) {
 
-	s1, err := open(getDataFile("deprecation", "deprecated-invalid.yaml"))
+	s1, err := open(deprecationFile("deprecated-invalid.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "deprecated-future.yaml"))
+	s2, err := open(deprecationFile("deprecated-future.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -84,10 +84,10 @@ func TestBreaking_SunsetModifiedFromInvalidForDeprecatedEndpoint(t *testing.T) {
 // BC: deleting other extension (not sunset) header for a deprecated endpoint is not breaking
 func TestBreaking_NonSunsetDeletedForDeprecatedEndpoint(t *testing.T) {
 
-	s1, err := open(getDataFile("deprecation", "deprecated-with-other-extension.yaml"))
+	s1, err := open(deprecationFile("deprecated-with-other-extension.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "deprecated-no-sunset.yaml"))
+	s2, err := open(deprecationFile("deprecated-no-sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -99,10 +99,10 @@ func TestBreaking_NonSunsetDeletedForDeprecatedEndpoint(t *testing.T) {
 // BC: no change to headers for a deprecated endpoint is not breaking
 func TestBreaking_NoChangeToSunsetDeprecatedEndpoint(t *testing.T) {
 
-	s1, err := open(getDataFile("deprecation", "deprecated-future.yaml"))
+	s1, err := open(deprecationFile("deprecated-future.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "deprecated-future-2.yaml"))
+	s2, err := open(deprecationFile("deprecated-future-2.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)

--- a/checker/check_breaking_property_test.go
+++ b/checker/check_breaking_property_test.go
@@ -101,10 +101,10 @@ func TestBreaking_PropertyRequiredDisabled(t *testing.T) {
 
 // BC: changing an existing property in response body to optional is breaking
 func TestBreaking_RespBodyRequiredPropertyDisabled(t *testing.T) {
-	s1, err := open(getReqPropFile("response-base.json"))
+	s1, err := open(getDataFile("required-properties", "response-base.json"))
 	require.NoError(t, err)
 
-	s2, err := open(getReqPropFile("response-revision.json"))
+	s2, err := open(getDataFile("required-properties", "response-revision.json"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -275,10 +275,10 @@ func TestBreaking_RespBodyEmbeddedPropertyNullable(t *testing.T) {
 
 // BC: changing a required property in response body to optional and also deleting it is breaking
 func TestBreaking_RespBodyDeleteAndDisableRequiredProperty(t *testing.T) {
-	s1, err := open(getReqPropFile("response-del-required-prop-base.yaml"))
+	s1, err := open(getDataFile("required-properties", "response-del-required-prop-base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getReqPropFile("response-del-required-prop-revision.yaml"))
+	s2, err := open(getDataFile("required-properties", "response-del-required-prop-revision.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -289,10 +289,10 @@ func TestBreaking_RespBodyDeleteAndDisableRequiredProperty(t *testing.T) {
 
 // BC: adding a non-existent required property in request body is not breaking
 func TestBreaking_ReqBodyNewRequiredPropertyNew(t *testing.T) {
-	s1, err := open(getReqPropFile("request-new-required-prop-base.yaml"))
+	s1, err := open(getDataFile("required-properties", "request-new-required-prop-base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getReqPropFile("request-new-required-prop-revision.yaml"))
+	s2, err := open(getDataFile("required-properties", "request-new-required-prop-revision.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -303,10 +303,10 @@ func TestBreaking_ReqBodyNewRequiredPropertyNew(t *testing.T) {
 
 // BC: changing an existing property in response body to required is not breaking
 func TestBreaking_RespBodyRequiredPropertyEnabled(t *testing.T) {
-	s1, err := open(getReqPropFile("response-revision.json"))
+	s1, err := open(getDataFile("required-properties", "response-revision.json"))
 	require.NoError(t, err)
 
-	s2, err := open(getReqPropFile("response-base.json"))
+	s2, err := open(getDataFile("required-properties", "response-base.json"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -317,10 +317,10 @@ func TestBreaking_RespBodyRequiredPropertyEnabled(t *testing.T) {
 
 // BC: changing an existing property in request body to optional is not breaking
 func TestBreaking_ReqBodyRequiredPropertyDisabled(t *testing.T) {
-	s1, err := open(getReqPropFile("request-base.yaml"))
+	s1, err := open(getDataFile("required-properties", "request-base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getReqPropFile("request-revision.yaml"))
+	s2, err := open(getDataFile("required-properties", "request-revision.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -331,10 +331,10 @@ func TestBreaking_ReqBodyRequiredPropertyDisabled(t *testing.T) {
 
 // BC: changing an existing property in request body to required is breaking
 func TestBreaking_ReqBodyRequiredPropertyEnabled(t *testing.T) {
-	s1, err := open(getReqPropFile("request-revision.yaml"))
+	s1, err := open(getDataFile("required-properties", "request-revision.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getReqPropFile("request-base.yaml"))
+	s2, err := open(getDataFile("required-properties", "request-base.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -347,10 +347,10 @@ func TestBreaking_ReqBodyRequiredPropertyEnabled(t *testing.T) {
 
 // BC: adding a new required property in request body is breaking
 func TestBreaking_ReqBodyNewRequiredProperty(t *testing.T) {
-	s1, err := open(getReqPropFile("request-new-base.yaml"))
+	s1, err := open(getDataFile("required-properties", "request-new-base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getReqPropFile("request-new-revision.yaml"))
+	s2, err := open(getDataFile("required-properties", "request-new-revision.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -363,10 +363,10 @@ func TestBreaking_ReqBodyNewRequiredProperty(t *testing.T) {
 
 // BC: deleting a required property in request is breaking with warn
 func TestBreaking_ReqBodyDeleteRequiredProperty(t *testing.T) {
-	s1, err := open(getReqPropFile("request-new-revision.yaml"))
+	s1, err := open(getDataFile("required-properties", "request-new-revision.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getReqPropFile("request-new-base.yaml"))
+	s2, err := open(getDataFile("required-properties", "request-new-base.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -380,10 +380,10 @@ func TestBreaking_ReqBodyDeleteRequiredProperty(t *testing.T) {
 
 // BC: deleting an embedded optional property in request is breaking with warn
 func TestBreaking_ReqBodyDeleteRequiredProperty2(t *testing.T) {
-	s1, err := open(getReqPropFile("request-property-items.yaml"))
+	s1, err := open(getDataFile("required-properties", "request-property-items.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getReqPropFile("request-property-items-2.yaml"))
+	s2, err := open(getDataFile("required-properties", "request-property-items-2.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -401,10 +401,10 @@ func TestBreaking_ReqBodyDeleteRequiredProperty2(t *testing.T) {
 
 // BC: adding a new required property in response body is not breaking
 func TestBreaking_RespBodyNewRequiredProperty(t *testing.T) {
-	s1, err := open(getReqPropFile("response-new-base.json"))
+	s1, err := open(getDataFile("required-properties", "response-new-base.json"))
 	require.NoError(t, err)
 
-	s2, err := open(getReqPropFile("response-new-revision.json"))
+	s2, err := open(getDataFile("required-properties", "response-new-revision.json"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -415,10 +415,10 @@ func TestBreaking_RespBodyNewRequiredProperty(t *testing.T) {
 
 // BC: deleting a required property in response body is breaking
 func TestBreaking_RespBodyDeleteRequiredProperty(t *testing.T) {
-	s1, err := open(getReqPropFile("response-new-revision.json"))
+	s1, err := open(getDataFile("required-properties", "response-new-revision.json"))
 	require.NoError(t, err)
 
-	s2, err := open(getReqPropFile("response-new-base.json"))
+	s2, err := open(getDataFile("required-properties", "response-new-base.json"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -431,10 +431,10 @@ func TestBreaking_RespBodyDeleteRequiredProperty(t *testing.T) {
 
 // BC: adding a new required property under AllOf in response body is not breaking
 func TestBreaking_RespBodyNewAllOfRequiredProperty(t *testing.T) {
-	s1, err := open(getReqPropFile("response-allof-base.json"))
+	s1, err := open(getDataFile("required-properties", "response-allof-base.json"))
 	require.NoError(t, err)
 
-	s2, err := open(getReqPropFile("response-allof-revision.json"))
+	s2, err := open(getDataFile("required-properties", "response-allof-revision.json"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -445,10 +445,10 @@ func TestBreaking_RespBodyNewAllOfRequiredProperty(t *testing.T) {
 
 // BC: deleting a required property under AllOf in response body is breaking
 func TestBreaking_RespBodyDeleteAllOfRequiredProperty(t *testing.T) {
-	s1, err := open(getReqPropFile("response-allof-revision.json"))
+	s1, err := open(getDataFile("required-properties", "response-allof-revision.json"))
 	require.NoError(t, err)
 
-	s2, err := open(getReqPropFile("response-allof-base.json"))
+	s2, err := open(getDataFile("required-properties", "response-allof-base.json"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -461,10 +461,10 @@ func TestBreaking_RespBodyDeleteAllOfRequiredProperty(t *testing.T) {
 
 // BC: adding a new required read-only property in request body is not breaking
 func TestBreaking_ReadOnlyNewRequiredProperty(t *testing.T) {
-	s1, err := open(getReqPropFile("read-only-new-base.yaml"))
+	s1, err := open(getDataFile("required-properties", "read-only-new-base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getReqPropFile("read-only-new-revision.yaml"))
+	s2, err := open(getDataFile("required-properties", "read-only-new-revision.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -475,10 +475,10 @@ func TestBreaking_ReadOnlyNewRequiredProperty(t *testing.T) {
 
 // BC: changing an existing read-only property in request body to required is not breaking
 func TestBreaking_ReadOnlyPropertyRequiredEnabled(t *testing.T) {
-	s1, err := open(getReqPropFile("read-only-base.yaml"))
+	s1, err := open(getDataFile("required-properties", "read-only-base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getReqPropFile("read-only-revision.yaml"))
+	s2, err := open(getDataFile("required-properties", "read-only-revision.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -489,10 +489,10 @@ func TestBreaking_ReadOnlyPropertyRequiredEnabled(t *testing.T) {
 
 // BC: deleting a required write-only property in response body is not breaking
 func TestBreaking_WriteOnlyDeleteRequiredProperty(t *testing.T) {
-	s1, err := open(getReqPropFile("write-only-delete-base.yaml"))
+	s1, err := open(getDataFile("required-properties", "write-only-delete-base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getReqPropFile("write-only-delete-revision.yaml"))
+	s2, err := open(getDataFile("required-properties", "write-only-delete-revision.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -506,10 +506,10 @@ func TestBreaking_WriteOnlyDeleteRequiredProperty(t *testing.T) {
 
 // BC: deleting a non-required non-write-only property in response body is breaking with warning
 func TestBreaking_WriteOnlyDeleteNonRequiredProperty(t *testing.T) {
-	s1, err := open(getReqPropFile("write-only-delete-partial-base.yaml"))
+	s1, err := open(getDataFile("required-properties", "write-only-delete-partial-base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getReqPropFile("write-only-delete-partial-revision.yaml"))
+	s2, err := open(getDataFile("required-properties", "write-only-delete-partial-revision.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -527,10 +527,10 @@ func TestBreaking_WriteOnlyDeleteNonRequiredProperty(t *testing.T) {
 
 // BC: changing an existing write-only property in response body to optional is not breaking
 func TestBreaking_WriteOnlyPropertyRequiredDisabled(t *testing.T) {
-	s1, err := open(getReqPropFile("write-only-base.yaml"))
+	s1, err := open(getDataFile("required-properties", "write-only-base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getReqPropFile("write-only-revision.yaml"))
+	s2, err := open(getDataFile("required-properties", "write-only-revision.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -541,10 +541,10 @@ func TestBreaking_WriteOnlyPropertyRequiredDisabled(t *testing.T) {
 
 // BC: changing an existing required property in response body to write-only is not breaking
 func TestBreaking_RequiredPropertyWriteOnlyEnabled(t *testing.T) {
-	s1, err := open(getReqPropFile("write-only-changed-base.yaml"))
+	s1, err := open(getDataFile("required-properties", "write-only-changed-base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getReqPropFile("write-only-changed-revision.yaml"))
+	s2, err := open(getDataFile("required-properties", "write-only-changed-revision.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -555,10 +555,10 @@ func TestBreaking_RequiredPropertyWriteOnlyEnabled(t *testing.T) {
 
 // BC: changing an existing required property in response body to not-write-only is breaking
 func TestBreaking_RequiredPropertyWriteOnlyDisabled(t *testing.T) {
-	s1, err := open(getReqPropFile("write-only-changed-revision.yaml"))
+	s1, err := open(getDataFile("required-properties", "write-only-changed-revision.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getReqPropFile("write-only-changed-base.yaml"))
+	s2, err := open(getDataFile("required-properties", "write-only-changed-base.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -574,10 +574,10 @@ func TestBreaking_RequiredPropertyWriteOnlyDisabled(t *testing.T) {
 
 // BC: changing an existing property in request body to required is breaking
 func TestBreaking_Body(t *testing.T) {
-	s1, err := open(getReqPropFile("body1.yaml"))
+	s1, err := open(getDataFile("required-properties", "body1.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getReqPropFile("body2.yaml"))
+	s2, err := open(getDataFile("required-properties", "body2.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -591,10 +591,10 @@ func TestBreaking_Body(t *testing.T) {
 
 // BC: changing an existing property in request body items to required is breaking
 func TestBreaking_Items(t *testing.T) {
-	s1, err := open(getReqPropFile("items1.yaml"))
+	s1, err := open(getDataFile("required-properties", "items1.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getReqPropFile("items2.yaml"))
+	s2, err := open(getDataFile("required-properties", "items2.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -608,10 +608,10 @@ func TestBreaking_Items(t *testing.T) {
 
 // BC: changing an existing property in request body items to required with a default value is not breaking
 func TestBreaking_ItemsWithDefault(t *testing.T) {
-	s1, err := open(getReqPropFile("items1.yaml"))
+	s1, err := open(getDataFile("required-properties", "items1.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getReqPropFile("items3.yaml"))
+	s2, err := open(getDataFile("required-properties", "items3.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -622,10 +622,10 @@ func TestBreaking_ItemsWithDefault(t *testing.T) {
 
 // BC: changing an existing property in request body anyOf to required is breaking
 func TestBreaking_AnyOf(t *testing.T) {
-	s1, err := open(getReqPropFile("anyOf1.yaml"))
+	s1, err := open(getDataFile("required-properties", "anyOf1.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getReqPropFile("anyOf2.yaml"))
+	s2, err := open(getDataFile("required-properties", "anyOf2.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -638,10 +638,10 @@ func TestBreaking_AnyOf(t *testing.T) {
 
 // BC: changing an existing property under another property in request body to required is breaking
 func TestBreaking_NestedProp(t *testing.T) {
-	s1, err := open(getReqPropFile("nested-property1.yaml"))
+	s1, err := open(getDataFile("required-properties", "nested-property1.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getReqPropFile("nested-property2.yaml"))
+	s2, err := open(getDataFile("required-properties", "nested-property2.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)

--- a/checker/check_breaking_property_test.go
+++ b/checker/check_breaking_property_test.go
@@ -101,10 +101,10 @@ func TestBreaking_PropertyRequiredDisabled(t *testing.T) {
 
 // BC: changing an existing property in response body to optional is breaking
 func TestBreaking_RespBodyRequiredPropertyDisabled(t *testing.T) {
-	s1, err := open(getDataFile("required-properties", "response-base.json"))
+	s1, err := open(requiredPropertyFile("response-base.json"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("required-properties", "response-revision.json"))
+	s2, err := open(requiredPropertyFile("response-revision.json"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -275,10 +275,10 @@ func TestBreaking_RespBodyEmbeddedPropertyNullable(t *testing.T) {
 
 // BC: changing a required property in response body to optional and also deleting it is breaking
 func TestBreaking_RespBodyDeleteAndDisableRequiredProperty(t *testing.T) {
-	s1, err := open(getDataFile("required-properties", "response-del-required-prop-base.yaml"))
+	s1, err := open(requiredPropertyFile("response-del-required-prop-base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("required-properties", "response-del-required-prop-revision.yaml"))
+	s2, err := open(requiredPropertyFile("response-del-required-prop-revision.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -289,10 +289,10 @@ func TestBreaking_RespBodyDeleteAndDisableRequiredProperty(t *testing.T) {
 
 // BC: adding a non-existent required property in request body is not breaking
 func TestBreaking_ReqBodyNewRequiredPropertyNew(t *testing.T) {
-	s1, err := open(getDataFile("required-properties", "request-new-required-prop-base.yaml"))
+	s1, err := open(requiredPropertyFile("request-new-required-prop-base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("required-properties", "request-new-required-prop-revision.yaml"))
+	s2, err := open(requiredPropertyFile("request-new-required-prop-revision.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -303,10 +303,10 @@ func TestBreaking_ReqBodyNewRequiredPropertyNew(t *testing.T) {
 
 // BC: changing an existing property in response body to required is not breaking
 func TestBreaking_RespBodyRequiredPropertyEnabled(t *testing.T) {
-	s1, err := open(getDataFile("required-properties", "response-revision.json"))
+	s1, err := open(requiredPropertyFile("response-revision.json"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("required-properties", "response-base.json"))
+	s2, err := open(requiredPropertyFile("response-base.json"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -317,10 +317,10 @@ func TestBreaking_RespBodyRequiredPropertyEnabled(t *testing.T) {
 
 // BC: changing an existing property in request body to optional is not breaking
 func TestBreaking_ReqBodyRequiredPropertyDisabled(t *testing.T) {
-	s1, err := open(getDataFile("required-properties", "request-base.yaml"))
+	s1, err := open(requiredPropertyFile("request-base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("required-properties", "request-revision.yaml"))
+	s2, err := open(requiredPropertyFile("request-revision.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -331,10 +331,10 @@ func TestBreaking_ReqBodyRequiredPropertyDisabled(t *testing.T) {
 
 // BC: changing an existing property in request body to required is breaking
 func TestBreaking_ReqBodyRequiredPropertyEnabled(t *testing.T) {
-	s1, err := open(getDataFile("required-properties", "request-revision.yaml"))
+	s1, err := open(requiredPropertyFile("request-revision.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("required-properties", "request-base.yaml"))
+	s2, err := open(requiredPropertyFile("request-base.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -347,10 +347,10 @@ func TestBreaking_ReqBodyRequiredPropertyEnabled(t *testing.T) {
 
 // BC: adding a new required property in request body is breaking
 func TestBreaking_ReqBodyNewRequiredProperty(t *testing.T) {
-	s1, err := open(getDataFile("required-properties", "request-new-base.yaml"))
+	s1, err := open(requiredPropertyFile("request-new-base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("required-properties", "request-new-revision.yaml"))
+	s2, err := open(requiredPropertyFile("request-new-revision.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -363,10 +363,10 @@ func TestBreaking_ReqBodyNewRequiredProperty(t *testing.T) {
 
 // BC: deleting a required property in request is breaking with warn
 func TestBreaking_ReqBodyDeleteRequiredProperty(t *testing.T) {
-	s1, err := open(getDataFile("required-properties", "request-new-revision.yaml"))
+	s1, err := open(requiredPropertyFile("request-new-revision.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("required-properties", "request-new-base.yaml"))
+	s2, err := open(requiredPropertyFile("request-new-base.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -380,10 +380,10 @@ func TestBreaking_ReqBodyDeleteRequiredProperty(t *testing.T) {
 
 // BC: deleting an embedded optional property in request is breaking with warn
 func TestBreaking_ReqBodyDeleteRequiredProperty2(t *testing.T) {
-	s1, err := open(getDataFile("required-properties", "request-property-items.yaml"))
+	s1, err := open(requiredPropertyFile("request-property-items.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("required-properties", "request-property-items-2.yaml"))
+	s2, err := open(requiredPropertyFile("request-property-items-2.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -401,10 +401,10 @@ func TestBreaking_ReqBodyDeleteRequiredProperty2(t *testing.T) {
 
 // BC: adding a new required property in response body is not breaking
 func TestBreaking_RespBodyNewRequiredProperty(t *testing.T) {
-	s1, err := open(getDataFile("required-properties", "response-new-base.json"))
+	s1, err := open(requiredPropertyFile("response-new-base.json"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("required-properties", "response-new-revision.json"))
+	s2, err := open(requiredPropertyFile("response-new-revision.json"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -415,10 +415,10 @@ func TestBreaking_RespBodyNewRequiredProperty(t *testing.T) {
 
 // BC: deleting a required property in response body is breaking
 func TestBreaking_RespBodyDeleteRequiredProperty(t *testing.T) {
-	s1, err := open(getDataFile("required-properties", "response-new-revision.json"))
+	s1, err := open(requiredPropertyFile("response-new-revision.json"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("required-properties", "response-new-base.json"))
+	s2, err := open(requiredPropertyFile("response-new-base.json"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -431,10 +431,10 @@ func TestBreaking_RespBodyDeleteRequiredProperty(t *testing.T) {
 
 // BC: adding a new required property under AllOf in response body is not breaking
 func TestBreaking_RespBodyNewAllOfRequiredProperty(t *testing.T) {
-	s1, err := open(getDataFile("required-properties", "response-allof-base.json"))
+	s1, err := open(requiredPropertyFile("response-allof-base.json"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("required-properties", "response-allof-revision.json"))
+	s2, err := open(requiredPropertyFile("response-allof-revision.json"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -445,10 +445,10 @@ func TestBreaking_RespBodyNewAllOfRequiredProperty(t *testing.T) {
 
 // BC: deleting a required property under AllOf in response body is breaking
 func TestBreaking_RespBodyDeleteAllOfRequiredProperty(t *testing.T) {
-	s1, err := open(getDataFile("required-properties", "response-allof-revision.json"))
+	s1, err := open(requiredPropertyFile("response-allof-revision.json"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("required-properties", "response-allof-base.json"))
+	s2, err := open(requiredPropertyFile("response-allof-base.json"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -461,10 +461,10 @@ func TestBreaking_RespBodyDeleteAllOfRequiredProperty(t *testing.T) {
 
 // BC: adding a new required read-only property in request body is not breaking
 func TestBreaking_ReadOnlyNewRequiredProperty(t *testing.T) {
-	s1, err := open(getDataFile("required-properties", "read-only-new-base.yaml"))
+	s1, err := open(requiredPropertyFile("read-only-new-base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("required-properties", "read-only-new-revision.yaml"))
+	s2, err := open(requiredPropertyFile("read-only-new-revision.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -475,10 +475,10 @@ func TestBreaking_ReadOnlyNewRequiredProperty(t *testing.T) {
 
 // BC: changing an existing read-only property in request body to required is not breaking
 func TestBreaking_ReadOnlyPropertyRequiredEnabled(t *testing.T) {
-	s1, err := open(getDataFile("required-properties", "read-only-base.yaml"))
+	s1, err := open(requiredPropertyFile("read-only-base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("required-properties", "read-only-revision.yaml"))
+	s2, err := open(requiredPropertyFile("read-only-revision.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -489,10 +489,10 @@ func TestBreaking_ReadOnlyPropertyRequiredEnabled(t *testing.T) {
 
 // BC: deleting a required write-only property in response body is not breaking
 func TestBreaking_WriteOnlyDeleteRequiredProperty(t *testing.T) {
-	s1, err := open(getDataFile("required-properties", "write-only-delete-base.yaml"))
+	s1, err := open(requiredPropertyFile("write-only-delete-base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("required-properties", "write-only-delete-revision.yaml"))
+	s2, err := open(requiredPropertyFile("write-only-delete-revision.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -506,10 +506,10 @@ func TestBreaking_WriteOnlyDeleteRequiredProperty(t *testing.T) {
 
 // BC: deleting a non-required non-write-only property in response body is breaking with warning
 func TestBreaking_WriteOnlyDeleteNonRequiredProperty(t *testing.T) {
-	s1, err := open(getDataFile("required-properties", "write-only-delete-partial-base.yaml"))
+	s1, err := open(requiredPropertyFile("write-only-delete-partial-base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("required-properties", "write-only-delete-partial-revision.yaml"))
+	s2, err := open(requiredPropertyFile("write-only-delete-partial-revision.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -527,10 +527,10 @@ func TestBreaking_WriteOnlyDeleteNonRequiredProperty(t *testing.T) {
 
 // BC: changing an existing write-only property in response body to optional is not breaking
 func TestBreaking_WriteOnlyPropertyRequiredDisabled(t *testing.T) {
-	s1, err := open(getDataFile("required-properties", "write-only-base.yaml"))
+	s1, err := open(requiredPropertyFile("write-only-base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("required-properties", "write-only-revision.yaml"))
+	s2, err := open(requiredPropertyFile("write-only-revision.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -541,10 +541,10 @@ func TestBreaking_WriteOnlyPropertyRequiredDisabled(t *testing.T) {
 
 // BC: changing an existing required property in response body to write-only is not breaking
 func TestBreaking_RequiredPropertyWriteOnlyEnabled(t *testing.T) {
-	s1, err := open(getDataFile("required-properties", "write-only-changed-base.yaml"))
+	s1, err := open(requiredPropertyFile("write-only-changed-base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("required-properties", "write-only-changed-revision.yaml"))
+	s2, err := open(requiredPropertyFile("write-only-changed-revision.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -555,10 +555,10 @@ func TestBreaking_RequiredPropertyWriteOnlyEnabled(t *testing.T) {
 
 // BC: changing an existing required property in response body to not-write-only is breaking
 func TestBreaking_RequiredPropertyWriteOnlyDisabled(t *testing.T) {
-	s1, err := open(getDataFile("required-properties", "write-only-changed-revision.yaml"))
+	s1, err := open(requiredPropertyFile("write-only-changed-revision.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("required-properties", "write-only-changed-base.yaml"))
+	s2, err := open(requiredPropertyFile("write-only-changed-base.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -574,10 +574,10 @@ func TestBreaking_RequiredPropertyWriteOnlyDisabled(t *testing.T) {
 
 // BC: changing an existing property in request body to required is breaking
 func TestBreaking_Body(t *testing.T) {
-	s1, err := open(getDataFile("required-properties", "body1.yaml"))
+	s1, err := open(requiredPropertyFile("body1.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("required-properties", "body2.yaml"))
+	s2, err := open(requiredPropertyFile("body2.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -591,10 +591,10 @@ func TestBreaking_Body(t *testing.T) {
 
 // BC: changing an existing property in request body items to required is breaking
 func TestBreaking_Items(t *testing.T) {
-	s1, err := open(getDataFile("required-properties", "items1.yaml"))
+	s1, err := open(requiredPropertyFile("items1.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("required-properties", "items2.yaml"))
+	s2, err := open(requiredPropertyFile("items2.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -608,10 +608,10 @@ func TestBreaking_Items(t *testing.T) {
 
 // BC: changing an existing property in request body items to required with a default value is not breaking
 func TestBreaking_ItemsWithDefault(t *testing.T) {
-	s1, err := open(getDataFile("required-properties", "items1.yaml"))
+	s1, err := open(requiredPropertyFile("items1.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("required-properties", "items3.yaml"))
+	s2, err := open(requiredPropertyFile("items3.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -622,10 +622,10 @@ func TestBreaking_ItemsWithDefault(t *testing.T) {
 
 // BC: changing an existing property in request body anyOf to required is breaking
 func TestBreaking_AnyOf(t *testing.T) {
-	s1, err := open(getDataFile("required-properties", "anyOf1.yaml"))
+	s1, err := open(requiredPropertyFile("anyOf1.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("required-properties", "anyOf2.yaml"))
+	s2, err := open(requiredPropertyFile("anyOf2.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -638,10 +638,10 @@ func TestBreaking_AnyOf(t *testing.T) {
 
 // BC: changing an existing property under another property in request body to required is breaking
 func TestBreaking_NestedProp(t *testing.T) {
-	s1, err := open(getDataFile("required-properties", "nested-property1.yaml"))
+	s1, err := open(requiredPropertyFile("nested-property1.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("required-properties", "nested-property2.yaml"))
+	s2, err := open(requiredPropertyFile("nested-property2.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)

--- a/checker/check_request_parameter_deprecation_test.go
+++ b/checker/check_request_parameter_deprecation_test.go
@@ -14,10 +14,10 @@ import (
 // BC: deprecating a parameter with a deprecation policy and an invalid sunset date is breaking
 func TestBreaking_ParameterDeprecationWithInvalidSunset(t *testing.T) {
 
-	s1, err := open(getDataFile("param-deprecation", "base.yaml"))
+	s1, err := open(paramDeprecationFile("base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("param-deprecation", "deprecated-invalid.yaml"))
+	s2, err := open(paramDeprecationFile("deprecated-invalid.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -33,10 +33,10 @@ func TestBreaking_ParameterDeprecationWithInvalidSunset(t *testing.T) {
 // BC: deprecating a parameter without a deprecation policy but without specifying sunset date is not breaking
 func TestBreaking_ParameterDeprecationWithoutSunsetNoPolicy(t *testing.T) {
 
-	s1, err := open(getDataFile("param-deprecation", "base.yaml"))
+	s1, err := open(paramDeprecationFile("base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("param-deprecation", "deprecated-no-sunset.yaml"))
+	s2, err := open(paramDeprecationFile("deprecated-no-sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -49,10 +49,10 @@ func TestBreaking_ParameterDeprecationWithoutSunsetNoPolicy(t *testing.T) {
 // BC: deprecating a parameter with a deprecation policy but without specifying sunset date is breaking
 func TestBreaking_ParameterDeprecationWithoutSunsetWithPolicy(t *testing.T) {
 
-	s1, err := open(getDataFile("param-deprecation", "base.yaml"))
+	s1, err := open(paramDeprecationFile("base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("param-deprecation", "deprecated-no-sunset.yaml"))
+	s2, err := open(paramDeprecationFile("deprecated-no-sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -67,10 +67,10 @@ func TestBreaking_ParameterDeprecationWithoutSunsetWithPolicy(t *testing.T) {
 // BC: deprecating a parameter with a default deprecation policy but without specifying sunset date is not breaking
 func TestBreaking_ParameterDeprecationWithoutSunset(t *testing.T) {
 
-	s1, err := open(getDataFile("param-deprecation", "base.yaml"))
+	s1, err := open(paramDeprecationFile("base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("param-deprecation", "deprecated-no-sunset.yaml"))
+	s2, err := open(paramDeprecationFile("deprecated-no-sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -83,10 +83,10 @@ func TestBreaking_ParameterDeprecationWithoutSunset(t *testing.T) {
 // BC: deprecating an operation without a deprecation policy and without specifying sunset date is not breaking for alpha level
 func TestBreaking_ParameterDeprecationForAlpha(t *testing.T) {
 
-	s1, err := open(getDataFile("param-deprecation", "base-alpha-stability.yaml"))
+	s1, err := open(paramDeprecationFile("base-alpha-stability.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("param-deprecation", "deprecated-no-sunset-alpha-stability.yaml"))
+	s2, err := open(paramDeprecationFile("deprecated-no-sunset-alpha-stability.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -97,10 +97,10 @@ func TestBreaking_ParameterDeprecationForAlpha(t *testing.T) {
 
 // BC: deprecating a parameter with a deprecation policy and sunset date before required deprecation period is breaking
 func TestBreaking_ParameterDeprecationWithEarlySunset(t *testing.T) {
-	s1, err := open(getDataFile("param-deprecation", "base.yaml"))
+	s1, err := open(paramDeprecationFile("base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("param-deprecation", "deprecated-future.yaml"))
+	s2, err := open(paramDeprecationFile("deprecated-future.yaml"))
 	require.NoError(t, err)
 	sunsetDate := civil.DateOf(time.Now()).AddDays(9).String()
 
@@ -119,10 +119,10 @@ func TestBreaking_ParameterDeprecationWithEarlySunset(t *testing.T) {
 // BC: deprecating a parameter with a deprecation policy and sunset date after required deprecation period is not breaking
 func TestBreaking_ParameterDeprecationWithProperSunset(t *testing.T) {
 
-	s1, err := open(getDataFile("param-deprecation", "base.yaml"))
+	s1, err := open(paramDeprecationFile("base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("param-deprecation", "deprecated-future.yaml"))
+	s2, err := open(paramDeprecationFile("deprecated-future.yaml"))
 	require.NoError(t, err)
 
 	s2.Spec.Paths.Value("/api/test").GetOperation("GET").Parameters.GetByInAndName("query", "id").Extensions[diff.SunsetExtension] = toJson(t, civil.DateOf(time.Now()).AddDays(10).String())
@@ -140,10 +140,10 @@ func TestBreaking_ParameterDeprecationWithProperSunset(t *testing.T) {
 
 // CL: parameters that became deprecated
 func TestParameterDeprecated_DetectsDeprecated(t *testing.T) {
-	s1, err := open(getDataFile("param-deprecation", "base.yaml"))
+	s1, err := open(paramDeprecationFile("base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("param-deprecation", "deprecated-future.yaml"))
+	s2, err := open(paramDeprecationFile("deprecated-future.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -163,10 +163,10 @@ func TestParameterDeprecated_DetectsDeprecated(t *testing.T) {
 
 // CL: parameters that were re-activated
 func TestParameterDeprecated_DetectsReactivated(t *testing.T) {
-	s1, err := open(getDataFile("param-deprecation", "deprecated-future.yaml"))
+	s1, err := open(paramDeprecationFile("deprecated-future.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("param-deprecation", "base.yaml"))
+	s2, err := open(paramDeprecationFile("base.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -186,10 +186,10 @@ func TestParameterDeprecated_DetectsReactivated(t *testing.T) {
 
 // CL: message includes sunset details when parameter deprecated with sunset date
 func TestParameterDeprecated_MessageIncludesSunset(t *testing.T) {
-	s1, err := open(getDataFile("param-deprecation", "base.yaml"))
+	s1, err := open(paramDeprecationFile("base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("param-deprecation", "deprecated-future.yaml"))
+	s2, err := open(paramDeprecationFile("deprecated-future.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -205,10 +205,10 @@ func TestParameterDeprecated_MessageIncludesSunset(t *testing.T) {
 
 // CL: message includes both sunset and stability when parameter deprecated with both
 func TestParameterDeprecated_MessageIncludesSunsetAndStability(t *testing.T) {
-	s1, err := open(getDataFile("param-deprecation", "base-beta-stability.yaml"))
+	s1, err := open(paramDeprecationFile("base-beta-stability.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("param-deprecation", "deprecated-future-beta-stability.yaml"))
+	s2, err := open(paramDeprecationFile("deprecated-future-beta-stability.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -224,10 +224,10 @@ func TestParameterDeprecated_MessageIncludesSunsetAndStability(t *testing.T) {
 
 // CL: message has no details when parameter deprecated without sunset or stability
 func TestParameterDeprecated_MessageWithoutDetails(t *testing.T) {
-	s1, err := open(getDataFile("param-deprecation", "base.yaml"))
+	s1, err := open(paramDeprecationFile("base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("param-deprecation", "deprecated-no-sunset.yaml"))
+	s2, err := open(paramDeprecationFile("deprecated-no-sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -243,10 +243,10 @@ func TestParameterDeprecated_MessageWithoutDetails(t *testing.T) {
 
 // CL: message includes stability when parameter deprecated with stability but no sunset
 func TestParameterDeprecated_MessageIncludesStabilityOnly(t *testing.T) {
-	s1, err := open(getDataFile("param-deprecation", "base-beta-stability.yaml"))
+	s1, err := open(paramDeprecationFile("base-beta-stability.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("param-deprecation", "deprecated-no-sunset-beta-stability.yaml"))
+	s2, err := open(paramDeprecationFile("deprecated-no-sunset-beta-stability.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)

--- a/checker/check_request_parameter_deprecation_test.go
+++ b/checker/check_request_parameter_deprecation_test.go
@@ -14,10 +14,10 @@ import (
 // BC: deprecating a parameter with a deprecation policy and an invalid sunset date is breaking
 func TestBreaking_ParameterDeprecationWithInvalidSunset(t *testing.T) {
 
-	s1, err := open(getParameterDeprecationFile("base.yaml"))
+	s1, err := open(getDataFile("param-deprecation", "base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getParameterDeprecationFile("deprecated-invalid.yaml"))
+	s2, err := open(getDataFile("param-deprecation", "deprecated-invalid.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -33,10 +33,10 @@ func TestBreaking_ParameterDeprecationWithInvalidSunset(t *testing.T) {
 // BC: deprecating a parameter without a deprecation policy but without specifying sunset date is not breaking
 func TestBreaking_ParameterDeprecationWithoutSunsetNoPolicy(t *testing.T) {
 
-	s1, err := open(getParameterDeprecationFile("base.yaml"))
+	s1, err := open(getDataFile("param-deprecation", "base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getParameterDeprecationFile("deprecated-no-sunset.yaml"))
+	s2, err := open(getDataFile("param-deprecation", "deprecated-no-sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -49,10 +49,10 @@ func TestBreaking_ParameterDeprecationWithoutSunsetNoPolicy(t *testing.T) {
 // BC: deprecating a parameter with a deprecation policy but without specifying sunset date is breaking
 func TestBreaking_ParameterDeprecationWithoutSunsetWithPolicy(t *testing.T) {
 
-	s1, err := open(getParameterDeprecationFile("base.yaml"))
+	s1, err := open(getDataFile("param-deprecation", "base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getParameterDeprecationFile("deprecated-no-sunset.yaml"))
+	s2, err := open(getDataFile("param-deprecation", "deprecated-no-sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -67,10 +67,10 @@ func TestBreaking_ParameterDeprecationWithoutSunsetWithPolicy(t *testing.T) {
 // BC: deprecating a parameter with a default deprecation policy but without specifying sunset date is not breaking
 func TestBreaking_ParameterDeprecationWithoutSunset(t *testing.T) {
 
-	s1, err := open(getParameterDeprecationFile("base.yaml"))
+	s1, err := open(getDataFile("param-deprecation", "base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getParameterDeprecationFile("deprecated-no-sunset.yaml"))
+	s2, err := open(getDataFile("param-deprecation", "deprecated-no-sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -83,10 +83,10 @@ func TestBreaking_ParameterDeprecationWithoutSunset(t *testing.T) {
 // BC: deprecating an operation without a deprecation policy and without specifying sunset date is not breaking for alpha level
 func TestBreaking_ParameterDeprecationForAlpha(t *testing.T) {
 
-	s1, err := open(getParameterDeprecationFile("base-alpha-stability.yaml"))
+	s1, err := open(getDataFile("param-deprecation", "base-alpha-stability.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getParameterDeprecationFile("deprecated-no-sunset-alpha-stability.yaml"))
+	s2, err := open(getDataFile("param-deprecation", "deprecated-no-sunset-alpha-stability.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -97,10 +97,10 @@ func TestBreaking_ParameterDeprecationForAlpha(t *testing.T) {
 
 // BC: deprecating a parameter with a deprecation policy and sunset date before required deprecation period is breaking
 func TestBreaking_ParameterDeprecationWithEarlySunset(t *testing.T) {
-	s1, err := open(getParameterDeprecationFile("base.yaml"))
+	s1, err := open(getDataFile("param-deprecation", "base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getParameterDeprecationFile("deprecated-future.yaml"))
+	s2, err := open(getDataFile("param-deprecation", "deprecated-future.yaml"))
 	require.NoError(t, err)
 	sunsetDate := civil.DateOf(time.Now()).AddDays(9).String()
 
@@ -119,10 +119,10 @@ func TestBreaking_ParameterDeprecationWithEarlySunset(t *testing.T) {
 // BC: deprecating a parameter with a deprecation policy and sunset date after required deprecation period is not breaking
 func TestBreaking_ParameterDeprecationWithProperSunset(t *testing.T) {
 
-	s1, err := open(getParameterDeprecationFile("base.yaml"))
+	s1, err := open(getDataFile("param-deprecation", "base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getParameterDeprecationFile("deprecated-future.yaml"))
+	s2, err := open(getDataFile("param-deprecation", "deprecated-future.yaml"))
 	require.NoError(t, err)
 
 	s2.Spec.Paths.Value("/api/test").GetOperation("GET").Parameters.GetByInAndName("query", "id").Extensions[diff.SunsetExtension] = toJson(t, civil.DateOf(time.Now()).AddDays(10).String())
@@ -140,10 +140,10 @@ func TestBreaking_ParameterDeprecationWithProperSunset(t *testing.T) {
 
 // CL: parameters that became deprecated
 func TestParameterDeprecated_DetectsDeprecated(t *testing.T) {
-	s1, err := open(getParameterDeprecationFile("base.yaml"))
+	s1, err := open(getDataFile("param-deprecation", "base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getParameterDeprecationFile("deprecated-future.yaml"))
+	s2, err := open(getDataFile("param-deprecation", "deprecated-future.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -163,10 +163,10 @@ func TestParameterDeprecated_DetectsDeprecated(t *testing.T) {
 
 // CL: parameters that were re-activated
 func TestParameterDeprecated_DetectsReactivated(t *testing.T) {
-	s1, err := open(getParameterDeprecationFile("deprecated-future.yaml"))
+	s1, err := open(getDataFile("param-deprecation", "deprecated-future.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getParameterDeprecationFile("base.yaml"))
+	s2, err := open(getDataFile("param-deprecation", "base.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -186,10 +186,10 @@ func TestParameterDeprecated_DetectsReactivated(t *testing.T) {
 
 // CL: message includes sunset details when parameter deprecated with sunset date
 func TestParameterDeprecated_MessageIncludesSunset(t *testing.T) {
-	s1, err := open(getParameterDeprecationFile("base.yaml"))
+	s1, err := open(getDataFile("param-deprecation", "base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getParameterDeprecationFile("deprecated-future.yaml"))
+	s2, err := open(getDataFile("param-deprecation", "deprecated-future.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -205,10 +205,10 @@ func TestParameterDeprecated_MessageIncludesSunset(t *testing.T) {
 
 // CL: message includes both sunset and stability when parameter deprecated with both
 func TestParameterDeprecated_MessageIncludesSunsetAndStability(t *testing.T) {
-	s1, err := open(getParameterDeprecationFile("base-beta-stability.yaml"))
+	s1, err := open(getDataFile("param-deprecation", "base-beta-stability.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getParameterDeprecationFile("deprecated-future-beta-stability.yaml"))
+	s2, err := open(getDataFile("param-deprecation", "deprecated-future-beta-stability.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -224,10 +224,10 @@ func TestParameterDeprecated_MessageIncludesSunsetAndStability(t *testing.T) {
 
 // CL: message has no details when parameter deprecated without sunset or stability
 func TestParameterDeprecated_MessageWithoutDetails(t *testing.T) {
-	s1, err := open(getParameterDeprecationFile("base.yaml"))
+	s1, err := open(getDataFile("param-deprecation", "base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getParameterDeprecationFile("deprecated-no-sunset.yaml"))
+	s2, err := open(getDataFile("param-deprecation", "deprecated-no-sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -243,10 +243,10 @@ func TestParameterDeprecated_MessageWithoutDetails(t *testing.T) {
 
 // CL: message includes stability when parameter deprecated with stability but no sunset
 func TestParameterDeprecated_MessageIncludesStabilityOnly(t *testing.T) {
-	s1, err := open(getParameterDeprecationFile("base-beta-stability.yaml"))
+	s1, err := open(getDataFile("param-deprecation", "base-beta-stability.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getParameterDeprecationFile("deprecated-no-sunset-beta-stability.yaml"))
+	s2, err := open(getDataFile("param-deprecation", "deprecated-no-sunset-beta-stability.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)

--- a/checker/check_request_parameter_removed_test.go
+++ b/checker/check_request_parameter_removed_test.go
@@ -10,10 +10,10 @@ import (
 
 // BC: deleting a parameter without deprecation is breaking
 func TestBreaking_DeletedParameter(t *testing.T) {
-	s1, err := open(getDataFile("param-deprecation", "base.yaml"))
+	s1, err := open(paramDeprecationFile("base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("param-deprecation", "sunset.yaml"))
+	s2, err := open(paramDeprecationFile("sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -28,10 +28,10 @@ func TestBreaking_DeletedParameter(t *testing.T) {
 // BC: deleting a parameter after sunset date is not breaking
 func TestBreaking_ParameterDeprecationPast(t *testing.T) {
 
-	s1, err := open(getDataFile("param-deprecation", "deprecated-past.yaml"))
+	s1, err := open(paramDeprecationFile("deprecated-past.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("param-deprecation", "sunset.yaml"))
+	s2, err := open(paramDeprecationFile("sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -43,10 +43,10 @@ func TestBreaking_ParameterDeprecationPast(t *testing.T) {
 // BC: deleting a parameter before sunset date is breaking
 func TestBreaking_ParameterDeprecationFuture(t *testing.T) {
 
-	s1, err := open(getDataFile("param-deprecation", "deprecated-future.yaml"))
+	s1, err := open(paramDeprecationFile("deprecated-future.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("param-deprecation", "sunset.yaml"))
+	s2, err := open(paramDeprecationFile("sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -61,10 +61,10 @@ func TestBreaking_ParameterDeprecationFuture(t *testing.T) {
 // BC: deleting a deprecated parameter without sunset date is not breaking
 func TestBreaking_ParameterDeprecationNoSunset(t *testing.T) {
 
-	s1, err := open(getDataFile("param-deprecation", "deprecated-no-sunset.yaml"))
+	s1, err := open(paramDeprecationFile("deprecated-no-sunset.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("param-deprecation", "sunset.yaml"))
+	s2, err := open(paramDeprecationFile("sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -75,10 +75,10 @@ func TestBreaking_ParameterDeprecationNoSunset(t *testing.T) {
 
 // BC: removing a parameter without a deprecation policy and without specifying sunset date is not breaking for alpha level
 func TestBreaking_RemovedParameterForAlpha(t *testing.T) {
-	s1, err := open(getDataFile("param-deprecation", "base-alpha-stability.yaml"))
+	s1, err := open(paramDeprecationFile("base-alpha-stability.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("param-deprecation", "sunset-alpha-stability.yaml"))
+	s2, err := open(paramDeprecationFile("sunset-alpha-stability.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -90,10 +90,10 @@ func TestBreaking_RemovedParameterForAlpha(t *testing.T) {
 // BC: removing a deprecated parameter with an invalid date is breaking
 func TestBreaking_RemoveParameterWithInvalidSunset(t *testing.T) {
 
-	s1, err := open(getDataFile("param-deprecation", "deprecated-invalid.yaml"))
+	s1, err := open(paramDeprecationFile("deprecated-invalid.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("param-deprecation", "sunset.yaml"))
+	s2, err := open(paramDeprecationFile("sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)

--- a/checker/check_request_parameter_removed_test.go
+++ b/checker/check_request_parameter_removed_test.go
@@ -10,10 +10,10 @@ import (
 
 // BC: deleting a parameter without deprecation is breaking
 func TestBreaking_DeletedParameter(t *testing.T) {
-	s1, err := open(getParameterDeprecationFile("base.yaml"))
+	s1, err := open(getDataFile("param-deprecation", "base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getParameterDeprecationFile("sunset.yaml"))
+	s2, err := open(getDataFile("param-deprecation", "sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -28,10 +28,10 @@ func TestBreaking_DeletedParameter(t *testing.T) {
 // BC: deleting a parameter after sunset date is not breaking
 func TestBreaking_ParameterDeprecationPast(t *testing.T) {
 
-	s1, err := open(getParameterDeprecationFile("deprecated-past.yaml"))
+	s1, err := open(getDataFile("param-deprecation", "deprecated-past.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getParameterDeprecationFile("sunset.yaml"))
+	s2, err := open(getDataFile("param-deprecation", "sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -43,10 +43,10 @@ func TestBreaking_ParameterDeprecationPast(t *testing.T) {
 // BC: deleting a parameter before sunset date is breaking
 func TestBreaking_ParameterDeprecationFuture(t *testing.T) {
 
-	s1, err := open(getParameterDeprecationFile("deprecated-future.yaml"))
+	s1, err := open(getDataFile("param-deprecation", "deprecated-future.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getParameterDeprecationFile("sunset.yaml"))
+	s2, err := open(getDataFile("param-deprecation", "sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -61,10 +61,10 @@ func TestBreaking_ParameterDeprecationFuture(t *testing.T) {
 // BC: deleting a deprecated parameter without sunset date is not breaking
 func TestBreaking_ParameterDeprecationNoSunset(t *testing.T) {
 
-	s1, err := open(getParameterDeprecationFile("deprecated-no-sunset.yaml"))
+	s1, err := open(getDataFile("param-deprecation", "deprecated-no-sunset.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getParameterDeprecationFile("sunset.yaml"))
+	s2, err := open(getDataFile("param-deprecation", "sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -75,10 +75,10 @@ func TestBreaking_ParameterDeprecationNoSunset(t *testing.T) {
 
 // BC: removing a parameter without a deprecation policy and without specifying sunset date is not breaking for alpha level
 func TestBreaking_RemovedParameterForAlpha(t *testing.T) {
-	s1, err := open(getParameterDeprecationFile("base-alpha-stability.yaml"))
+	s1, err := open(getDataFile("param-deprecation", "base-alpha-stability.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getParameterDeprecationFile("sunset-alpha-stability.yaml"))
+	s2, err := open(getDataFile("param-deprecation", "sunset-alpha-stability.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -90,10 +90,10 @@ func TestBreaking_RemovedParameterForAlpha(t *testing.T) {
 // BC: removing a deprecated parameter with an invalid date is breaking
 func TestBreaking_RemoveParameterWithInvalidSunset(t *testing.T) {
 
-	s1, err := open(getParameterDeprecationFile("deprecated-invalid.yaml"))
+	s1, err := open(getDataFile("param-deprecation", "deprecated-invalid.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getParameterDeprecationFile("sunset.yaml"))
+	s2, err := open(getDataFile("param-deprecation", "sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)

--- a/checker/check_request_parameter_sunset_changed_test.go
+++ b/checker/check_request_parameter_sunset_changed_test.go
@@ -11,10 +11,10 @@ import (
 // BC: deleting sunset header for a deprecated parameter is breaking
 func TestBreaking_SunsetDeletedForDeprecatedParameter(t *testing.T) {
 
-	s1, err := open(getDataFile("param-deprecation", "deprecated-with-sunset.yaml"))
+	s1, err := open(paramDeprecationFile("deprecated-with-sunset.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("param-deprecation", "deprecated-no-sunset.yaml"))
+	s2, err := open(paramDeprecationFile("deprecated-no-sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -29,10 +29,10 @@ func TestBreaking_SunsetDeletedForDeprecatedParameter(t *testing.T) {
 // BC: deleting sunset header for a deprecated parameter is breaking even if the parameter is renamed
 func TestBreaking_SunsetDeletedForDeprecatedAndRenamedParameter(t *testing.T) {
 
-	s1, err := open(getDataFile("param-deprecation", "deprecated-with-sunset-path.yaml"))
+	s1, err := open(paramDeprecationFile("deprecated-with-sunset-path.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("param-deprecation", "deprecated-no-sunset-path-renamed.yaml"))
+	s2, err := open(paramDeprecationFile("deprecated-no-sunset-path-renamed.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -47,10 +47,10 @@ func TestBreaking_SunsetDeletedForDeprecatedAndRenamedParameter(t *testing.T) {
 // BC: changing sunset to an earlier date for a deprecated parameter with a deprecation policy is breaking
 func TestBreaking_SunsetModifiedForDeprecatedParameter(t *testing.T) {
 
-	s1, err := open(getDataFile("param-deprecation", "deprecated-future.yaml"))
+	s1, err := open(paramDeprecationFile("deprecated-future.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("param-deprecation", "deprecated-past.yaml"))
+	s2, err := open(paramDeprecationFile("deprecated-past.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -65,10 +65,10 @@ func TestBreaking_SunsetModifiedForDeprecatedParameter(t *testing.T) {
 // BC: changing sunset to an invalid date for a deprecated parameter is breaking
 func TestBreaking_SunsetModifiedToInvalidForDeprecatedParameter(t *testing.T) {
 
-	s1, err := open(getDataFile("param-deprecation", "deprecated-future.yaml"))
+	s1, err := open(paramDeprecationFile("deprecated-future.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("param-deprecation", "deprecated-invalid.yaml"))
+	s2, err := open(paramDeprecationFile("deprecated-invalid.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -84,10 +84,10 @@ func TestBreaking_SunsetModifiedToInvalidForDeprecatedParameter(t *testing.T) {
 // BC: changing sunset from an invalid date for a deprecated parameter is breaking
 func TestBreaking_SunsetModifiedFromInvalidForDeprecatedParameter(t *testing.T) {
 
-	s1, err := open(getDataFile("param-deprecation", "deprecated-invalid.yaml"))
+	s1, err := open(paramDeprecationFile("deprecated-invalid.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("param-deprecation", "deprecated-future.yaml"))
+	s2, err := open(paramDeprecationFile("deprecated-future.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -103,10 +103,10 @@ func TestBreaking_SunsetModifiedFromInvalidForDeprecatedParameter(t *testing.T) 
 // BC: deleting other extension (not sunset) header for a deprecated parameter is not breaking
 func TestBreaking_NonSunsetDeletedForDeprecatedParameter(t *testing.T) {
 
-	s1, err := open(getDataFile("param-deprecation", "deprecated-with-other-extension.yaml"))
+	s1, err := open(paramDeprecationFile("deprecated-with-other-extension.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("param-deprecation", "deprecated-no-sunset.yaml"))
+	s2, err := open(paramDeprecationFile("deprecated-no-sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -118,10 +118,10 @@ func TestBreaking_NonSunsetDeletedForDeprecatedParameter(t *testing.T) {
 // BC: no change to headers for a deprecated parameter is not breaking
 func TestBreaking_NoChangeToSunsetDeprecatedParameter(t *testing.T) {
 
-	s1, err := open(getDataFile("param-deprecation", "deprecated-future.yaml"))
+	s1, err := open(paramDeprecationFile("deprecated-future.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("param-deprecation", "deprecated-future-2.yaml"))
+	s2, err := open(paramDeprecationFile("deprecated-future-2.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)

--- a/checker/check_request_parameter_sunset_changed_test.go
+++ b/checker/check_request_parameter_sunset_changed_test.go
@@ -11,10 +11,10 @@ import (
 // BC: deleting sunset header for a deprecated parameter is breaking
 func TestBreaking_SunsetDeletedForDeprecatedParameter(t *testing.T) {
 
-	s1, err := open(getParameterDeprecationFile("deprecated-with-sunset.yaml"))
+	s1, err := open(getDataFile("param-deprecation", "deprecated-with-sunset.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getParameterDeprecationFile("deprecated-no-sunset.yaml"))
+	s2, err := open(getDataFile("param-deprecation", "deprecated-no-sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -29,10 +29,10 @@ func TestBreaking_SunsetDeletedForDeprecatedParameter(t *testing.T) {
 // BC: deleting sunset header for a deprecated parameter is breaking even if the parameter is renamed
 func TestBreaking_SunsetDeletedForDeprecatedAndRenamedParameter(t *testing.T) {
 
-	s1, err := open(getParameterDeprecationFile("deprecated-with-sunset-path.yaml"))
+	s1, err := open(getDataFile("param-deprecation", "deprecated-with-sunset-path.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getParameterDeprecationFile("deprecated-no-sunset-path-renamed.yaml"))
+	s2, err := open(getDataFile("param-deprecation", "deprecated-no-sunset-path-renamed.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -47,10 +47,10 @@ func TestBreaking_SunsetDeletedForDeprecatedAndRenamedParameter(t *testing.T) {
 // BC: changing sunset to an earlier date for a deprecated parameter with a deprecation policy is breaking
 func TestBreaking_SunsetModifiedForDeprecatedParameter(t *testing.T) {
 
-	s1, err := open(getParameterDeprecationFile("deprecated-future.yaml"))
+	s1, err := open(getDataFile("param-deprecation", "deprecated-future.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getParameterDeprecationFile("deprecated-past.yaml"))
+	s2, err := open(getDataFile("param-deprecation", "deprecated-past.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -65,10 +65,10 @@ func TestBreaking_SunsetModifiedForDeprecatedParameter(t *testing.T) {
 // BC: changing sunset to an invalid date for a deprecated parameter is breaking
 func TestBreaking_SunsetModifiedToInvalidForDeprecatedParameter(t *testing.T) {
 
-	s1, err := open(getParameterDeprecationFile("deprecated-future.yaml"))
+	s1, err := open(getDataFile("param-deprecation", "deprecated-future.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getParameterDeprecationFile("deprecated-invalid.yaml"))
+	s2, err := open(getDataFile("param-deprecation", "deprecated-invalid.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -84,10 +84,10 @@ func TestBreaking_SunsetModifiedToInvalidForDeprecatedParameter(t *testing.T) {
 // BC: changing sunset from an invalid date for a deprecated parameter is breaking
 func TestBreaking_SunsetModifiedFromInvalidForDeprecatedParameter(t *testing.T) {
 
-	s1, err := open(getParameterDeprecationFile("deprecated-invalid.yaml"))
+	s1, err := open(getDataFile("param-deprecation", "deprecated-invalid.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getParameterDeprecationFile("deprecated-future.yaml"))
+	s2, err := open(getDataFile("param-deprecation", "deprecated-future.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -103,10 +103,10 @@ func TestBreaking_SunsetModifiedFromInvalidForDeprecatedParameter(t *testing.T) 
 // BC: deleting other extension (not sunset) header for a deprecated parameter is not breaking
 func TestBreaking_NonSunsetDeletedForDeprecatedParameter(t *testing.T) {
 
-	s1, err := open(getParameterDeprecationFile("deprecated-with-other-extension.yaml"))
+	s1, err := open(getDataFile("param-deprecation", "deprecated-with-other-extension.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getParameterDeprecationFile("deprecated-no-sunset.yaml"))
+	s2, err := open(getDataFile("param-deprecation", "deprecated-no-sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -118,10 +118,10 @@ func TestBreaking_NonSunsetDeletedForDeprecatedParameter(t *testing.T) {
 // BC: no change to headers for a deprecated parameter is not breaking
 func TestBreaking_NoChangeToSunsetDeprecatedParameter(t *testing.T) {
 
-	s1, err := open(getParameterDeprecationFile("deprecated-future.yaml"))
+	s1, err := open(getDataFile("param-deprecation", "deprecated-future.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getParameterDeprecationFile("deprecated-future-2.yaml"))
+	s2, err := open(getDataFile("param-deprecation", "deprecated-future-2.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)

--- a/checker/check_request_property_deprecation_test.go
+++ b/checker/check_request_property_deprecation_test.go
@@ -16,9 +16,9 @@ import (
 
 // CL: detecting deprecated request properties with sunset date
 func TestRequestPropertyDeprecationCheck(t *testing.T) {
-	s1, err := open(getDeprecationFile("request_property_deprecation_base.yaml"))
+	s1, err := open(getDataFile("deprecation", "request_property_deprecation_base.yaml"))
 	require.NoError(t, err)
-	s2, err := open(getDeprecationFile("request_property_deprecation_spec.yaml"))
+	s2, err := open(getDataFile("deprecation", "request_property_deprecation_spec.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -32,9 +32,9 @@ func TestRequestPropertyDeprecationCheck(t *testing.T) {
 
 // CL: detecting deprecated request properties in allOf schemas with multiple media types
 func TestRequestPropertyDeprecationCheck_AllOf(t *testing.T) {
-	s1, err := open(getDeprecationFile("request_property_deprecation_allof_base.yaml"))
+	s1, err := open(getDataFile("deprecation", "request_property_deprecation_allof_base.yaml"))
 	require.NoError(t, err)
-	s2, err := open(getDeprecationFile("request_property_deprecation_allof_spec.yaml"))
+	s2, err := open(getDataFile("deprecation", "request_property_deprecation_allof_spec.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -56,9 +56,9 @@ func TestRequestPropertyDeprecationCheck_AllOf(t *testing.T) {
 
 // CL: each media type gets its own report with distinct details (issue #594)
 func TestRequestPropertyDeprecationCheck_MediaTypeContext(t *testing.T) {
-	s1, err := open(getDeprecationFile("request_property_deprecation_allof_base.yaml"))
+	s1, err := open(getDataFile("deprecation", "request_property_deprecation_allof_base.yaml"))
 	require.NoError(t, err)
-	s2, err := open(getDeprecationFile("request_property_deprecation_allof_spec.yaml"))
+	s2, err := open(getDataFile("deprecation", "request_property_deprecation_allof_spec.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -83,10 +83,10 @@ func TestRequestPropertyDeprecationCheck_MediaTypeContext(t *testing.T) {
 
 // BC: deprecating a property with a deprecation policy but without specifying sunset date is breaking
 func TestRequestPropertyDeprecation_WithoutSunsetWithPolicy(t *testing.T) {
-	s1, err := open(getDeprecationFile("property_base_stable.yaml"))
+	s1, err := open(getDataFile("deprecation", "property_base_stable.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("property_deprecated_no_sunset.yaml"))
+	s2, err := open(getDataFile("deprecation", "property_deprecated_no_sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -100,10 +100,10 @@ func TestRequestPropertyDeprecation_WithoutSunsetWithPolicy(t *testing.T) {
 
 // BC: deprecating a property without a deprecation policy and without specifying sunset date is not breaking for alpha level
 func TestRequestPropertyDeprecation_ForAlpha(t *testing.T) {
-	s1, err := open(getDeprecationFile("property_base_alpha.yaml"))
+	s1, err := open(getDataFile("deprecation", "property_base_alpha.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("property_deprecated_no_sunset_alpha.yaml"))
+	s2, err := open(getDataFile("deprecation", "property_deprecated_no_sunset_alpha.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -114,10 +114,10 @@ func TestRequestPropertyDeprecation_ForAlpha(t *testing.T) {
 
 // BC: deprecating a property with a deprecation policy and sunset date before required deprecation period is breaking
 func TestRequestPropertyDeprecation_WithEarlySunset(t *testing.T) {
-	s1, err := open(getDeprecationFile("property_base_stable.yaml"))
+	s1, err := open(getDataFile("deprecation", "property_base_stable.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("property_deprecated_future.yaml"))
+	s2, err := open(getDataFile("deprecation", "property_deprecated_future.yaml"))
 	require.NoError(t, err)
 
 	sunsetDate := civil.DateOf(time.Now()).AddDays(9).String()
@@ -135,10 +135,10 @@ func TestRequestPropertyDeprecation_WithEarlySunset(t *testing.T) {
 
 // BC: deprecating a property with a deprecation policy and sunset date after required deprecation period is not breaking
 func TestRequestPropertyDeprecation_WithProperSunset(t *testing.T) {
-	s1, err := open(getDeprecationFile("property_base_stable.yaml"))
+	s1, err := open(getDataFile("deprecation", "property_base_stable.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("property_deprecated_future.yaml"))
+	s2, err := open(getDataFile("deprecation", "property_deprecated_future.yaml"))
 	require.NoError(t, err)
 
 	sunsetDate := civil.DateOf(time.Now()).AddDays(10).String()
@@ -156,10 +156,10 @@ func TestRequestPropertyDeprecation_WithProperSunset(t *testing.T) {
 
 // CL: properties that were re-activated
 func TestRequestPropertyDeprecation_DetectsReactivated(t *testing.T) {
-	s1, err := open(getDeprecationFile("property_deprecated_future.yaml"))
+	s1, err := open(getDataFile("deprecation", "property_deprecated_future.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("property_base_stable.yaml"))
+	s2, err := open(getDataFile("deprecation", "property_base_stable.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -178,10 +178,10 @@ func TestRequestPropertyDeprecation_DetectsReactivated(t *testing.T) {
 
 // BC: deprecating a property with an invalid sunset date format is breaking
 func TestRequestPropertyDeprecation_WithInvalidSunset(t *testing.T) {
-	s1, err := open(getDeprecationFile("property_base_stable.yaml"))
+	s1, err := open(getDataFile("deprecation", "property_base_stable.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("property_deprecated_invalid_sunset.yaml"))
+	s2, err := open(getDataFile("deprecation", "property_deprecated_invalid_sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -194,10 +194,10 @@ func TestRequestPropertyDeprecation_WithInvalidSunset(t *testing.T) {
 
 // CL: deprecating a request property with invalid stability level is skipped (handled in CheckBackwardCompatibility)
 func TestRequestPropertyDeprecation_WithInvalidStability(t *testing.T) {
-	s1, err := open(getDeprecationFile("property_base_stable.yaml"))
+	s1, err := open(getDataFile("deprecation", "property_base_stable.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("property_deprecated_future.yaml"))
+	s2, err := open(getDataFile("deprecation", "property_deprecated_future.yaml"))
 	require.NoError(t, err)
 
 	// Set invalid stability level on the operation
@@ -212,10 +212,10 @@ func TestRequestPropertyDeprecation_WithInvalidStability(t *testing.T) {
 
 // CL: message has no details when request property deprecated without sunset or stability
 func TestRequestPropertyDeprecation_MessageWithoutDetails(t *testing.T) {
-	s1, err := open(getDeprecationFile("property_base.yaml"))
+	s1, err := open(getDataFile("deprecation", "property_base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("property_deprecated_no_sunset_no_stability.yaml"))
+	s2, err := open(getDataFile("deprecation", "property_deprecated_no_sunset_no_stability.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -229,10 +229,10 @@ func TestRequestPropertyDeprecation_MessageWithoutDetails(t *testing.T) {
 
 // CL: message includes sunset date when request property deprecated with valid sunset
 func TestRequestPropertyDeprecation_MessageWithSunsetDate(t *testing.T) {
-	s1, err := open(getDeprecationFile("property_base_stable.yaml"))
+	s1, err := open(getDataFile("deprecation", "property_base_stable.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("property_deprecated_future.yaml"))
+	s2, err := open(getDataFile("deprecation", "property_deprecated_future.yaml"))
 	require.NoError(t, err)
 
 	sunsetDate := civil.DateOf(time.Now()).AddDays(30).String()
@@ -252,9 +252,9 @@ func TestRequestPropertyDeprecation_MessageWithSunsetDate(t *testing.T) {
 func TestRequestPropertyDeprecationCheck_SourceLocation(t *testing.T) {
 	loader := openapi3.NewLoader()
 	loader.IncludeOrigin = true
-	s1, err := load.NewSpecInfo(loader, load.NewSource(getDeprecationFile("request_property_deprecation_base.yaml")))
+	s1, err := load.NewSpecInfo(loader, load.NewSource(getDataFile("deprecation", "request_property_deprecation_base.yaml")))
 	require.NoError(t, err)
-	s2, err := load.NewSpecInfo(loader, load.NewSource(getDeprecationFile("request_property_deprecation_spec.yaml")))
+	s2, err := load.NewSpecInfo(loader, load.NewSource(getDataFile("deprecation", "request_property_deprecation_spec.yaml")))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)

--- a/checker/check_request_property_deprecation_test.go
+++ b/checker/check_request_property_deprecation_test.go
@@ -16,9 +16,9 @@ import (
 
 // CL: detecting deprecated request properties with sunset date
 func TestRequestPropertyDeprecationCheck(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "request_property_deprecation_base.yaml"))
+	s1, err := open(deprecationFile("request_property_deprecation_base.yaml"))
 	require.NoError(t, err)
-	s2, err := open(getDataFile("deprecation", "request_property_deprecation_spec.yaml"))
+	s2, err := open(deprecationFile("request_property_deprecation_spec.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -32,9 +32,9 @@ func TestRequestPropertyDeprecationCheck(t *testing.T) {
 
 // CL: detecting deprecated request properties in allOf schemas with multiple media types
 func TestRequestPropertyDeprecationCheck_AllOf(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "request_property_deprecation_allof_base.yaml"))
+	s1, err := open(deprecationFile("request_property_deprecation_allof_base.yaml"))
 	require.NoError(t, err)
-	s2, err := open(getDataFile("deprecation", "request_property_deprecation_allof_spec.yaml"))
+	s2, err := open(deprecationFile("request_property_deprecation_allof_spec.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -56,9 +56,9 @@ func TestRequestPropertyDeprecationCheck_AllOf(t *testing.T) {
 
 // CL: each media type gets its own report with distinct details (issue #594)
 func TestRequestPropertyDeprecationCheck_MediaTypeContext(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "request_property_deprecation_allof_base.yaml"))
+	s1, err := open(deprecationFile("request_property_deprecation_allof_base.yaml"))
 	require.NoError(t, err)
-	s2, err := open(getDataFile("deprecation", "request_property_deprecation_allof_spec.yaml"))
+	s2, err := open(deprecationFile("request_property_deprecation_allof_spec.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -83,10 +83,10 @@ func TestRequestPropertyDeprecationCheck_MediaTypeContext(t *testing.T) {
 
 // BC: deprecating a property with a deprecation policy but without specifying sunset date is breaking
 func TestRequestPropertyDeprecation_WithoutSunsetWithPolicy(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "property_base_stable.yaml"))
+	s1, err := open(deprecationFile("property_base_stable.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "property_deprecated_no_sunset.yaml"))
+	s2, err := open(deprecationFile("property_deprecated_no_sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -100,10 +100,10 @@ func TestRequestPropertyDeprecation_WithoutSunsetWithPolicy(t *testing.T) {
 
 // BC: deprecating a property without a deprecation policy and without specifying sunset date is not breaking for alpha level
 func TestRequestPropertyDeprecation_ForAlpha(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "property_base_alpha.yaml"))
+	s1, err := open(deprecationFile("property_base_alpha.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "property_deprecated_no_sunset_alpha.yaml"))
+	s2, err := open(deprecationFile("property_deprecated_no_sunset_alpha.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -114,10 +114,10 @@ func TestRequestPropertyDeprecation_ForAlpha(t *testing.T) {
 
 // BC: deprecating a property with a deprecation policy and sunset date before required deprecation period is breaking
 func TestRequestPropertyDeprecation_WithEarlySunset(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "property_base_stable.yaml"))
+	s1, err := open(deprecationFile("property_base_stable.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "property_deprecated_future.yaml"))
+	s2, err := open(deprecationFile("property_deprecated_future.yaml"))
 	require.NoError(t, err)
 
 	sunsetDate := civil.DateOf(time.Now()).AddDays(9).String()
@@ -135,10 +135,10 @@ func TestRequestPropertyDeprecation_WithEarlySunset(t *testing.T) {
 
 // BC: deprecating a property with a deprecation policy and sunset date after required deprecation period is not breaking
 func TestRequestPropertyDeprecation_WithProperSunset(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "property_base_stable.yaml"))
+	s1, err := open(deprecationFile("property_base_stable.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "property_deprecated_future.yaml"))
+	s2, err := open(deprecationFile("property_deprecated_future.yaml"))
 	require.NoError(t, err)
 
 	sunsetDate := civil.DateOf(time.Now()).AddDays(10).String()
@@ -156,10 +156,10 @@ func TestRequestPropertyDeprecation_WithProperSunset(t *testing.T) {
 
 // CL: properties that were re-activated
 func TestRequestPropertyDeprecation_DetectsReactivated(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "property_deprecated_future.yaml"))
+	s1, err := open(deprecationFile("property_deprecated_future.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "property_base_stable.yaml"))
+	s2, err := open(deprecationFile("property_base_stable.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -178,10 +178,10 @@ func TestRequestPropertyDeprecation_DetectsReactivated(t *testing.T) {
 
 // BC: deprecating a property with an invalid sunset date format is breaking
 func TestRequestPropertyDeprecation_WithInvalidSunset(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "property_base_stable.yaml"))
+	s1, err := open(deprecationFile("property_base_stable.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "property_deprecated_invalid_sunset.yaml"))
+	s2, err := open(deprecationFile("property_deprecated_invalid_sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -194,10 +194,10 @@ func TestRequestPropertyDeprecation_WithInvalidSunset(t *testing.T) {
 
 // CL: deprecating a request property with invalid stability level is skipped (handled in CheckBackwardCompatibility)
 func TestRequestPropertyDeprecation_WithInvalidStability(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "property_base_stable.yaml"))
+	s1, err := open(deprecationFile("property_base_stable.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "property_deprecated_future.yaml"))
+	s2, err := open(deprecationFile("property_deprecated_future.yaml"))
 	require.NoError(t, err)
 
 	// Set invalid stability level on the operation
@@ -212,10 +212,10 @@ func TestRequestPropertyDeprecation_WithInvalidStability(t *testing.T) {
 
 // CL: message has no details when request property deprecated without sunset or stability
 func TestRequestPropertyDeprecation_MessageWithoutDetails(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "property_base.yaml"))
+	s1, err := open(deprecationFile("property_base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "property_deprecated_no_sunset_no_stability.yaml"))
+	s2, err := open(deprecationFile("property_deprecated_no_sunset_no_stability.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -229,10 +229,10 @@ func TestRequestPropertyDeprecation_MessageWithoutDetails(t *testing.T) {
 
 // CL: message includes sunset date when request property deprecated with valid sunset
 func TestRequestPropertyDeprecation_MessageWithSunsetDate(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "property_base_stable.yaml"))
+	s1, err := open(deprecationFile("property_base_stable.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "property_deprecated_future.yaml"))
+	s2, err := open(deprecationFile("property_deprecated_future.yaml"))
 	require.NoError(t, err)
 
 	sunsetDate := civil.DateOf(time.Now()).AddDays(30).String()
@@ -252,9 +252,9 @@ func TestRequestPropertyDeprecation_MessageWithSunsetDate(t *testing.T) {
 func TestRequestPropertyDeprecationCheck_SourceLocation(t *testing.T) {
 	loader := openapi3.NewLoader()
 	loader.IncludeOrigin = true
-	s1, err := load.NewSpecInfo(loader, load.NewSource(getDataFile("deprecation", "request_property_deprecation_base.yaml")))
+	s1, err := load.NewSpecInfo(loader, load.NewSource(deprecationFile("request_property_deprecation_base.yaml")))
 	require.NoError(t, err)
-	s2, err := load.NewSpecInfo(loader, load.NewSource(getDataFile("deprecation", "request_property_deprecation_spec.yaml")))
+	s2, err := load.NewSpecInfo(loader, load.NewSource(deprecationFile("request_property_deprecation_spec.yaml")))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)

--- a/checker/check_response_property_deprecation_test.go
+++ b/checker/check_response_property_deprecation_test.go
@@ -16,9 +16,9 @@ import (
 
 // CL: detecting deprecated response properties with sunset date
 func TestResponsePropertyDeprecationCheck(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "response_property_deprecation_base.yaml"))
+	s1, err := open(deprecationFile("response_property_deprecation_base.yaml"))
 	require.NoError(t, err)
-	s2, err := open(getDataFile("deprecation", "response_property_deprecation_spec.yaml"))
+	s2, err := open(deprecationFile("response_property_deprecation_spec.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -32,9 +32,9 @@ func TestResponsePropertyDeprecationCheck(t *testing.T) {
 
 // CL: detecting deprecated response properties in allOf schemas with multiple media types
 func TestResponsePropertyDeprecationCheck_AllOf(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "response_property_deprecation_allof_base.yaml"))
+	s1, err := open(deprecationFile("response_property_deprecation_allof_base.yaml"))
 	require.NoError(t, err)
-	s2, err := open(getDataFile("deprecation", "response_property_deprecation_allof_spec.yaml"))
+	s2, err := open(deprecationFile("response_property_deprecation_allof_spec.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -56,9 +56,9 @@ func TestResponsePropertyDeprecationCheck_AllOf(t *testing.T) {
 
 // CL: each media type gets its own report with distinct details (issue #594)
 func TestResponsePropertyDeprecationCheck_MediaTypeContext(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "response_property_deprecation_allof_base.yaml"))
+	s1, err := open(deprecationFile("response_property_deprecation_allof_base.yaml"))
 	require.NoError(t, err)
-	s2, err := open(getDataFile("deprecation", "response_property_deprecation_allof_spec.yaml"))
+	s2, err := open(deprecationFile("response_property_deprecation_allof_spec.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -83,10 +83,10 @@ func TestResponsePropertyDeprecationCheck_MediaTypeContext(t *testing.T) {
 
 // BC: deprecating a response property with a deprecation policy but without specifying sunset date is breaking
 func TestResponsePropertyDeprecation_WithoutSunsetWithPolicy(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "property_base_stable.yaml"))
+	s1, err := open(deprecationFile("property_base_stable.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "property_deprecated_no_sunset.yaml"))
+	s2, err := open(deprecationFile("property_deprecated_no_sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -100,10 +100,10 @@ func TestResponsePropertyDeprecation_WithoutSunsetWithPolicy(t *testing.T) {
 
 // BC: deprecating a response property without a deprecation policy and without specifying sunset date is not breaking for alpha level
 func TestResponsePropertyDeprecation_ForAlpha(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "property_base_alpha.yaml"))
+	s1, err := open(deprecationFile("property_base_alpha.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "property_deprecated_no_sunset_alpha.yaml"))
+	s2, err := open(deprecationFile("property_deprecated_no_sunset_alpha.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -114,10 +114,10 @@ func TestResponsePropertyDeprecation_ForAlpha(t *testing.T) {
 
 // BC: deprecating a response property with a deprecation policy and sunset date before required deprecation period is breaking
 func TestResponsePropertyDeprecation_WithEarlySunset(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "property_base_stable.yaml"))
+	s1, err := open(deprecationFile("property_base_stable.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "property_deprecated_future.yaml"))
+	s2, err := open(deprecationFile("property_deprecated_future.yaml"))
 	require.NoError(t, err)
 
 	sunsetDate := civil.DateOf(time.Now()).AddDays(9).String()
@@ -134,10 +134,10 @@ func TestResponsePropertyDeprecation_WithEarlySunset(t *testing.T) {
 
 // BC: deprecating a response property with a deprecation policy and sunset date after required deprecation period is not breaking
 func TestResponsePropertyDeprecation_WithProperSunset(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "property_base_stable.yaml"))
+	s1, err := open(deprecationFile("property_base_stable.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "property_deprecated_future.yaml"))
+	s2, err := open(deprecationFile("property_deprecated_future.yaml"))
 	require.NoError(t, err)
 
 	sunsetDate := civil.DateOf(time.Now()).AddDays(10).String()
@@ -155,10 +155,10 @@ func TestResponsePropertyDeprecation_WithProperSunset(t *testing.T) {
 
 // CL: response properties that were re-activated
 func TestResponsePropertyDeprecation_DetectsReactivated(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "property_deprecated.yaml"))
+	s1, err := open(deprecationFile("property_deprecated.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "property_base_stable.yaml"))
+	s2, err := open(deprecationFile("property_base_stable.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -177,10 +177,10 @@ func TestResponsePropertyDeprecation_DetectsReactivated(t *testing.T) {
 
 // BC: deprecating a response property with an invalid sunset date format is breaking
 func TestResponsePropertyDeprecation_WithInvalidSunset(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "property_base_stable.yaml"))
+	s1, err := open(deprecationFile("property_base_stable.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "property_deprecated_invalid_sunset.yaml"))
+	s2, err := open(deprecationFile("property_deprecated_invalid_sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -193,10 +193,10 @@ func TestResponsePropertyDeprecation_WithInvalidSunset(t *testing.T) {
 
 // CL: deprecating a response property with invalid stability level is skipped (handled in CheckBackwardCompatibility)
 func TestResponsePropertyDeprecation_WithInvalidStability(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "property_base_stable.yaml"))
+	s1, err := open(deprecationFile("property_base_stable.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "property_deprecated_future.yaml"))
+	s2, err := open(deprecationFile("property_deprecated_future.yaml"))
 	require.NoError(t, err)
 
 	// Set invalid stability level on the operation
@@ -211,10 +211,10 @@ func TestResponsePropertyDeprecation_WithInvalidStability(t *testing.T) {
 
 // CL: message has no details when response property deprecated without sunset or stability
 func TestResponsePropertyDeprecation_MessageWithoutDetails(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "property_base.yaml"))
+	s1, err := open(deprecationFile("property_base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "property_deprecated_no_sunset_no_stability.yaml"))
+	s2, err := open(deprecationFile("property_deprecated_no_sunset_no_stability.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -228,10 +228,10 @@ func TestResponsePropertyDeprecation_MessageWithoutDetails(t *testing.T) {
 
 // CL: message includes sunset date when response property deprecated with valid sunset
 func TestResponsePropertyDeprecation_MessageWithSunsetDate(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "property_base_stable.yaml"))
+	s1, err := open(deprecationFile("property_base_stable.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "property_deprecated_future.yaml"))
+	s2, err := open(deprecationFile("property_deprecated_future.yaml"))
 	require.NoError(t, err)
 
 	sunsetDate := civil.DateOf(time.Now()).AddDays(30).String()
@@ -251,9 +251,9 @@ func TestResponsePropertyDeprecation_MessageWithSunsetDate(t *testing.T) {
 func TestResponsePropertyDeprecationCheck_SourceLocation(t *testing.T) {
 	loader := openapi3.NewLoader()
 	loader.IncludeOrigin = true
-	s1, err := load.NewSpecInfo(loader, load.NewSource(getDataFile("deprecation", "response_property_deprecation_base.yaml")))
+	s1, err := load.NewSpecInfo(loader, load.NewSource(deprecationFile("response_property_deprecation_base.yaml")))
 	require.NoError(t, err)
-	s2, err := load.NewSpecInfo(loader, load.NewSource(getDataFile("deprecation", "response_property_deprecation_spec.yaml")))
+	s2, err := load.NewSpecInfo(loader, load.NewSource(deprecationFile("response_property_deprecation_spec.yaml")))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)

--- a/checker/check_response_property_deprecation_test.go
+++ b/checker/check_response_property_deprecation_test.go
@@ -16,9 +16,9 @@ import (
 
 // CL: detecting deprecated response properties with sunset date
 func TestResponsePropertyDeprecationCheck(t *testing.T) {
-	s1, err := open(getDeprecationFile("response_property_deprecation_base.yaml"))
+	s1, err := open(getDataFile("deprecation", "response_property_deprecation_base.yaml"))
 	require.NoError(t, err)
-	s2, err := open(getDeprecationFile("response_property_deprecation_spec.yaml"))
+	s2, err := open(getDataFile("deprecation", "response_property_deprecation_spec.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -32,9 +32,9 @@ func TestResponsePropertyDeprecationCheck(t *testing.T) {
 
 // CL: detecting deprecated response properties in allOf schemas with multiple media types
 func TestResponsePropertyDeprecationCheck_AllOf(t *testing.T) {
-	s1, err := open(getDeprecationFile("response_property_deprecation_allof_base.yaml"))
+	s1, err := open(getDataFile("deprecation", "response_property_deprecation_allof_base.yaml"))
 	require.NoError(t, err)
-	s2, err := open(getDeprecationFile("response_property_deprecation_allof_spec.yaml"))
+	s2, err := open(getDataFile("deprecation", "response_property_deprecation_allof_spec.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -56,9 +56,9 @@ func TestResponsePropertyDeprecationCheck_AllOf(t *testing.T) {
 
 // CL: each media type gets its own report with distinct details (issue #594)
 func TestResponsePropertyDeprecationCheck_MediaTypeContext(t *testing.T) {
-	s1, err := open(getDeprecationFile("response_property_deprecation_allof_base.yaml"))
+	s1, err := open(getDataFile("deprecation", "response_property_deprecation_allof_base.yaml"))
 	require.NoError(t, err)
-	s2, err := open(getDeprecationFile("response_property_deprecation_allof_spec.yaml"))
+	s2, err := open(getDataFile("deprecation", "response_property_deprecation_allof_spec.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -83,10 +83,10 @@ func TestResponsePropertyDeprecationCheck_MediaTypeContext(t *testing.T) {
 
 // BC: deprecating a response property with a deprecation policy but without specifying sunset date is breaking
 func TestResponsePropertyDeprecation_WithoutSunsetWithPolicy(t *testing.T) {
-	s1, err := open(getDeprecationFile("property_base_stable.yaml"))
+	s1, err := open(getDataFile("deprecation", "property_base_stable.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("property_deprecated_no_sunset.yaml"))
+	s2, err := open(getDataFile("deprecation", "property_deprecated_no_sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -100,10 +100,10 @@ func TestResponsePropertyDeprecation_WithoutSunsetWithPolicy(t *testing.T) {
 
 // BC: deprecating a response property without a deprecation policy and without specifying sunset date is not breaking for alpha level
 func TestResponsePropertyDeprecation_ForAlpha(t *testing.T) {
-	s1, err := open(getDeprecationFile("property_base_alpha.yaml"))
+	s1, err := open(getDataFile("deprecation", "property_base_alpha.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("property_deprecated_no_sunset_alpha.yaml"))
+	s2, err := open(getDataFile("deprecation", "property_deprecated_no_sunset_alpha.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -114,10 +114,10 @@ func TestResponsePropertyDeprecation_ForAlpha(t *testing.T) {
 
 // BC: deprecating a response property with a deprecation policy and sunset date before required deprecation period is breaking
 func TestResponsePropertyDeprecation_WithEarlySunset(t *testing.T) {
-	s1, err := open(getDeprecationFile("property_base_stable.yaml"))
+	s1, err := open(getDataFile("deprecation", "property_base_stable.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("property_deprecated_future.yaml"))
+	s2, err := open(getDataFile("deprecation", "property_deprecated_future.yaml"))
 	require.NoError(t, err)
 
 	sunsetDate := civil.DateOf(time.Now()).AddDays(9).String()
@@ -134,10 +134,10 @@ func TestResponsePropertyDeprecation_WithEarlySunset(t *testing.T) {
 
 // BC: deprecating a response property with a deprecation policy and sunset date after required deprecation period is not breaking
 func TestResponsePropertyDeprecation_WithProperSunset(t *testing.T) {
-	s1, err := open(getDeprecationFile("property_base_stable.yaml"))
+	s1, err := open(getDataFile("deprecation", "property_base_stable.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("property_deprecated_future.yaml"))
+	s2, err := open(getDataFile("deprecation", "property_deprecated_future.yaml"))
 	require.NoError(t, err)
 
 	sunsetDate := civil.DateOf(time.Now()).AddDays(10).String()
@@ -155,10 +155,10 @@ func TestResponsePropertyDeprecation_WithProperSunset(t *testing.T) {
 
 // CL: response properties that were re-activated
 func TestResponsePropertyDeprecation_DetectsReactivated(t *testing.T) {
-	s1, err := open(getDeprecationFile("property_deprecated.yaml"))
+	s1, err := open(getDataFile("deprecation", "property_deprecated.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("property_base_stable.yaml"))
+	s2, err := open(getDataFile("deprecation", "property_base_stable.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -177,10 +177,10 @@ func TestResponsePropertyDeprecation_DetectsReactivated(t *testing.T) {
 
 // BC: deprecating a response property with an invalid sunset date format is breaking
 func TestResponsePropertyDeprecation_WithInvalidSunset(t *testing.T) {
-	s1, err := open(getDeprecationFile("property_base_stable.yaml"))
+	s1, err := open(getDataFile("deprecation", "property_base_stable.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("property_deprecated_invalid_sunset.yaml"))
+	s2, err := open(getDataFile("deprecation", "property_deprecated_invalid_sunset.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -193,10 +193,10 @@ func TestResponsePropertyDeprecation_WithInvalidSunset(t *testing.T) {
 
 // CL: deprecating a response property with invalid stability level is skipped (handled in CheckBackwardCompatibility)
 func TestResponsePropertyDeprecation_WithInvalidStability(t *testing.T) {
-	s1, err := open(getDeprecationFile("property_base_stable.yaml"))
+	s1, err := open(getDataFile("deprecation", "property_base_stable.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("property_deprecated_future.yaml"))
+	s2, err := open(getDataFile("deprecation", "property_deprecated_future.yaml"))
 	require.NoError(t, err)
 
 	// Set invalid stability level on the operation
@@ -211,10 +211,10 @@ func TestResponsePropertyDeprecation_WithInvalidStability(t *testing.T) {
 
 // CL: message has no details when response property deprecated without sunset or stability
 func TestResponsePropertyDeprecation_MessageWithoutDetails(t *testing.T) {
-	s1, err := open(getDeprecationFile("property_base.yaml"))
+	s1, err := open(getDataFile("deprecation", "property_base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("property_deprecated_no_sunset_no_stability.yaml"))
+	s2, err := open(getDataFile("deprecation", "property_deprecated_no_sunset_no_stability.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -228,10 +228,10 @@ func TestResponsePropertyDeprecation_MessageWithoutDetails(t *testing.T) {
 
 // CL: message includes sunset date when response property deprecated with valid sunset
 func TestResponsePropertyDeprecation_MessageWithSunsetDate(t *testing.T) {
-	s1, err := open(getDeprecationFile("property_base_stable.yaml"))
+	s1, err := open(getDataFile("deprecation", "property_base_stable.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("property_deprecated_future.yaml"))
+	s2, err := open(getDataFile("deprecation", "property_deprecated_future.yaml"))
 	require.NoError(t, err)
 
 	sunsetDate := civil.DateOf(time.Now()).AddDays(30).String()
@@ -251,9 +251,9 @@ func TestResponsePropertyDeprecation_MessageWithSunsetDate(t *testing.T) {
 func TestResponsePropertyDeprecationCheck_SourceLocation(t *testing.T) {
 	loader := openapi3.NewLoader()
 	loader.IncludeOrigin = true
-	s1, err := load.NewSpecInfo(loader, load.NewSource(getDeprecationFile("response_property_deprecation_base.yaml")))
+	s1, err := load.NewSpecInfo(loader, load.NewSource(getDataFile("deprecation", "response_property_deprecation_base.yaml")))
 	require.NoError(t, err)
-	s2, err := load.NewSpecInfo(loader, load.NewSource(getDeprecationFile("response_property_deprecation_spec.yaml")))
+	s2, err := load.NewSpecInfo(loader, load.NewSource(getDataFile("deprecation", "response_property_deprecation_spec.yaml")))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -11,10 +11,10 @@ import (
 // BC: decreasing stability level is breaking
 func TestBreaking_StabilityLevelDecreased(t *testing.T) {
 
-	s1, err := open(getDataFile("deprecation", "base-beta-stability.yaml"))
+	s1, err := open(deprecationFile("base-beta-stability.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "base-alpha-stability.yaml"))
+	s2, err := open(deprecationFile("base-alpha-stability.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -33,10 +33,10 @@ func TestBreaking_StabilityLevelDecreased(t *testing.T) {
 // BC: increasing stability level is not breaking
 func TestBreaking_StabilityLevelIncreased(t *testing.T) {
 
-	s1, err := open(getDataFile("deprecation", "base-alpha-stability.yaml"))
+	s1, err := open(deprecationFile("base-alpha-stability.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "base-beta-stability.yaml"))
+	s2, err := open(deprecationFile("base-beta-stability.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -47,10 +47,10 @@ func TestBreaking_StabilityLevelIncreased(t *testing.T) {
 
 // BC: specifying an invalid stability level in revision is breaking
 func TestBreaking_InvalidStabilityLevelInRevision(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "base.yaml"))
+	s1, err := open(deprecationFile("base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "base-invalid-stability.yaml"))
+	s2, err := open(deprecationFile("base-invalid-stability.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -64,10 +64,10 @@ func TestBreaking_InvalidStabilityLevelInRevision(t *testing.T) {
 
 // BC: specifying an invalid stability level in base is breaking
 func TestBreaking_InvalidStabilityLevelInBase(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "base-invalid-stability.yaml"))
+	s1, err := open(deprecationFile("base-invalid-stability.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "base.yaml"))
+	s2, err := open(deprecationFile("base.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -81,10 +81,10 @@ func TestBreaking_InvalidStabilityLevelInBase(t *testing.T) {
 
 // BC: specifying a non-text, not-json stability level in base is breaking
 func TestBreaking_InvalidNonJsonStabilityLevel(t *testing.T) {
-	s1, err := open(getDataFile("deprecation", "base.yaml"))
+	s1, err := open(deprecationFile("base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDataFile("deprecation", "base-invalid-stability-2.yaml"))
+	s2, err := open(deprecationFile("base-invalid-stability-2.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -11,10 +11,10 @@ import (
 // BC: decreasing stability level is breaking
 func TestBreaking_StabilityLevelDecreased(t *testing.T) {
 
-	s1, err := open(getDeprecationFile("base-beta-stability.yaml"))
+	s1, err := open(getDataFile("deprecation", "base-beta-stability.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("base-alpha-stability.yaml"))
+	s2, err := open(getDataFile("deprecation", "base-alpha-stability.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -33,10 +33,10 @@ func TestBreaking_StabilityLevelDecreased(t *testing.T) {
 // BC: increasing stability level is not breaking
 func TestBreaking_StabilityLevelIncreased(t *testing.T) {
 
-	s1, err := open(getDeprecationFile("base-alpha-stability.yaml"))
+	s1, err := open(getDataFile("deprecation", "base-alpha-stability.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("base-beta-stability.yaml"))
+	s2, err := open(getDataFile("deprecation", "base-beta-stability.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -47,10 +47,10 @@ func TestBreaking_StabilityLevelIncreased(t *testing.T) {
 
 // BC: specifying an invalid stability level in revision is breaking
 func TestBreaking_InvalidStabilityLevelInRevision(t *testing.T) {
-	s1, err := open(getDeprecationFile("base.yaml"))
+	s1, err := open(getDataFile("deprecation", "base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("base-invalid-stability.yaml"))
+	s2, err := open(getDataFile("deprecation", "base-invalid-stability.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -64,10 +64,10 @@ func TestBreaking_InvalidStabilityLevelInRevision(t *testing.T) {
 
 // BC: specifying an invalid stability level in base is breaking
 func TestBreaking_InvalidStabilityLevelInBase(t *testing.T) {
-	s1, err := open(getDeprecationFile("base-invalid-stability.yaml"))
+	s1, err := open(getDataFile("deprecation", "base-invalid-stability.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("base.yaml"))
+	s2, err := open(getDataFile("deprecation", "base.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
@@ -81,10 +81,10 @@ func TestBreaking_InvalidStabilityLevelInBase(t *testing.T) {
 
 // BC: specifying a non-text, not-json stability level in base is breaking
 func TestBreaking_InvalidNonJsonStabilityLevel(t *testing.T) {
-	s1, err := open(getDeprecationFile("base.yaml"))
+	s1, err := open(getDataFile("deprecation", "base.yaml"))
 	require.NoError(t, err)
 
-	s2, err := open(getDeprecationFile("base-invalid-stability-2.yaml"))
+	s2, err := open(getDataFile("deprecation", "base-invalid-stability-2.yaml"))
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)

--- a/checker/helpers_test.go
+++ b/checker/helpers_test.go
@@ -60,12 +60,20 @@ func d(t *testing.T, config *diff.Config, v1, v2 int, loaders ...*openapi3.Loade
 	return checker.CheckBackwardCompatibility(allChecksConfig(), d, osm)
 }
 
-// getDataFile returns the path to a file under data/<subdir>/.
-// Generic replacement for the per-subdirectory helpers — new test
-// categories don't need their own dedicated helper.
-func getDataFile(subdir, file string) string {
-	return fmt.Sprintf("../data/%s/%s", subdir, file)
+// dataFileFn returns a closure that resolves files under data/<subdir>/.
+// Use it to declare a named handle per data subdirectory; call sites then
+// pass only the file name.
+func dataFileFn(subdir string) func(string) string {
+	return func(file string) string {
+		return fmt.Sprintf("../data/%s/%s", subdir, file)
+	}
 }
+
+var (
+	deprecationFile      = dataFileFn("deprecation")
+	paramDeprecationFile = dataFileFn("param-deprecation")
+	requiredPropertyFile = dataFileFn("required-properties")
+)
 
 func singleCheckConfig(c checker.BackwardCompatibilityCheck, opts ...checker.Option) *checker.Config {
 	return checker.NewConfig(checker.BackwardCompatibilityChecks{c}, append([]checker.Option{checker.WithSingleCheck(c)}, opts...)...)

--- a/checker/helpers_test.go
+++ b/checker/helpers_test.go
@@ -60,19 +60,11 @@ func d(t *testing.T, config *diff.Config, v1, v2 int, loaders ...*openapi3.Loade
 	return checker.CheckBackwardCompatibility(allChecksConfig(), d, osm)
 }
 
-// getDeprecationFile returns the path to a file under data/deprecation/.
-func getDeprecationFile(file string) string {
-	return fmt.Sprintf("../data/deprecation/%s", file)
-}
-
-// getReqPropFile returns the path to a file under data/required-properties/.
-func getReqPropFile(file string) string {
-	return fmt.Sprintf("../data/required-properties/%s", file)
-}
-
-// getParameterDeprecationFile returns the path to a file under data/param-deprecation/.
-func getParameterDeprecationFile(file string) string {
-	return fmt.Sprintf("../data/param-deprecation/%s", file)
+// getDataFile returns the path to a file under data/<subdir>/.
+// Generic replacement for the per-subdirectory helpers — new test
+// categories don't need their own dedicated helper.
+func getDataFile(subdir, file string) string {
+	return fmt.Sprintf("../data/%s/%s", subdir, file)
 }
 
 func singleCheckConfig(c checker.BackwardCompatibilityCheck, opts ...checker.Option) *checker.Config {


### PR DESCRIPTION
## Before

Three parallel helpers in `checker/helpers_test.go`, each wrapping the same `fmt.Sprintf` with a different hard-coded `data/` subdirectory:

```go
func getDeprecationFile(file string) string          { return fmt.Sprintf("../data/deprecation/%s", file) }
func getReqPropFile(file string) string              { return fmt.Sprintf("../data/required-properties/%s", file) }
func getParameterDeprecationFile(file string) string { return fmt.Sprintf("../data/param-deprecation/%s", file) }
```

The format string is copy-pasted three times, and every new test category needs another such helper.

## After

A single closure constructor plus one named handle per subdirectory, both in `helpers_test.go`:

```go
func dataFileFn(subdir string) func(string) string {
    return func(file string) string {
        return fmt.Sprintf("../data/%s/%s", subdir, file)
    }
}

var (
    deprecationFile      = dataFileFn("deprecation")
    paramDeprecationFile = dataFileFn("param-deprecation")
    requiredPropertyFile = dataFileFn("required-properties")
)
```

Call sites read `deprecationFile("base.yaml")`, as terse as the original `getDeprecationFile("base.yaml")`. The format string lives in one place; each subdir name appears exactly once. New test categories add a single `var` line, not a new function.

## Scope

- ~238 call sites migrated mechanically across 10 test files.
- Pure shape change, no behaviour change.
- `go test ./...` clean.

Closes #906.

Note: PR #845 introduces a fourth handle. Once both PRs are merged, that one folds into a `stabilityFile = dataFileFn("stability")` line in the same shape.