### PR TITLE
fix(checker): scalar to form/explode array is non-breaking for query params (#689)

### DIFF
--- a/checker/check_request_parameters_type_changed.go
+++ b/checker/check_request_parameters_type_changed.go
@@ -1,6 +1,7 @@
 package checker
 
 import (
+	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 )
 
@@ -12,6 +13,36 @@ const (
 	RequestParameterPropertyTypeSpecializedId    = "request-parameter-property-type-specialized"
 	RequestParameterPropertyTypeChangedCommentId = "request-parameter-property-type-changed-warn-comment"
 )
+
+// isParameterScalarToFormExplodeArray reports whether typeDiff describes a
+// scalar-to-array change on a parameter using form/explode serialization
+// (the default for query and cookie parameters), where the new array's
+// element type matches the old scalar type. Per the OpenAPI spec, a client
+// sending a single value (?color=red) is a valid one-element array under
+// these serialization rules, so the schema change is backwards-compatible.
+func isParameterScalarToFormExplodeArray(paramDiff *diff.ParameterDiff, typeDiff *diff.StringsDiff) bool {
+	if paramDiff == nil || paramDiff.Revision == nil || paramDiff.SchemaDiff == nil {
+		return false
+	}
+	if typeDiff == nil ||
+		len(typeDiff.Added) != 1 || typeDiff.Added[0] != "array" ||
+		len(typeDiff.Deleted) != 1 || typeDiff.Deleted[0] == "array" {
+		return false
+	}
+
+	method, err := paramDiff.Revision.SerializationMethod()
+	if err != nil || method == nil ||
+		method.Style != openapi3.SerializationForm || !method.Explode {
+		return false
+	}
+
+	revSchema := paramDiff.SchemaDiff.Revision
+	if revSchema == nil || revSchema.Items == nil || revSchema.Items.Value == nil {
+		return false
+	}
+	itemTypes := revSchema.Items.Value.Type.Slice()
+	return len(itemTypes) == 1 && itemTypes[0] == typeDiff.Deleted[0]
+}
 
 func RequestParameterTypeChangedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
@@ -47,7 +78,8 @@ func RequestParameterTypeChangedCheck(diffReport *diff.Diff, operationsSources *
 
 						id := RequestParameterTypeGeneralizedId
 
-						if breakingTypeFormatChangedInRequest(typeDiff, formatDiff, false, schemaDiff) {
+						if breakingTypeFormatChangedInRequest(typeDiff, formatDiff, false, schemaDiff) &&
+							!isParameterScalarToFormExplodeArray(paramDiff, typeDiff) {
 							id = RequestParameterTypeChangedId
 						}
 

--- a/checker/check_request_parameters_type_changed_test.go
+++ b/checker/check_request_parameters_type_changed_test.go
@@ -254,3 +254,51 @@ func TestBreaking_ReqQueryParamTypeIntegerToNumber(t *testing.T) {
 	require.Equal(t, "for the `query` request parameter `filters`, the type/format of property `groupId` was generalized from `integer`/`` to `number`/``", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 	require.Equal(t, checker.INFO, errs[0].GetLevel())
 }
+
+// CL: widening a query parameter from a scalar to a form/explode array of the
+// same type is backwards-compatible (one-element array on the wire), so it
+// should be reported as a generalization rather than a breaking change.
+// Reproduces issue #689.
+func TestRequestQueryParamScalarToFormExplodeArray(t *testing.T) {
+	s1, err := open("../data/checker/request_parameter_type_changed_base.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/checker/request_parameter_type_changed_base.yaml")
+	require.NoError(t, err)
+
+	queryParam := s2.Spec.Paths.Value("/api/v1.0/groups").Post.Parameters[1].Value
+	queryParam.Schema.Value.Type = &openapi3.Types{"array"}
+	queryParam.Schema.Value.Format = ""
+	queryParam.Schema.Value.Items = &openapi3.SchemaRef{
+		Value: &openapi3.Schema{Type: &openapi3.Types{"string"}, Format: "uuid"},
+	}
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestParameterTypeChangedCheck), d, osm, checker.INFO)
+	require.Len(t, errs, 1)
+	require.Equal(t, checker.RequestParameterTypeGeneralizedId, errs[0].GetId())
+	require.Equal(t, checker.INFO, errs[0].GetLevel())
+}
+
+// CL: widening a path parameter from scalar to array stays breaking, since
+// path parameters use simple style (not form), so a single value on the wire
+// no longer matches the new array schema.
+func TestRequestPathParamScalarToArrayStillBreaking(t *testing.T) {
+	s1, err := open("../data/checker/request_parameter_type_changed_base.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/checker/request_parameter_type_changed_base.yaml")
+	require.NoError(t, err)
+
+	pathParam := s2.Spec.Paths.Value("/api/v1.0/groups").Post.Parameters[0].Value
+	pathParam.Schema.Value.Type = &openapi3.Types{"array"}
+	pathParam.Schema.Value.Items = &openapi3.SchemaRef{
+		Value: &openapi3.Schema{Type: &openapi3.Types{"string"}},
+	}
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestParameterTypeChangedCheck), d, osm, checker.INFO)
+	require.Len(t, errs, 1)
+	require.Equal(t, checker.RequestParameterTypeChangedId, errs[0].GetId())
+	require.Equal(t, checker.ERR, errs[0].GetLevel())
+}


### PR DESCRIPTION
## Bug

A query parameter changing from a scalar type to an array of the same scalar type was flagged as a breaking change:

```diff
  {
    "name": "color",
    "in": "query",
    "schema": {
-     "type": "string"
+     "type": "array",
+     "items": { "type": "string" }
    }
  }
```

```
1 changes: 1 error, 0 warning, 0 info
error	[request-parameter-type-changed] at rev.yaml
	in API GET /examples
		for the `query` request parameter `color`, the type/format was changed from `string`/`` to `array`/``
```

But this is the OpenAPI 3 default serialization (`style: form`, `explode: true`) for query parameters, where `?color=red` is a valid one-element array on the wire. Clients that previously sent `?color=red` continue to work against the new schema. Per the spec linked from the original issue, the change is backwards-compatible.

## Fix

`RequestParameterTypeChangedCheck` now consults a new helper, `isParameterScalarToFormExplodeArray`, before deciding whether the change is breaking. The helper returns true when all three hold:

1. `typeDiff` is exactly `Deleted=[X] / Added=[array]` for a non-array scalar `X`.
2. `paramDiff.Revision.SerializationMethod()` returns `Style: form, Explode: true` (default for query and cookie parameters).
3. The revision schema's `Items.Value.Type` is `[X]`, so the array element type matches the deleted scalar.

If all three hold, the event is emitted as `RequestParameterTypeGeneralizedId` at INFO level (existing message reads naturally: "the type/format was generalized from `string`/`` to `array`/``"). Otherwise behaviour is unchanged.

## Deliberately unaffected

- Reverse direction (`array → scalar`): clients that used repeated keys would break, still ERR.
- Items type mismatch (`string → array of integer`): still ERR.
- Path / header parameters: default style is `simple`, not `form`, so the helper short-circuits and the change stays ERR.

## Tests

- New `TestRequestQueryParamScalarToFormExplodeArray`: positive case, asserts INFO + `RequestParameterTypeGeneralizedId`.
- New `TestRequestPathParamScalarToArrayStillBreaking`: negative case for path parameters, asserts ERR + `RequestParameterTypeChangedId`.
- `go test ./...` clean.

Closes #689.