### PR TITLE
feat(diff/breaking/changelog/summary): --auto-upgrade for cross-version specs

### DIFF
--- a/data/upgrade/equivalent-31.yaml
+++ b/data/upgrade/equivalent-31.yaml
@@ -1,0 +1,21 @@
+openapi: 3.1.0
+info:
+  title: upgrade-test
+  version: '1.0'
+paths:
+  /items:
+    get:
+      parameters:
+        - in: query
+          name: q
+          schema:
+            type: [string, "null"]
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: integer
+                exclusiveMinimum: 0
+                examples: [7]

--- a/docs/OPENAPI-31.md
+++ b/docs/OPENAPI-31.md
@@ -40,6 +40,52 @@ Changes are detected for all 3.1-specific fields:
 - **unevaluatedItems/unevaluatedProperties**: added/removed
 - **contentSchema/contentMediaType/contentEncoding**: added/removed/changed
 
+## Migrating from 3.0 to 3.1
+
+OpenAPI 3.1 changes the shape of several constructs:
+
+| 3.0 | 3.1 |
+|---|---|
+| `nullable: true` on `type: string` | `type: ["string", "null"]` |
+| `exclusiveMinimum: true` + `minimum: 0` | `exclusiveMinimum: 0` (numeric) |
+| `example: 7` | `examples: [7]` |
+
+A team migrating their spec from 3.0 to 3.1 has two problems oasdiff can help with: producing the migrated spec, and verifying the migration doesn't break clients.
+
+### Converting a spec with `oasdiff upgrade`
+
+The `upgrade` subcommand rewrites a 3.0 spec into the latest 3.x canonical form (currently 3.2.0). The transforms are idempotent, so running it on an already-canonical spec just bumps the version string.
+
+```
+oasdiff upgrade old-spec.yaml > new-spec.yaml
+oasdiff upgrade old-spec.yaml --format json > new-spec.json
+cat old-spec.yaml | oasdiff upgrade -
+```
+
+The output goes to stdout; redirect to a file to keep it. The default output format is `yaml`; pass `--format json` for JSON.
+
+The walker handles 3.0 → 3.x only. Swagger 2.0 → 3.0 is out of scope.
+
+Available since `v1.16.0`.
+
+### Comparing across versions with `--auto-upgrade`
+
+`diff`, `breaking`, `changelog`, and `summary` accept an `--auto-upgrade` flag that runs the same canonicalisation on both specs in-memory right after load. This makes cross-version comparisons (e.g. a 3.0 base against a 3.1 revision) produce a meaningful result instead of a noisy diff dominated by dialect-level differences.
+
+```
+# old.yaml is 3.0, new.yaml is 3.1
+oasdiff breaking  old.yaml new.yaml --auto-upgrade
+oasdiff changelog old.yaml new.yaml --auto-upgrade
+oasdiff diff      old.yaml new.yaml --auto-upgrade
+oasdiff summary   old.yaml new.yaml --auto-upgrade
+```
+
+Without the flag, the diff surfaces the 3.0→3.1 dialect rewrites (`nullable` becomes `type: ["string", "null"]`, etc.) as if they were schema changes. With the flag, both sides are canonicalised first, so only the genuine schema-level differences remain.
+
+The flag is off by default; opt in per invocation. Safe to set even when both specs are already the same version: the walker is idempotent on already-canonical input.
+
+Available since `v1.16.0`.
+
 ## Caveats
 
 The following 3.1 features are not yet fully supported by [`kin-openapi`](https://github.com/getkin/kin-openapi) (the parser oasdiff uses) and therefore do not appear in oasdiff diffs:

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,13 +62,14 @@ Pre-built binaries for macOS, Linux, and Windows (both x86_64 and arm64) are on 
 Grouped by what you're trying to do. New to oasdiff? Start with **Commands**.
 
 ### Commands
-The six top-level subcommands.
+The seven top-level subcommands.
 
 - [`diff`](DIFF.md) — full diff between two OpenAPI specs (output: html, json, markdown, markup, text, or yaml — default yaml)
 - [`summary`](DIFF.md) — high-level count of changes between two specs (built on the diff engine; same shared options)
 - [`breaking`](BREAKING-CHANGES.md) — only breaking changes
 - [`changelog`](BREAKING-CHANGES.md) — every significant change, breaking or not, in human-readable form
 - [`flatten`](ALLOF.md) — replace `allOf` schemas with a merged equivalent
+- [`upgrade`](OPENAPI-31.md#converting-a-spec-with-oasdiff-upgrade) — canonicalize an OpenAPI 3.0 spec to the latest 3.x
 - [`checks`](CHECKS.md) — list the rules oasdiff uses to classify changes ([customize them](CUSTOMIZING-CHECKS.md))
 
 ### Inputs

--- a/internal/cmd_flags.go
+++ b/internal/cmd_flags.go
@@ -22,6 +22,7 @@ func addCommonDiffFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().Bool("case-insensitive-headers", false, "case-insensitive header name comparison")
 	cmd.PersistentFlags().StringSlice("exclude-extensions", nil, "OpenAPI Extension names to exclude from diff (e.g., x-internal)")
 	cmd.PersistentFlags().Bool("allow-external-refs", true, "allow external $refs in specs; disable to prevent SSRF when processing untrusted specs")
+	cmd.PersistentFlags().Bool("auto-upgrade", false, "canonicalize both specs to the latest OpenAPI 3.x before diffing; useful for cross-version comparisons (e.g. 3.0 vs 3.1)")
 
 	addHiddenFlattenFlag(cmd)
 	addHiddenCircularDepFlag(cmd)

--- a/internal/diff.go
+++ b/internal/diff.go
@@ -116,6 +116,8 @@ func normalDiff(loader *openapi3.Loader, flags *Flags) (*diffResult, *ReturnErro
 		s2.Spec = s1.Spec
 	}
 
+	autoUpgradeSpecs(flags.getAutoUpgrade(), s1, s2)
+
 	diffReport, operationsSources, err := diff.GetWithOperationsSourcesMap(flags.toConfig(), s1, s2)
 	if err != nil {
 		return nil, getErrDiffFailed(err)
@@ -138,6 +140,11 @@ func composedDiff(loader *openapi3.Loader, flags *Flags) (*diffResult, *ReturnEr
 	s2, err := load.NewSpecInfoFromGlob(loader, flags.getRevision().Path, flattenAllOf, flattenParams, lowerHeaderNames)
 	if err != nil {
 		return nil, getErrFailedToLoadSpecs("revision", flags.getRevision().Path, err)
+	}
+
+	if flags.getAutoUpgrade() {
+		autoUpgradeSpecs(true, s1...)
+		autoUpgradeSpecs(true, s2...)
 	}
 
 	diffReport, operationsSources, err := diff.GetPathsDiff(flags.toConfig(), s1, s2)

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -71,6 +71,10 @@ func (flags *Flags) getAllowExternalRefs() bool {
 	return flags.v.GetBool("allow-external-refs")
 }
 
+func (flags *Flags) getAutoUpgrade() bool {
+	return flags.v.GetBool("auto-upgrade")
+}
+
 func (flags *Flags) getIncludeChecks() []string {
 	return fixViperStringSlice(flags.v.GetStringSlice("include-checks"))
 }

--- a/internal/run_test.go
+++ b/internal/run_test.go
@@ -348,6 +348,32 @@ func Test_UpgradeCmdInvalid(t *testing.T) {
 	require.Contains(t, stderr.String(), "failed to load original spec")
 }
 
+func Test_AutoUpgradeBreaking_CrossVersionEquivalent(t *testing.T) {
+	// simple-30.yaml and equivalent-31.yaml describe the same API; the latter
+	// is the 3.1 canonical form of the former (nullable -> type array, etc).
+	// With --auto-upgrade, both specs are canonicalised so the dialect diff
+	// disappears and oasdiff reports no changes.
+	var stdout bytes.Buffer
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff breaking ../data/upgrade/simple-30.yaml ../data/upgrade/equivalent-31.yaml --auto-upgrade --fail-on ERR"), &stdout, io.Discard))
+	require.Contains(t, stdout.String(), "No changes detected")
+}
+
+func Test_AutoUpgradeChangelog_CrossVersionEquivalent(t *testing.T) {
+	var stdout bytes.Buffer
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff changelog ../data/upgrade/simple-30.yaml ../data/upgrade/equivalent-31.yaml --auto-upgrade --fail-on ERR"), &stdout, io.Discard))
+	require.Contains(t, stdout.String(), "No changes detected")
+}
+
+func Test_AutoUpgradeDiff_SameVersionIsHarmless(t *testing.T) {
+	// When both specs are already on the same version, --auto-upgrade still
+	// canonicalises them (idempotent). The diff result must not change.
+	withoutFlag := bytes.Buffer{}
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff summary ../data/upgrade/already-31.yaml ../data/upgrade/already-31.yaml"), &withoutFlag, io.Discard))
+	withFlag := bytes.Buffer{}
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff summary ../data/upgrade/already-31.yaml ../data/upgrade/already-31.yaml --auto-upgrade"), &withFlag, io.Discard))
+	require.Equal(t, withoutFlag.String(), withFlag.String())
+}
+
 func Test_Checks(t *testing.T) {
 	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru --tags decrease,parameters --severity info,warn,error"), io.Discard, io.Discard))
 }

--- a/internal/upgrade.go
+++ b/internal/upgrade.go
@@ -58,6 +58,25 @@ func runUpgrade(flags *Flags, stdout io.Writer) (bool, *ReturnError) {
 	return false, nil
 }
 
+// autoUpgradeSpecs canonicalizes the given specs to the latest OpenAPI 3.x
+// when --auto-upgrade is set. The walker is idempotent on already-canonical
+// specs, so calling it on a same-version pair is a safe no-op (the version
+// string bumps to the latest 3.x). Used by diff/breaking/changelog/summary
+// to make cross-version comparisons (e.g. 3.0 vs 3.1) just work.
+//
+// Nil entries are skipped; callers don't have to filter.
+func autoUpgradeSpecs(enabled bool, specs ...*load.SpecInfo) {
+	if !enabled {
+		return
+	}
+	for _, s := range specs {
+		if s == nil || s.Spec == nil {
+			continue
+		}
+		openapi3conv.Upgrade(s.Spec)
+	}
+}
+
 func outputUpgradedSpec(stdout io.Writer, spec *openapi3.T, format string) *ReturnError {
 	// Reuse the flatten output path: both subcommands serialize a full
 	// *openapi3.T to JSON/YAML and the rendering is identical. If a future

--- a/internal/viper.go
+++ b/internal/viper.go
@@ -206,6 +206,7 @@ type Config struct {
 	StripPrefixRevision    string   `mapstructure:"strip-prefix-revision"`
 	IncludePathParams      bool     `mapstructure:"include-path-params"`
 	AllowExternalRefs      bool     `mapstructure:"allow-external-refs"`
+	AutoUpgrade            bool     `mapstructure:"auto-upgrade"`
 	Template               string   `mapstructure:"template"`
 }
 


### PR DESCRIPTION
Stacks on top of #922. Once #922 merges to main, this PR rebases onto main automatically and the base flips.

## Summary

Adds an `--auto-upgrade` flag to `diff`, `breaking`, `changelog`, and `summary` that canonicalises both specs to the latest OpenAPI 3.x before diffing. Solves the cross-version comparison problem (a 3.0 base against a 3.1 revision) which today produces a noisy diff dominated by dialect-level differences.

## How it works

After both specs are loaded (and before the diff runs), the same `openapi3conv.Upgrade` helper introduced in #922 runs on each spec. The walker is idempotent on already-canonical specs, so a same-version pair is a safe no-op (it just bumps the version string).

```
oasdiff breaking old-3.0.yaml new-3.1.yaml --auto-upgrade
oasdiff changelog old-3.0.yaml new-3.1.yaml --auto-upgrade
oasdiff summary   old-3.0.yaml new-3.1.yaml --auto-upgrade
oasdiff diff      old-3.0.yaml new-3.1.yaml --auto-upgrade
```

Off by default; opt in per invocation. Default behaviour for all four subcommands is unchanged.

## Smoke test (a 3.0 spec vs its 3.1 canonical form)

| Without `--auto-upgrade` | With `--auto-upgrade` |
|---|---|
| `No breaking changes to report, but the specs are different` (dialect noise) | `No changes detected` |

## Plumbing

- One new flag in `addCommonDiffFlags` (covers all four subcommands).
- One new accessor `flags.getAutoUpgrade()`.
- One new field on the viper `Config` struct (`AutoUpgrade`).
- One new helper `autoUpgradeSpecs(enabled bool, specs ...*load.SpecInfo)` in `internal/upgrade.go`.
- Two call sites: `normalDiff` (single-spec each side) and `composedDiff` (glob, applies per spec in each set).

## Tests

| Test | Asserts |
|---|---|
| `Test_AutoUpgradeBreaking_CrossVersionEquivalent` | A 3.0 spec compared against its 3.1 canonical form produces `No changes detected` with `--auto-upgrade` |
| `Test_AutoUpgradeChangelog_CrossVersionEquivalent` | Same, on `changelog` |
| `Test_AutoUpgradeDiff_SameVersionIsHarmless` | Same-version pair: `summary` output is byte-identical with and without the flag |

## What this PR deliberately does NOT do

- No annotation in the output indicating the upgrade fired. v1 is silent; a follow-up can add a stderr note and a structured `auto_upgraded` field in JSON/YAML outputs if telemetry shows users want it.
- No automatic detection: `--auto-upgrade` is opt-in. v2 may promote to default if it tests well.

This is step 2 of the OpenAPI 3.1 readiness bundle. Step 1 was #922 (standalone `oasdiff upgrade`). Step 3 will be the validate subcommand (PR #894) once the kin replace directive is stripped.