### PR TITLE
feat(upgrade): new subcommand canonicalises 3.0 specs to the latest 3.x

### DIFF
--- a/data/upgrade/already-31.yaml
+++ b/data/upgrade/already-31.yaml
@@ -1,0 +1,10 @@
+openapi: 3.1.0
+info:
+  title: already-31
+  version: '1.0'
+paths:
+  /items:
+    get:
+      responses:
+        '200':
+          description: ok

--- a/data/upgrade/invalid.yaml
+++ b/data/upgrade/invalid.yaml
@@ -1,0 +1,1 @@
+this is not openapi at all

--- a/data/upgrade/simple-30.yaml
+++ b/data/upgrade/simple-30.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.3
+info:
+  title: upgrade-test
+  version: '1.0'
+paths:
+  /items:
+    get:
+      parameters:
+        - in: query
+          name: q
+          schema:
+            type: string
+            nullable: true
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: integer
+                exclusiveMinimum: true
+                minimum: 0
+                example: 7

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	cloud.google.com/go v0.123.0
 	github.com/TwiN/go-color v1.4.1
-	github.com/getkin/kin-openapi v0.137.0
+	github.com/getkin/kin-openapi v0.138.0
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,6 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
-github.com/getkin/kin-openapi v0.137.0 h1:Q3HhawNQV0GfvO2mIYMUBUSEFrDsVlzcYz4VydL9YEo=
-github.com/getkin/kin-openapi v0.137.0/go.mod h1:vUYWaKyMqj7PfTybelXtLuLN9tReS12vxnzMRK+z2GY=
 github.com/getkin/kin-openapi v0.138.0 h1:ebfE0JAmF6AqHrNBy1KO3Fs68K9tPs48HalvLPo7Rv4=
 github.com/getkin/kin-openapi v0.138.0/go.mod h1:vUYWaKyMqj7PfTybelXtLuLN9tReS12vxnzMRK+z2GY=
 github.com/go-openapi/jsonpointer v0.22.5 h1:8on/0Yp4uTb9f4XvTrM2+1CPrV05QPZXu+rvu2o9jcA=

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/getkin/kin-openapi v0.137.0 h1:Q3HhawNQV0GfvO2mIYMUBUSEFrDsVlzcYz4VydL9YEo=
 github.com/getkin/kin-openapi v0.137.0/go.mod h1:vUYWaKyMqj7PfTybelXtLuLN9tReS12vxnzMRK+z2GY=
+github.com/getkin/kin-openapi v0.138.0 h1:ebfE0JAmF6AqHrNBy1KO3Fs68K9tPs48HalvLPo7Rv4=
+github.com/getkin/kin-openapi v0.138.0/go.mod h1:vUYWaKyMqj7PfTybelXtLuLN9tReS12vxnzMRK+z2GY=
 github.com/go-openapi/jsonpointer v0.22.5 h1:8on/0Yp4uTb9f4XvTrM2+1CPrV05QPZXu+rvu2o9jcA=
 github.com/go-openapi/jsonpointer v0.22.5/go.mod h1:gyUR3sCvGSWchA2sUBJGluYMbe1zazrYWIkWPjjMUY0=
 github.com/go-openapi/swag/jsonname v0.25.5 h1:8p150i44rv/Drip4vWI3kGi9+4W9TdI3US3uUYSFhSo=

--- a/internal/run.go
+++ b/internal/run.go
@@ -32,6 +32,7 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) int {
 		getBreakingChangesCmd(),
 		getChangelogCmd(),
 		getFlattenCmd(),
+		getUpgradeCmd(),
 		getChecksCmd(),
 	)
 

