### PR TITLE
fix(cli): friendlier flag-parse error messages (#482)

### DIFF
--- a/internal/flag_errors.go
+++ b/internal/flag_errors.go
@@ -1,0 +1,56 @@
+package internal
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// friendlyFlagError rewrites pflag's raw stdlib parse-error wrapping into a
+// human-readable hint. For example,
+//
+//	invalid argument "x" for "--flatten-params" flag: strconv.ParseBool: parsing "x": invalid syntax
+//
+// becomes
+//
+//	invalid argument "x" for "--flatten-params" flag: must be true or false
+//
+// Errors that pflag did not produce are returned unchanged.
+func friendlyFlagError(_ *cobra.Command, err error) error {
+	var ive *pflag.InvalidValueError
+	if !errors.As(err, &ive) {
+		return err
+	}
+
+	hint := flagTypeHint(ive.GetFlag())
+	if hint == "" {
+		return err
+	}
+
+	flagName := "--" + ive.GetFlag().Name
+	return fmt.Errorf("invalid argument %q for %q flag: %s", ive.GetValue(), flagName, hint)
+}
+
+// flagTypeHint returns a friendly description of the values a flag accepts,
+// keyed off pflag's Value.Type() string. Returns "" when no specific hint
+// applies, in which case the caller should leave the original error alone.
+func flagTypeHint(f *pflag.Flag) string {
+	if f == nil {
+		return ""
+	}
+	switch f.Value.Type() {
+	case "bool":
+		return "must be true or false"
+	case "int", "int8", "int16", "int32", "int64":
+		return "must be an integer"
+	case "uint", "uint8", "uint16", "uint32", "uint64":
+		return "must be a non-negative integer"
+	case "float32", "float64":
+		return "must be a number"
+	case "duration":
+		return "must be a duration like 30s or 5m"
+	}
+	return ""
+}

--- a/internal/flag_errors_test.go
+++ b/internal/flag_errors_test.go
@@ -1,0 +1,50 @@
+package internal
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+)
+
+// invalidValueErrorFor parses the given flag with the given raw value and
+// returns the *pflag.InvalidValueError that pflag emits when the raw value
+// fails the flag's Set() method.
+func invalidValueErrorFor(t *testing.T, registerFlag func(fs *pflag.FlagSet), name, rawValue string) error {
+	t.Helper()
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	registerFlag(fs)
+	return fs.Parse([]string{"--" + name + "=" + rawValue})
+}
+
+func TestFriendlyFlagError_BoolHint(t *testing.T) {
+	err := invalidValueErrorFor(t, func(fs *pflag.FlagSet) { fs.Bool("flatten-params", false, "") }, "flatten-params", "x")
+	require.Error(t, err)
+	out := friendlyFlagError(&cobra.Command{}, err)
+	require.EqualError(t, out, `invalid argument "x" for "--flatten-params" flag: must be true or false`)
+}
+
+func TestFriendlyFlagError_IntHint(t *testing.T) {
+	err := invalidValueErrorFor(t, func(fs *pflag.FlagSet) { fs.Int("max-circular-dep", 5, "") }, "max-circular-dep", "foo")
+	require.Error(t, err)
+	out := friendlyFlagError(&cobra.Command{}, err)
+	require.EqualError(t, out, `invalid argument "foo" for "--max-circular-dep" flag: must be an integer`)
+}
+
+func TestFriendlyFlagError_DurationHint(t *testing.T) {
+	err := invalidValueErrorFor(t, func(fs *pflag.FlagSet) { fs.Duration("timeout", 0, "") }, "timeout", "soon")
+	require.Error(t, err)
+	out := friendlyFlagError(&cobra.Command{}, err)
+	require.EqualError(t, out, `invalid argument "soon" for "--timeout" flag: must be a duration like 30s or 5m`)
+}
+
+func TestFriendlyFlagError_UnknownTypeUnchanged(t *testing.T) {
+	// String flags accept anything, so we can't trigger an InvalidValueError
+	// for them. Instead, hand friendlyFlagError an unrelated error and verify
+	// it passes through.
+	original := errors.New("unrelated failure")
+	out := friendlyFlagError(&cobra.Command{}, original)
+	require.Same(t, original, out)
+}

