### PR TITLE
Fix false breaking change for equivalent anyOf refactors

### DIFF
--- a/checker/check_request_property_any_of_updated.go
+++ b/checker/check_request_property_any_of_updated.go
@@ -1,6 +1,7 @@
 package checker
 
 import (
+	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 )
 
@@ -55,18 +56,25 @@ func RequestPropertyAnyOfUpdatedCheck(diffReport *diff.Diff, operationsSources *
 					).WithSources(baseSource, revisionSource))
 				}
 
-				if mediaTypeDiff.SchemaDiff.AnyOfDiff != nil && len(mediaTypeDiff.SchemaDiff.AnyOfDiff.Deleted) > 0 {
-					baseSource, revisionSource := SubschemaSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "anyOf", mediaTypeDiff.SchemaDiff.AnyOfDiff.Deleted[0].Index, -1)
-					result = append(result, NewApiChange(
-						RequestBodyAnyOfRemovedId,
-						config,
-						[]any{mediaTypeDiff.SchemaDiff.AnyOfDiff.Deleted.String()},
-						"",
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
-					).WithSources(baseSource, revisionSource))
+				if mediaTypeDiff.SchemaDiff.AnyOfDiff != nil {
+					deleted := filterValidationEquivalentDeletedSubschemas(
+						mediaTypeDiff.SchemaDiff.AnyOfDiff.Deleted,
+						mediaTypeDiff.SchemaDiff.Base.AnyOf,
+						mediaTypeDiff.SchemaDiff.Revision.AnyOf,
+					)
+					if len(deleted) > 0 {
+						baseSource, revisionSource := SubschemaSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "anyOf", deleted[0].Index, -1)
+						result = append(result, NewApiChange(
+							RequestBodyAnyOfRemovedId,
+							config,
+							[]any{deleted.String()},
+							"",
+							operationsSources,
+							operationItem.Revision,
+							operation,
+							path,
+						).WithSources(baseSource, revisionSource))
+					}
 				}
 
 				CheckModifiedPropertiesDiff(
@@ -97,12 +105,17 @@ func RequestPropertyAnyOfUpdatedCheck(diffReport *diff.Diff, operationsSources *
 							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
 						}
 
-						if len(propertyDiff.AnyOfDiff.Deleted) > 0 {
-							propBaseSource, propRevisionSource := SubschemaSources(operationsSources, operationItem, propertyDiff, "anyOf", propertyDiff.AnyOfDiff.Deleted[0].Index, -1)
+						deleted := filterValidationEquivalentDeletedSubschemas(
+							propertyDiff.AnyOfDiff.Deleted,
+							propertyDiff.Base.AnyOf,
+							propertyDiff.Revision.AnyOf,
+						)
+						if len(deleted) > 0 {
+							propBaseSource, propRevisionSource := SubschemaSources(operationsSources, operationItem, propertyDiff, "anyOf", deleted[0].Index, -1)
 							result = append(result, NewApiChange(
 								RequestPropertyAnyOfRemovedId,
 								config,
-								[]any{propertyDiff.AnyOfDiff.Deleted.String(), propName},
+								[]any{deleted.String(), propName},
 								"",
 								operationsSources,
 								operationItem.Revision,
@@ -115,4 +128,43 @@ func RequestPropertyAnyOfUpdatedCheck(diffReport *diff.Diff, operationsSources *
 		}
 	}
 	return result
+}
+
+func filterValidationEquivalentDeletedSubschemas(deleted diff.Subschemas, baseRefs, revisionRefs openapi3.SchemaRefs) diff.Subschemas {
+	result := diff.Subschemas{}
+	for _, deletedSubschema := range deleted {
+		if deletedSubschema.Index < 0 || deletedSubschema.Index >= len(baseRefs) {
+			result = append(result, deletedSubschema)
+			continue
+		}
+
+		if hasValidationEquivalentSubschema(baseRefs[deletedSubschema.Index], revisionRefs) {
+			continue
+		}
+
+		result = append(result, deletedSubschema)
+	}
+
+	return result
+}
+
+func hasValidationEquivalentSubschema(schemaRef *openapi3.SchemaRef, schemaRefs openapi3.SchemaRefs) bool {
+	for _, candidateRef := range schemaRefs {
+		if !isInlineRefactor(schemaRef, candidateRef) {
+			continue
+		}
+		if diff.SchemaRefsValidationEquivalent(schemaRef, candidateRef) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isInlineRefactor(schemaRef1, schemaRef2 *openapi3.SchemaRef) bool {
+	if schemaRef1 == nil || schemaRef2 == nil {
+		return false
+	}
+
+	return (schemaRef1.Ref == "") != (schemaRef2.Ref == "")
 }

--- a/checker/check_request_property_any_of_updated_test.go
+++ b/checker/check_request_property_any_of_updated_test.go
@@ -100,6 +100,23 @@ func TestRequestPropertyAnyOfRemoved(t *testing.T) {
 		}}, errs)
 }
 
+// BC: refactoring an anyOf branch from inline enum to an equivalent $ref is not breaking
+func TestRequestPropertyAnyOfInlineEnumRefactorToRef(t *testing.T) {
+	s1, err := open("../data/checker/request_property_any_of_ref_inline_enum_base.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/checker/request_property_any_of_ref_inline_enum_revision.yaml")
+	require.NoError(t, err)
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+
+	breakingChanges := checker.CheckBackwardCompatibility(allChecksConfig(), d, osm)
+	require.Empty(t, breakingChanges)
+
+	anyOfChanges := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyAnyOfUpdatedCheck), d, osm, checker.INFO)
+	require.False(t, containsId(anyOfChanges, checker.RequestPropertyAnyOfRemovedId))
+}
+
 // CL: no changes when paths diff is nil
 func TestRequestPropertyAnyOfNoPathsDiff(t *testing.T) {
 	config := &checker.Config{}

--- a/data/checker/request_property_any_of_ref_inline_enum_base.yaml
+++ b/data/checker/request_property_any_of_ref_inline_enum_base.yaml
@@ -1,0 +1,36 @@
+openapi: 3.1.0
+info:
+  title: Repro
+  version: 1.0.0
+
+paths:
+  /users/{user_id}:
+    put:
+      parameters:
+        - name: user_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AdminUserUpdateRequest"
+      responses:
+        "200":
+          description: OK
+
+components:
+  schemas:
+    AdminUserUpdateRequest:
+      type: object
+      properties:
+        role:
+          anyOf:
+            - type: string
+              enum:
+                - user
+                - superadmin
+            - type: "null"
+          title: Role

--- a/data/checker/request_property_any_of_ref_inline_enum_revision.yaml
+++ b/data/checker/request_property_any_of_ref_inline_enum_revision.yaml
@@ -1,0 +1,39 @@
+openapi: 3.1.0
+info:
+  title: Repro
+  version: 1.0.0
+
+paths:
+  /users/{user_id}:
+    put:
+      parameters:
+        - name: user_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AdminUserUpdateRequest"
+      responses:
+        "200":
+          description: OK
+
+components:
+  schemas:
+    AdminUserUpdateRequest:
+      type: object
+      properties:
+        role:
+          anyOf:
+            - $ref: "#/components/schemas/UserRole"
+            - type: "null"
+
+    UserRole:
+      type: string
+      enum:
+        - user
+        - superadmin
+      title: UserRole

--- a/diff/schema_validation_equivalence.go
+++ b/diff/schema_validation_equivalence.go
@@ -1,0 +1,129 @@
+package diff
+
+import "github.com/getkin/kin-openapi/openapi3"
+
+// SchemaRefsValidationEquivalent reports whether two resolved schema refs have
+// the same validation contract according to oasdiff's schema diff model.
+// Annotation-only changes such as title, description, examples, default, and
+// comments are ignored. Checker-significant metadata such as deprecated is
+// treated as a contract change.
+func SchemaRefsValidationEquivalent(schemaRef1, schemaRef2 *openapi3.SchemaRef) bool {
+	schemaDiff, err := getSchemaDiff(NewConfig(), newState(), schemaRef1, schemaRef2)
+	if err != nil {
+		return false
+	}
+
+	return !schemaDiffHasValidationChanges(schemaDiff)
+}
+
+func schemaDiffHasValidationChanges(schemaDiff *SchemaDiff) bool {
+	if schemaDiff == nil {
+		return false
+	}
+
+	if schemaDiff.SchemaAdded ||
+		schemaDiff.SchemaDeleted ||
+		schemaDiff.CircularRefDiff ||
+		!schemaDiff.ExtensionsDiff.Empty() ||
+		subschemasDiffHasValidationChanges(schemaDiff.OneOfDiff) ||
+		subschemasDiffHasValidationChanges(schemaDiff.AnyOfDiff) ||
+		subschemasDiffHasValidationChanges(schemaDiff.AllOfDiff) ||
+		schemaDiffHasValidationChanges(schemaDiff.NotDiff) ||
+		!schemaDiff.TypeDiff.Empty() ||
+		!schemaDiff.ListOfTypesDiff.Empty() ||
+		!schemaDiff.FormatDiff.Empty() ||
+		!schemaDiff.EnumDiff.Empty() ||
+		!schemaDiff.AdditionalPropertiesAllowedDiff.Empty() ||
+		!schemaDiff.UniqueItemsDiff.Empty() ||
+		!schemaDiff.ExclusiveMinDiff.Empty() ||
+		!schemaDiff.ExclusiveMaxDiff.Empty() ||
+		!schemaDiff.NullableDiff.Empty() ||
+		!schemaDiff.ReadOnlyDiff.Empty() ||
+		!schemaDiff.WriteOnlyDiff.Empty() ||
+		!schemaDiff.AllowEmptyValueDiff.Empty() ||
+		!schemaDiff.XMLDiff.Empty() ||
+		!schemaDiff.DeprecatedDiff.Empty() ||
+		!schemaDiff.MinDiff.Empty() ||
+		!schemaDiff.MaxDiff.Empty() ||
+		!schemaDiff.MultipleOfDiff.Empty() ||
+		!schemaDiff.MinLengthDiff.Empty() ||
+		!schemaDiff.MaxLengthDiff.Empty() ||
+		!schemaDiff.PatternDiff.Empty() ||
+		!schemaDiff.MinItemsDiff.Empty() ||
+		!schemaDiff.MaxItemsDiff.Empty() ||
+		schemaDiffHasValidationChanges(schemaDiff.ItemsDiff) ||
+		!schemaDiff.RequiredDiff.Empty() ||
+		schemasDiffHasValidationChanges(schemaDiff.PropertiesDiff) ||
+		!schemaDiff.MinPropsDiff.Empty() ||
+		!schemaDiff.MaxPropsDiff.Empty() ||
+		schemaDiffHasValidationChanges(schemaDiff.AdditionalPropertiesDiff) ||
+		!schemaDiff.DiscriminatorDiff.Empty() ||
+		!schemaDiff.ConstDiff.Empty() ||
+		subschemasDiffHasValidationChanges(schemaDiff.PrefixItemsDiff) ||
+		schemaDiffHasValidationChanges(schemaDiff.ContainsDiff) ||
+		!schemaDiff.MinContainsDiff.Empty() ||
+		!schemaDiff.MaxContainsDiff.Empty() ||
+		schemasDiffHasValidationChanges(schemaDiff.PatternPropertiesDiff) ||
+		schemasDiffHasValidationChanges(schemaDiff.DependentSchemasDiff) ||
+		schemaDiffHasValidationChanges(schemaDiff.PropertyNamesDiff) ||
+		!schemaDiff.UnevaluatedItemsAllowedDiff.Empty() ||
+		schemaDiffHasValidationChanges(schemaDiff.UnevaluatedItemsDiff) ||
+		!schemaDiff.UnevaluatedPropertiesAllowedDiff.Empty() ||
+		schemaDiffHasValidationChanges(schemaDiff.UnevaluatedPropertiesDiff) ||
+		schemaDiffHasValidationChanges(schemaDiff.IfDiff) ||
+		schemaDiffHasValidationChanges(schemaDiff.ThenDiff) ||
+		schemaDiffHasValidationChanges(schemaDiff.ElseDiff) ||
+		!schemaDiff.DependentRequiredDiff.Empty() ||
+		!schemaDiff.SchemaIDDiff.Empty() ||
+		!schemaDiff.AnchorDiff.Empty() ||
+		!schemaDiff.DynamicRefDiff.Empty() ||
+		!schemaDiff.DynamicAnchorDiff.Empty() ||
+		!schemaDiff.ContentMediaTypeDiff.Empty() ||
+		!schemaDiff.ContentEncodingDiff.Empty() ||
+		schemaDiffHasValidationChanges(schemaDiff.ContentSchemaDiff) ||
+		schemasDiffHasValidationChanges(schemaDiff.DefsDiff) ||
+		!schemaDiff.SchemaDialectDiff.Empty() {
+		return true
+	}
+
+	return false
+}
+
+func subschemasDiffHasValidationChanges(subschemasDiff *SubschemasDiff) bool {
+	if subschemasDiff == nil {
+		return false
+	}
+
+	if len(subschemasDiff.Added) > 0 || len(subschemasDiff.Deleted) > 0 {
+		return true
+	}
+
+	for _, modified := range subschemasDiff.Modified {
+		if modified == nil {
+			continue
+		}
+		if schemaDiffHasValidationChanges(modified.Diff) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func schemasDiffHasValidationChanges(schemasDiff *SchemasDiff) bool {
+	if schemasDiff == nil {
+		return false
+	}
+
+	if len(schemasDiff.Added) > 0 || len(schemasDiff.Deleted) > 0 {
+		return true
+	}
+
+	for _, schemaDiff := range schemasDiff.Modified {
+		if schemaDiffHasValidationChanges(schemaDiff) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/diff/schema_validation_equivalence_test.go
+++ b/diff/schema_validation_equivalence_test.go
@@ -1,0 +1,80 @@
+package diff_test
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/oasdiff/diff"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchemaRefsValidationEquivalent_IgnoresTitle(t *testing.T) {
+	base := &openapi3.SchemaRef{
+		Value: &openapi3.Schema{
+			Type: &openapi3.Types{"string"},
+			Enum: []any{"user", "superadmin"},
+		},
+	}
+	revision := &openapi3.SchemaRef{
+		Ref: "#/components/schemas/UserRole",
+		Value: &openapi3.Schema{
+			Type:  &openapi3.Types{"string"},
+			Enum:  []any{"user", "superadmin"},
+			Title: "UserRole",
+		},
+	}
+
+	require.True(t, diff.SchemaRefsValidationEquivalent(base, revision))
+}
+
+func TestSchemaRefsValidationEquivalent_DetectsValidationChange(t *testing.T) {
+	base := &openapi3.SchemaRef{
+		Value: &openapi3.Schema{
+			Type: &openapi3.Types{"string"},
+			Enum: []any{"user", "superadmin"},
+		},
+	}
+	revision := &openapi3.SchemaRef{
+		Ref: "#/components/schemas/UserRole",
+		Value: &openapi3.Schema{
+			Type:  &openapi3.Types{"string"},
+			Enum:  []any{"user"},
+			Title: "UserRole",
+		},
+	}
+
+	require.False(t, diff.SchemaRefsValidationEquivalent(base, revision))
+}
+
+func TestSchemaRefsValidationEquivalent_DetectsDeprecatedChange(t *testing.T) {
+	base := &openapi3.SchemaRef{
+		Value: &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: openapi3.Schemas{
+				"role": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+						Enum: []any{"user", "superadmin"},
+					},
+				},
+			},
+		},
+	}
+	revision := &openapi3.SchemaRef{
+		Ref: "#/components/schemas/UserPayload",
+		Value: &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: openapi3.Schemas{
+				"role": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type:       &openapi3.Types{"string"},
+						Enum:       []any{"user", "superadmin"},
+						Deprecated: true,
+					},
+				},
+			},
+		},
+	}
+
+	require.False(t, diff.SchemaRefsValidationEquivalent(base, revision))
+}


### PR DESCRIPTION
## What changed

- Added validation-equivalence handling for removed `anyOf` branches during inline ↔ `$ref` refactors.
- Ignored annotation-only differences such as `title` while preserving checker-significant metadata changes such as `deprecated`.
- Added regression fixtures and tests for nullable enum schemas inside `anyOf`.

## Why

Refactoring an inline enum schema into an equivalent referenced component schema does not change the request contract. In that case, `request-property-any-of-removed` should not be reported as a breaking change.