--- a/internal/run_test.go
+++ b/internal/run_test.go
@@ -306,6 +306,48 @@ func Test_FlattenCmdInvalid(t *testing.T) {
 `, stderr.String())
 }
 
+func Test_UpgradeCmdOK(t *testing.T) {
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff upgrade ../data/upgrade/simple-30.yaml"), io.Discard, io.Discard))
+}
+
+func Test_UpgradeCmdProducesCanonicalForm(t *testing.T) {
+	var stdout bytes.Buffer
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff upgrade ../data/upgrade/simple-30.yaml"), &stdout, io.Discard))
+	out := stdout.String()
+	// Version-string bump.
+	require.Contains(t, out, "openapi: 3.2.0")
+	// nullable: true -> type array including "null".
+	require.Contains(t, out, "- \"null\"")
+	require.NotContains(t, out, "nullable: true")
+	// boolean exclusiveMinimum -> numeric form.
+	require.Contains(t, out, "exclusiveMinimum: 0")
+	// example -> examples.
+	require.Contains(t, out, "examples:")
+	require.NotContains(t, out, "example: 7")
+}
+
+func Test_UpgradeCmdAlreadyCurrent(t *testing.T) {
+	var stdout bytes.Buffer
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff upgrade ../data/upgrade/already-31.yaml"), &stdout, io.Discard))
+	out := stdout.String()
+	require.Contains(t, out, "openapi: 3.2.0")
+	require.Contains(t, out, "title: already-31")
+}
+
+func Test_UpgradeCmdJsonFormat(t *testing.T) {
+	var stdout bytes.Buffer
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff upgrade ../data/upgrade/simple-30.yaml --format json"), &stdout, io.Discard))
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &doc))
+	require.Equal(t, "3.2.0", doc["openapi"])
+}
+
+func Test_UpgradeCmdInvalid(t *testing.T) {
+	var stderr bytes.Buffer
+	require.Equal(t, 102, internal.Run(cmdToArgs("oasdiff upgrade ../data/upgrade/invalid.yaml"), io.Discard, &stderr))
+	require.Contains(t, stderr.String(), "failed to load original spec")
+}
+
 func Test_Checks(t *testing.T) {
 	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru --tags decrease,parameters --severity info,warn,error"), io.Discard, io.Discard))
 }

--- a/internal/upgrade.go
+++ b/internal/upgrade.go
@@ -1,0 +1,78 @@
+package internal
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/getkin/kin-openapi/openapi3conv"
+	"github.com/oasdiff/oasdiff/formatters"
+	"github.com/oasdiff/oasdiff/load"
+	"github.com/spf13/cobra"
+)
+
+const upgradeCmd = "upgrade"
+
+func getUpgradeCmd() *cobra.Command {
+
+	cmd := cobra.Command{
+		Use:   "upgrade spec",
+		Short: "Canonicalize an OpenAPI 3.x spec to the latest 3.x version",
+		Long: `Convert an OpenAPI 3.x spec to the latest 3.x representation.
+
+The walker rewrites schema-level constructs in place (nullable -> type array,
+boolean exclusiveMinimum/Maximum -> numeric, example -> examples, and similar),
+then updates the openapi version string. The transforms are idempotent: an
+already-canonical spec is unchanged aside from a possible version-string bump.
+
+Spec can be a path to a file, a URL or '-' to read standard input.
+`,
+		Args: cobra.ExactArgs(1),
+		RunE: getRun(runUpgrade),
+	}
+
+	enumWithOptions(&cmd, newEnumValue(formatters.SupportedFormatsByContentType(formatters.OutputFlatten), string(formatters.FormatYAML)), "format", "f", "output format")
+	cmd.PersistentFlags().Bool("allow-external-refs", true, "allow external $refs in specs; disable to prevent SSRF when processing untrusted specs")
+	addHiddenCircularDepFlag(&cmd)
+
+	return &cmd
+}
+
+func runUpgrade(flags *Flags, stdout io.Writer) (bool, *ReturnError) {
+
+	loader := openapi3.NewLoader()
+	loader.IsExternalRefsAllowed = flags.getAllowExternalRefs()
+	spec, err := load.NewSpecInfo(loader, flags.getBase())
+	if err != nil {
+		return false, getErrFailedToLoadSpec("original", flags.getBase(), err)
+	}
+
+	openapi3conv.Upgrade(spec.Spec)
+
+	format := flags.getFormat()
+
+	if returnErr := outputUpgradedSpec(stdout, spec.Spec, format); returnErr != nil {
+		return false, returnErr
+	}
+
+	return false, nil
+}
+
+func outputUpgradedSpec(stdout io.Writer, spec *openapi3.T, format string) *ReturnError {
+	// Reuse the flatten output path: both subcommands serialize a full
+	// *openapi3.T to JSON/YAML and the rendering is identical. If a future
+	// upgrade-specific renderer is needed, split it then.
+	formatter, err := formatters.Lookup(format, formatters.DefaultFormatterOpts())
+	if err != nil {
+		return getErrUnsupportedFormat(format, upgradeCmd)
+	}
+
+	bytes, err := formatter.RenderFlatten(spec, formatters.NewRenderOpts())
+	if err != nil {
+		return getErrFailedPrint("upgrade "+format, err)
+	}
+
+	_, _ = fmt.Fprintf(stdout, "%s\n", bytes)
+
+	return nil
+}


### PR DESCRIPTION
## Summary

Add a standalone `oasdiff upgrade` subcommand that canonicalises an OpenAPI 3.0 spec to the latest 3.x representation kin-openapi knows about (currently 3.2.0).

```
oasdiff upgrade spec.yaml [--format yaml|json]
```

## What it does

Wraps [`openapi3conv.Upgrade`](https://github.com/getkin/kin-openapi/blob/master/openapi3conv/openapi3_conv.go) from kin-openapi. The walker rewrites schema-level constructs in place and then bumps the `openapi:` version string:

| Before (3.0) | After (3.1+) |
|---|---|
| `nullable: true` on `type: string` | `type: ["string", "null"]` |
| `exclusiveMinimum: true` + `minimum: 0` | `exclusiveMinimum: 0` |
| `example: 7` | `examples: [7]` |

Transforms are idempotent: an already-canonical spec is unchanged aside from the possible version-string bump.

## CLI shape

Mirrors `oasdiff flatten`:

- Positional spec argument; accepts file path, URL, or `-` for stdin.
- `--format yaml|json`. Default `yaml` (most real-world OpenAPI specs are yaml and most users running upgrade want to commit the result; pass `--format json` for json).
- `--allow-external-refs` (default true) for SSRF control on untrusted input.
- Hidden `--max-circular-dep` flag (existing pattern).

Invalid specs surface through the existing load-error path, exit code 102. Flatten failures stay distinct from load failures (exit 122), unchanged by this PR.

## Dependency bump

Bumps `github.com/getkin/kin-openapi` from `v0.137.0` to `v0.138.0` to pick up the `openapi3conv` package (the walker landed upstream in 0.138.0).

## Tests

Five new tests in `internal/run_test.go`:

| Test | Asserts |
|---|---|
| `Test_UpgradeCmdOK` | exit 0 on a valid 3.0 spec |
| `Test_UpgradeCmdProducesCanonicalForm` | output contains `openapi: 3.2.0`, `nullable: true` is gone, `exclusiveMinimum: 0` is present, `examples:` replaces `example:` |
| `Test_UpgradeCmdAlreadyCurrent` | already-3.1 spec passes through cleanly with only the version-string bump |
| `Test_UpgradeCmdJsonFormat` | `--format json` produces valid JSON with `openapi: 3.2.0` |
| `Test_UpgradeCmdInvalid` | exit 102 + clear error for a non-OpenAPI input |

Fixtures live under `data/upgrade/`.

## Why this PR alone

Step 1 of an OpenAPI 3.1 readiness bundle. The same upgrade helper will back a `--auto-upgrade` flag on `diff` / `breaking` / `changelog` / `summary` in a follow-up. Shipping the standalone subcommand first shakes out any converter edge cases (lost comments, key reordering, weird-3.0 inputs) in the simplest context.