--- a/internal/run.go
+++ b/internal/run.go
@@ -18,6 +18,7 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) int {
 	rootCmd.SetArgs(args[1:])
 	rootCmd.SetOut(stdout)
 	rootCmd.SetErr(stderr)
+	rootCmd.SetFlagErrorFunc(friendlyFlagError)
 	rootCmd.Version = build.Version
 
 	// --config is a persistent flag on the root command so every subcommand

--- a/internal/run_test.go
+++ b/internal/run_test.go
@@ -284,7 +284,7 @@ func Test_BreakingChangesFlattenAllOf(t *testing.T) {
 func Test_BreakingChangesInvalidDeprecationDays(t *testing.T) {
 	var stderr bytes.Buffer
 	require.Equal(t, 100, internal.Run(cmdToArgs("oasdiff breaking ../data/deprecation/base.yaml ../data/deprecation/deprecated-with-sunset.yaml --deprecation-days-stable=-1"), io.Discard, &stderr))
-	require.Equal(t, "Error: invalid argument \"-1\" for \"--deprecation-days-stable\" flag: strconv.ParseUint: parsing \"-1\": invalid syntax\n", stderr.String())
+	require.Equal(t, "Error: invalid argument \"-1\" for \"--deprecation-days-stable\" flag: must be a non-negative integer\n", stderr.String())
 }
 
 func Test_BreakingChangesFlattenCommonParams(t *testing.T) {


### PR DESCRIPTION
## Bug

pflag returns the raw stdlib parse error from each typed flag's `Set()` method, which leaks implementation detail into user-facing CLI errors:

```
$ oasdiff changelog ... --flatten-params=x
Error: invalid argument "x" for "--flatten-params" flag: strconv.ParseBool: parsing "x": invalid syntax
```

Same shape applies to int (`strconv.ParseInt`), uint (`strconv.ParseUint`), float (`strconv.ParseFloat`), and duration. Reported in #482.

## Fix

Wire a `SetFlagErrorFunc` on the root cobra command that detects pflag's `*InvalidValueError` and rewrites the suffix per the flag's `Value.Type()`:

```
$ oasdiff changelog ... --flatten-params=x
Error: invalid argument "x" for "--flatten-params" flag: must be true or false
```

| Flag type | Suffix |
|---|---|
| `bool` | `must be true or false` |
| `int`, `int8`/16/32/64 | `must be an integer` |
| `uint`, `uint8`/16/32/64 | `must be a non-negative integer` |
| `float32`/64 | `must be a number` |
| `duration` | `must be a duration like 30s or 5m` |

`SetFlagErrorFunc` on the root command propagates to every subcommand via cobra's `FlagErrorFunc()` parent walk (`spf13/cobra@v1.10.2/command.go:547-558`), so no per-subcommand wiring is needed.

## Out of scope (deliberate)

- Other flag types (`string`, `[]string`, custom enums, etc.) fall through to pflag's original message unchanged.
- An upstream fix in `spf13/pflag` would benefit the wider Go ecosystem; pflag has [#269 "Better error messages for parsing errors"](https://github.com/spf13/pflag/issues/269) open since 2020. A separate PR upstream is being prepared, but landing this local fix unblocks the next oasdiff release without waiting on upstream review.

## Tests

- New `internal/flag_errors_test.go` covers bool / int / duration hint substitution and pass-through for unrelated errors.
- Existing `Test_BreakingChangesInvalidDeprecationDays` updated to assert the new (friendlier) message for `--deprecation-days-stable=-1`.
- `go test ./...` clean.

Closes #482.