### PR TITLE
chore(checker): remove stale TODO.md

### DIFF
--- a/checker/TODO.md
+++ b/checker/TODO.md
@@ -1,3 +1,0 @@
-- handle Not and AdditionalProps in schema recursion funcs like processModifiedPropertiesDiff etc.
-- remove redundant code for body can be done through CheckModifiedPropertiesDiff etc.
-- review Russian messages


### PR DESCRIPTION
Three-line TODO from May 2023 (commit 68340d8). Each line revisited against current code:

- **"handle Not and AdditionalProps in schema recursion funcs like processModifiedPropertiesDiff etc."** — `AdditionalProperties` is already traversed by `processModifiedPropertiesDiff` (`checker/checks-utils.go:117-119`). The `Not` gap is real and is now tracked separately in #916.
- **"remove redundant code for body can be done through CheckModifiedPropertiesDiff etc."** — verified obsolete. `grep` confirms no checker walks `PropertiesDiff.Modified`, `AllOfDiff.Modified`, `AnyOfDiff.Modified`, or `OneOfDiff.Modified` manually any more. Every property/composition walk goes through `CheckModifiedPropertiesDiff` / `CheckAddedPropertiesDiff` / `CheckDeletedPropertiesDiff`.
- **"review Russian messages"** — dropped, no concrete scope.

Net: delete the file. The one live concern is captured in #916; the rest is stale.
