### PR TITLE
Fix false removed subschemas for equivalent anyOf/oneOf refactors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,0 @@
-# Changelog
-
-## Unreleased
-
-### Fixed
-
-- Suppressed false positive removed `anyOf`/`oneOf` subschema reports when an inline branch is refactored to a validation-equivalent `$ref`; mixed reports now list only branches that were actually removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+### Fixed
+
+- Suppressed false positive removed `anyOf`/`oneOf` subschema reports when an inline branch is refactored to a validation-equivalent `$ref`; mixed reports now list only branches that were actually removed.

--- a/checker/check_request_property_any_of_updated.go
+++ b/checker/check_request_property_any_of_updated.go
@@ -1,6 +1,7 @@
 package checker
 
 import (
+	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 )
 
@@ -55,18 +56,25 @@ func RequestPropertyAnyOfUpdatedCheck(diffReport *diff.Diff, operationsSources *
 					).WithSources(baseSource, revisionSource))
 				}
 
-				if mediaTypeDiff.SchemaDiff.AnyOfDiff != nil && len(mediaTypeDiff.SchemaDiff.AnyOfDiff.Deleted) > 0 {
-					baseSource, revisionSource := SubschemaSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "anyOf", mediaTypeDiff.SchemaDiff.AnyOfDiff.Deleted[0].Index, -1)
-					result = append(result, NewApiChange(
-						RequestBodyAnyOfRemovedId,
-						config,
-						[]any{mediaTypeDiff.SchemaDiff.AnyOfDiff.Deleted.String()},
-						"",
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
-					).WithSources(baseSource, revisionSource))
+				if mediaTypeDiff.SchemaDiff.AnyOfDiff != nil {
+					deleted := filterValidationEquivalentDeletedSubschemas(
+						mediaTypeDiff.SchemaDiff.AnyOfDiff.Deleted,
+						mediaTypeDiff.SchemaDiff.Base.AnyOf,
+						mediaTypeDiff.SchemaDiff.Revision.AnyOf,
+					)
+					if len(deleted) > 0 {
+						baseSource, revisionSource := SubschemaSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "anyOf", deleted[0].Index, -1)
+						result = append(result, NewApiChange(
+							RequestBodyAnyOfRemovedId,
+							config,
+							[]any{deleted.String()},
+							"",
+							operationsSources,
+							operationItem.Revision,
+							operation,
+							path,
+						).WithSources(baseSource, revisionSource))
+					}
 				}
 
 				CheckModifiedPropertiesDiff(
@@ -97,12 +105,17 @@ func RequestPropertyAnyOfUpdatedCheck(diffReport *diff.Diff, operationsSources *
 							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
 						}
 
-						if len(propertyDiff.AnyOfDiff.Deleted) > 0 {
-							propBaseSource, propRevisionSource := SubschemaSources(operationsSources, operationItem, propertyDiff, "anyOf", propertyDiff.AnyOfDiff.Deleted[0].Index, -1)
+						deleted := filterValidationEquivalentDeletedSubschemas(
+							propertyDiff.AnyOfDiff.Deleted,
+							propertyDiff.Base.AnyOf,
+							propertyDiff.Revision.AnyOf,
+						)
+						if len(deleted) > 0 {
+							propBaseSource, propRevisionSource := SubschemaSources(operationsSources, operationItem, propertyDiff, "anyOf", deleted[0].Index, -1)
 							result = append(result, NewApiChange(
 								RequestPropertyAnyOfRemovedId,
 								config,
-								[]any{propertyDiff.AnyOfDiff.Deleted.String(), propName},
+								[]any{deleted.String(), propName},
 								"",
 								operationsSources,
 								operationItem.Revision,
@@ -115,4 +128,43 @@ func RequestPropertyAnyOfUpdatedCheck(diffReport *diff.Diff, operationsSources *
 		}
 	}
 	return result
+}
+
+func filterValidationEquivalentDeletedSubschemas(deleted diff.Subschemas, baseRefs, revisionRefs openapi3.SchemaRefs) diff.Subschemas {
+	result := diff.Subschemas{}
+	for _, deletedSubschema := range deleted {
+		if deletedSubschema.Index < 0 || deletedSubschema.Index >= len(baseRefs) {
+			result = append(result, deletedSubschema)
+			continue
+		}
+
+		if hasValidationEquivalentSubschema(baseRefs[deletedSubschema.Index], revisionRefs) {
+			continue
+		}
+
+		result = append(result, deletedSubschema)
+	}
+
+	return result
+}
+
+func hasValidationEquivalentSubschema(schemaRef *openapi3.SchemaRef, schemaRefs openapi3.SchemaRefs) bool {
+	for _, candidateRef := range schemaRefs {
+		if !isInlineRefactor(schemaRef, candidateRef) {
+			continue
+		}
+		if diff.SchemaRefsValidationEquivalent(schemaRef, candidateRef) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isInlineRefactor(schemaRef1, schemaRef2 *openapi3.SchemaRef) bool {
+	if schemaRef1 == nil || schemaRef2 == nil {
+		return false
+	}
+
+	return (schemaRef1.Ref == "") != (schemaRef2.Ref == "")
 }

--- a/checker/check_request_property_any_of_updated.go
+++ b/checker/check_request_property_any_of_updated.go
@@ -1,9 +1,6 @@
 package checker
 
-import (
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/oasdiff/oasdiff/diff"
-)
+import "github.com/oasdiff/oasdiff/diff"
 
 const (
 	RequestBodyAnyOfAddedId       = "request-body-any-of-added"
@@ -128,43 +125,4 @@ func RequestPropertyAnyOfUpdatedCheck(diffReport *diff.Diff, operationsSources *
 		}
 	}
 	return result
-}
-
-func filterValidationEquivalentDeletedSubschemas(deleted diff.Subschemas, baseRefs, revisionRefs openapi3.SchemaRefs) diff.Subschemas {
-	result := diff.Subschemas{}
-	for _, deletedSubschema := range deleted {
-		if deletedSubschema.Index < 0 || deletedSubschema.Index >= len(baseRefs) {
-			result = append(result, deletedSubschema)
-			continue
-		}
-
-		if hasValidationEquivalentSubschema(baseRefs[deletedSubschema.Index], revisionRefs) {
-			continue
-		}
-
-		result = append(result, deletedSubschema)
-	}
-
-	return result
-}
-
-func hasValidationEquivalentSubschema(schemaRef *openapi3.SchemaRef, schemaRefs openapi3.SchemaRefs) bool {
-	for _, candidateRef := range schemaRefs {
-		if !isInlineRefactor(schemaRef, candidateRef) {
-			continue
-		}
-		if diff.SchemaRefsValidationEquivalent(schemaRef, candidateRef) {
-			return true
-		}
-	}
-
-	return false
-}
-
-func isInlineRefactor(schemaRef1, schemaRef2 *openapi3.SchemaRef) bool {
-	if schemaRef1 == nil || schemaRef2 == nil {
-		return false
-	}
-
-	return (schemaRef1.Ref == "") != (schemaRef2.Ref == "")
 }

--- a/checker/check_request_property_any_of_updated.go
+++ b/checker/check_request_property_any_of_updated.go
@@ -39,18 +39,25 @@ func RequestPropertyAnyOfUpdatedCheck(diffReport *diff.Diff, operationsSources *
 					continue
 				}
 
-				if mediaTypeDiff.SchemaDiff.AnyOfDiff != nil && len(mediaTypeDiff.SchemaDiff.AnyOfDiff.Added) > 0 {
-					baseSource, revisionSource := SubschemaSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "anyOf", -1, mediaTypeDiff.SchemaDiff.AnyOfDiff.Added[0].Index)
-					result = append(result, NewApiChange(
-						RequestBodyAnyOfAddedId,
-						config,
-						[]any{mediaTypeDiff.SchemaDiff.AnyOfDiff.Added.String()},
-						"",
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
-					).WithSources(baseSource, revisionSource))
+				if mediaTypeDiff.SchemaDiff.AnyOfDiff != nil {
+					added := filterValidationEquivalentAddedSubschemas(
+						mediaTypeDiff.SchemaDiff.AnyOfDiff.Added,
+						mediaTypeDiff.SchemaDiff.Base.AnyOf,
+						mediaTypeDiff.SchemaDiff.Revision.AnyOf,
+					)
+					if len(added) > 0 {
+						baseSource, revisionSource := SubschemaSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "anyOf", -1, added[0].Index)
+						result = append(result, NewApiChange(
+							RequestBodyAnyOfAddedId,
+							config,
+							[]any{added.String()},
+							"",
+							operationsSources,
+							operationItem.Revision,
+							operation,
+							path,
+						).WithSources(baseSource, revisionSource))
+					}
 				}
 
 				if mediaTypeDiff.SchemaDiff.AnyOfDiff != nil {
@@ -88,12 +95,17 @@ func RequestPropertyAnyOfUpdatedCheck(diffReport *diff.Diff, operationsSources *
 
 						propName := propertyFullName(propertyPath, propertyName)
 
-						if len(propertyDiff.AnyOfDiff.Added) > 0 {
-							propBaseSource, propRevisionSource := SubschemaSources(operationsSources, operationItem, propertyDiff, "anyOf", -1, propertyDiff.AnyOfDiff.Added[0].Index)
+						added := filterValidationEquivalentAddedSubschemas(
+							propertyDiff.AnyOfDiff.Added,
+							propertyDiff.Base.AnyOf,
+							propertyDiff.Revision.AnyOf,
+						)
+						if len(added) > 0 {
+							propBaseSource, propRevisionSource := SubschemaSources(operationsSources, operationItem, propertyDiff, "anyOf", -1, added[0].Index)
 							result = append(result, NewApiChange(
 								RequestPropertyAnyOfAddedId,
 								config,
-								[]any{propertyDiff.AnyOfDiff.Added.String(), propName},
+								[]any{added.String(), propName},
 								"",
 								operationsSources,
 								operationItem.Revision,

--- a/checker/check_request_property_any_of_updated.go
+++ b/checker/check_request_property_any_of_updated.go
@@ -58,9 +58,7 @@ func RequestPropertyAnyOfUpdatedCheck(diffReport *diff.Diff, operationsSources *
 							path,
 						).WithSources(baseSource, revisionSource))
 					}
-				}
 
-				if mediaTypeDiff.SchemaDiff.AnyOfDiff != nil {
 					deleted := filterValidationEquivalentDeletedSubschemas(
 						mediaTypeDiff.SchemaDiff.AnyOfDiff.Deleted,
 						mediaTypeDiff.SchemaDiff.Base.AnyOf,

--- a/checker/check_request_property_any_of_updated.go
+++ b/checker/check_request_property_any_of_updated.go
@@ -56,7 +56,7 @@ func RequestPropertyAnyOfUpdatedCheck(diffReport *diff.Diff, operationsSources *
 							operationItem.Revision,
 							operation,
 							path,
-						).WithSources(baseSource, revisionSource))
+						).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
 					}
 
 					deleted := filterValidationEquivalentDeletedSubschemas(
@@ -75,7 +75,7 @@ func RequestPropertyAnyOfUpdatedCheck(diffReport *diff.Diff, operationsSources *
 							operationItem.Revision,
 							operation,
 							path,
-						).WithSources(baseSource, revisionSource))
+						).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
 					}
 				}
 

--- a/checker/check_request_property_any_of_updated_test.go
+++ b/checker/check_request_property_any_of_updated_test.go
@@ -119,6 +119,42 @@ func TestRequestPropertyAnyOfInlineEnumRefactorToRef(t *testing.T) {
 	require.Empty(t, anyOfChanges)
 }
 
+// CL: body-level anyOf added/removed changes carry media-type details so
+// reports can tell which media type each change belongs to when a request
+// body has more than one. Without WithDetails the entries are identical
+// and visitors can't tell apart "added Rabbit on application/json" from
+// "added Rabbit on application/xml".
+func TestRequestBodyAnyOfMultiMediaTypeDetails(t *testing.T) {
+	s1, err := open("../data/checker/request_body_any_of_media_type_base.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/checker/request_body_any_of_media_type_revision.yaml")
+	require.NoError(t, err)
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyAnyOfUpdatedCheck), d, osm, checker.INFO)
+
+	var addedDetails, removedDetails []string
+	for _, e := range errs {
+		c := e.(checker.ApiChange)
+		switch c.Id {
+		case checker.RequestBodyAnyOfAddedId:
+			addedDetails = append(addedDetails, c.Details)
+		case checker.RequestBodyAnyOfRemovedId:
+			removedDetails = append(removedDetails, c.Details)
+		}
+	}
+
+	require.ElementsMatch(t, []string{
+		"(media type: application/json)",
+		"(media type: application/xml)",
+	}, addedDetails)
+	require.ElementsMatch(t, []string{
+		"(media type: application/json)",
+		"(media type: application/xml)",
+	}, removedDetails)
+}
+
 // CL: no changes when paths diff is nil
 func TestRequestPropertyAnyOfNoPathsDiff(t *testing.T) {
 	config := &checker.Config{}

--- a/checker/check_request_property_any_of_updated_test.go
+++ b/checker/check_request_property_any_of_updated_test.go
@@ -100,6 +100,23 @@ func TestRequestPropertyAnyOfRemoved(t *testing.T) {
 		}}, errs)
 }
 
+// BC: refactoring an anyOf branch from inline enum to an equivalent $ref is not breaking
+func TestRequestPropertyAnyOfInlineEnumRefactorToRef(t *testing.T) {
+	s1, err := open("../data/checker/request_property_any_of_ref_inline_enum_base.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/checker/request_property_any_of_ref_inline_enum_revision.yaml")
+	require.NoError(t, err)
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+
+	breakingChanges := checker.CheckBackwardCompatibility(allChecksConfig(), d, osm)
+	require.Empty(t, breakingChanges)
+
+	anyOfChanges := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyAnyOfUpdatedCheck), d, osm, checker.INFO)
+	require.False(t, containsId(anyOfChanges, checker.RequestPropertyAnyOfRemovedId))
+}
+
 // CL: no changes when paths diff is nil
 func TestRequestPropertyAnyOfNoPathsDiff(t *testing.T) {
 	config := &checker.Config{}

--- a/checker/check_request_property_any_of_updated_test.go
+++ b/checker/check_request_property_any_of_updated_test.go
@@ -114,7 +114,9 @@ func TestRequestPropertyAnyOfInlineEnumRefactorToRef(t *testing.T) {
 	require.Empty(t, breakingChanges)
 
 	anyOfChanges := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyAnyOfUpdatedCheck), d, osm, checker.INFO)
+	require.False(t, containsId(anyOfChanges, checker.RequestPropertyAnyOfAddedId))
 	require.False(t, containsId(anyOfChanges, checker.RequestPropertyAnyOfRemovedId))
+	require.Empty(t, anyOfChanges)
 }
 
 // CL: no changes when paths diff is nil

--- a/checker/check_request_property_one_of_updated.go
+++ b/checker/check_request_property_one_of_updated.go
@@ -55,18 +55,25 @@ func RequestPropertyOneOfUpdatedCheck(diffReport *diff.Diff, operationsSources *
 					).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
 				}
 
-				if mediaTypeDiff.SchemaDiff.OneOfDiff != nil && len(mediaTypeDiff.SchemaDiff.OneOfDiff.Deleted) > 0 {
-					baseSource, revisionSource := SubschemaSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "oneOf", mediaTypeDiff.SchemaDiff.OneOfDiff.Deleted[0].Index, -1)
-					result = append(result, NewApiChange(
-						RequestBodyOneOfRemovedId,
-						config,
-						[]any{mediaTypeDiff.SchemaDiff.OneOfDiff.Deleted.String()},
-						"",
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
-					).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
+				if mediaTypeDiff.SchemaDiff.OneOfDiff != nil {
+					deleted := filterValidationEquivalentDeletedSubschemas(
+						mediaTypeDiff.SchemaDiff.OneOfDiff.Deleted,
+						mediaTypeDiff.SchemaDiff.Base.OneOf,
+						mediaTypeDiff.SchemaDiff.Revision.OneOf,
+					)
+					if len(deleted) > 0 {
+						baseSource, revisionSource := SubschemaSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "oneOf", deleted[0].Index, -1)
+						result = append(result, NewApiChange(
+							RequestBodyOneOfRemovedId,
+							config,
+							[]any{deleted.String()},
+							"",
+							operationsSources,
+							operationItem.Revision,
+							operation,
+							path,
+						).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
+					}
 				}
 
 				CheckModifiedPropertiesDiff(
@@ -97,12 +104,17 @@ func RequestPropertyOneOfUpdatedCheck(diffReport *diff.Diff, operationsSources *
 							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
 						}
 
-						if len(propertyDiff.OneOfDiff.Deleted) > 0 {
-							propBaseSource, propRevisionSource := SubschemaSources(operationsSources, operationItem, propertyDiff, "oneOf", propertyDiff.OneOfDiff.Deleted[0].Index, -1)
+						deleted := filterValidationEquivalentDeletedSubschemas(
+							propertyDiff.OneOfDiff.Deleted,
+							propertyDiff.Base.OneOf,
+							propertyDiff.Revision.OneOf,
+						)
+						if len(deleted) > 0 {
+							propBaseSource, propRevisionSource := SubschemaSources(operationsSources, operationItem, propertyDiff, "oneOf", deleted[0].Index, -1)
 							result = append(result, NewApiChange(
 								RequestPropertyOneOfRemovedId,
 								config,
-								[]any{propertyDiff.OneOfDiff.Deleted.String(), propName},
+								[]any{deleted.String(), propName},
 								"",
 								operationsSources,
 								operationItem.Revision,

--- a/checker/check_request_property_one_of_updated.go
+++ b/checker/check_request_property_one_of_updated.go
@@ -60,9 +60,7 @@ func RequestPropertyOneOfUpdatedCheck(diffReport *diff.Diff, operationsSources *
 							path,
 						).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
 					}
-				}
 
-				if mediaTypeDiff.SchemaDiff.OneOfDiff != nil {
 					deleted := filterValidationEquivalentDeletedSubschemas(
 						mediaTypeDiff.SchemaDiff.OneOfDiff.Deleted,
 						mediaTypeDiff.SchemaDiff.Base.OneOf,

--- a/checker/check_request_property_one_of_updated.go
+++ b/checker/check_request_property_one_of_updated.go
@@ -41,18 +41,25 @@ func RequestPropertyOneOfUpdatedCheck(diffReport *diff.Diff, operationsSources *
 					continue
 				}
 
-				if mediaTypeDiff.SchemaDiff.OneOfDiff != nil && len(mediaTypeDiff.SchemaDiff.OneOfDiff.Added) > 0 {
-					baseSource, revisionSource := SubschemaSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "oneOf", -1, mediaTypeDiff.SchemaDiff.OneOfDiff.Added[0].Index)
-					result = append(result, NewApiChange(
-						RequestBodyOneOfAddedId,
-						config,
-						[]any{mediaTypeDiff.SchemaDiff.OneOfDiff.Added.String()},
-						"",
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
-					).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
+				if mediaTypeDiff.SchemaDiff.OneOfDiff != nil {
+					added := filterValidationEquivalentAddedSubschemas(
+						mediaTypeDiff.SchemaDiff.OneOfDiff.Added,
+						mediaTypeDiff.SchemaDiff.Base.OneOf,
+						mediaTypeDiff.SchemaDiff.Revision.OneOf,
+					)
+					if len(added) > 0 {
+						baseSource, revisionSource := SubschemaSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "oneOf", -1, added[0].Index)
+						result = append(result, NewApiChange(
+							RequestBodyOneOfAddedId,
+							config,
+							[]any{added.String()},
+							"",
+							operationsSources,
+							operationItem.Revision,
+							operation,
+							path,
+						).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
+					}
 				}
 
 				if mediaTypeDiff.SchemaDiff.OneOfDiff != nil {
@@ -90,12 +97,17 @@ func RequestPropertyOneOfUpdatedCheck(diffReport *diff.Diff, operationsSources *
 
 						propName := propertyFullName(propertyPath, propertyName)
 
-						if len(propertyDiff.OneOfDiff.Added) > 0 {
-							propBaseSource, propRevisionSource := SubschemaSources(operationsSources, operationItem, propertyDiff, "oneOf", -1, propertyDiff.OneOfDiff.Added[0].Index)
+						added := filterValidationEquivalentAddedSubschemas(
+							propertyDiff.OneOfDiff.Added,
+							propertyDiff.Base.OneOf,
+							propertyDiff.Revision.OneOf,
+						)
+						if len(added) > 0 {
+							propBaseSource, propRevisionSource := SubschemaSources(operationsSources, operationItem, propertyDiff, "oneOf", -1, added[0].Index)
 							result = append(result, NewApiChange(
 								RequestPropertyOneOfAddedId,
 								config,
-								[]any{propertyDiff.OneOfDiff.Added.String(), propName},
+								[]any{added.String(), propName},
 								"",
 								operationsSources,
 								operationItem.Revision,

--- a/checker/check_response_property_any_of_updated.go
+++ b/checker/check_response_property_any_of_updated.go
@@ -63,9 +63,7 @@ func ResponsePropertyAnyOfUpdatedCheck(diffReport *diff.Diff, operationsSources 
 								path,
 							).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
 						}
-					}
 
-					if mediaTypeDiff.SchemaDiff.AnyOfDiff != nil {
 						deleted := filterValidationEquivalentDeletedSubschemas(
 							mediaTypeDiff.SchemaDiff.AnyOfDiff.Deleted,
 							mediaTypeDiff.SchemaDiff.Base.AnyOf,

--- a/checker/check_response_property_any_of_updated.go
+++ b/checker/check_response_property_any_of_updated.go
@@ -58,18 +58,25 @@ func ResponsePropertyAnyOfUpdatedCheck(diffReport *diff.Diff, operationsSources 
 						).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
 					}
 
-					if mediaTypeDiff.SchemaDiff.AnyOfDiff != nil && len(mediaTypeDiff.SchemaDiff.AnyOfDiff.Deleted) > 0 {
-						baseSource, revisionSource := SubschemaSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "anyOf", mediaTypeDiff.SchemaDiff.AnyOfDiff.Deleted[0].Index, -1)
-						result = append(result, NewApiChange(
-							ResponseBodyAnyOfRemovedId,
-							config,
-							[]any{mediaTypeDiff.SchemaDiff.AnyOfDiff.Deleted.String(), responseStatus},
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
+					if mediaTypeDiff.SchemaDiff.AnyOfDiff != nil {
+						deleted := filterValidationEquivalentDeletedSubschemas(
+							mediaTypeDiff.SchemaDiff.AnyOfDiff.Deleted,
+							mediaTypeDiff.SchemaDiff.Base.AnyOf,
+							mediaTypeDiff.SchemaDiff.Revision.AnyOf,
+						)
+						if len(deleted) > 0 {
+							baseSource, revisionSource := SubschemaSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "anyOf", deleted[0].Index, -1)
+							result = append(result, NewApiChange(
+								ResponseBodyAnyOfRemovedId,
+								config,
+								[]any{deleted.String(), responseStatus},
+								"",
+								operationsSources,
+								operationItem.Revision,
+								operation,
+								path,
+							).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
+						}
 					}
 
 					CheckModifiedPropertiesDiff(
@@ -98,12 +105,17 @@ func ResponsePropertyAnyOfUpdatedCheck(diffReport *diff.Diff, operationsSources 
 								).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
 							}
 
-							if len(propertyDiff.AnyOfDiff.Deleted) > 0 {
-								propBaseSource, propRevisionSource := SubschemaSources(operationsSources, operationItem, propertyDiff, "anyOf", propertyDiff.AnyOfDiff.Deleted[0].Index, -1)
+							deleted := filterValidationEquivalentDeletedSubschemas(
+								propertyDiff.AnyOfDiff.Deleted,
+								propertyDiff.Base.AnyOf,
+								propertyDiff.Revision.AnyOf,
+							)
+							if len(deleted) > 0 {
+								propBaseSource, propRevisionSource := SubschemaSources(operationsSources, operationItem, propertyDiff, "anyOf", deleted[0].Index, -1)
 								result = append(result, NewApiChange(
 									ResponsePropertyAnyOfRemovedId,
 									config,
-									[]any{propertyDiff.AnyOfDiff.Deleted.String(), propertyFullName(propertyPath, propertyName), responseStatus},
+									[]any{deleted.String(), propertyFullName(propertyPath, propertyName), responseStatus},
 									"",
 									operationsSources,
 									operationItem.Revision,

--- a/checker/check_response_property_any_of_updated.go
+++ b/checker/check_response_property_any_of_updated.go
@@ -44,18 +44,25 @@ func ResponsePropertyAnyOfUpdatedCheck(diffReport *diff.Diff, operationsSources 
 						continue
 					}
 
-					if mediaTypeDiff.SchemaDiff.AnyOfDiff != nil && len(mediaTypeDiff.SchemaDiff.AnyOfDiff.Added) > 0 {
-						baseSource, revisionSource := SubschemaSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "anyOf", -1, mediaTypeDiff.SchemaDiff.AnyOfDiff.Added[0].Index)
-						result = append(result, NewApiChange(
-							ResponseBodyAnyOfAddedId,
-							config,
-							[]any{mediaTypeDiff.SchemaDiff.AnyOfDiff.Added.String(), responseStatus},
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
+					if mediaTypeDiff.SchemaDiff.AnyOfDiff != nil {
+						added := filterValidationEquivalentAddedSubschemas(
+							mediaTypeDiff.SchemaDiff.AnyOfDiff.Added,
+							mediaTypeDiff.SchemaDiff.Base.AnyOf,
+							mediaTypeDiff.SchemaDiff.Revision.AnyOf,
+						)
+						if len(added) > 0 {
+							baseSource, revisionSource := SubschemaSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "anyOf", -1, added[0].Index)
+							result = append(result, NewApiChange(
+								ResponseBodyAnyOfAddedId,
+								config,
+								[]any{added.String(), responseStatus},
+								"",
+								operationsSources,
+								operationItem.Revision,
+								operation,
+								path,
+							).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
+						}
 					}
 
 					if mediaTypeDiff.SchemaDiff.AnyOfDiff != nil {
@@ -91,12 +98,17 @@ func ResponsePropertyAnyOfUpdatedCheck(diffReport *diff.Diff, operationsSources 
 								return
 							}
 
-							if len(propertyDiff.AnyOfDiff.Added) > 0 {
-								propBaseSource, propRevisionSource := SubschemaSources(operationsSources, operationItem, propertyDiff, "anyOf", -1, propertyDiff.AnyOfDiff.Added[0].Index)
+							added := filterValidationEquivalentAddedSubschemas(
+								propertyDiff.AnyOfDiff.Added,
+								propertyDiff.Base.AnyOf,
+								propertyDiff.Revision.AnyOf,
+							)
+							if len(added) > 0 {
+								propBaseSource, propRevisionSource := SubschemaSources(operationsSources, operationItem, propertyDiff, "anyOf", -1, added[0].Index)
 								result = append(result, NewApiChange(
 									ResponsePropertyAnyOfAddedId,
 									config,
-									[]any{propertyDiff.AnyOfDiff.Added.String(), propertyFullName(propertyPath, propertyName), responseStatus},
+									[]any{added.String(), propertyFullName(propertyPath, propertyName), responseStatus},
 									"",
 									operationsSources,
 									operationItem.Revision,

--- a/checker/check_response_property_one_of_updated.go
+++ b/checker/check_response_property_one_of_updated.go
@@ -44,18 +44,25 @@ func ResponsePropertyOneOfUpdated(diffReport *diff.Diff, operationsSources *diff
 						continue
 					}
 
-					if mediaTypeDiff.SchemaDiff.OneOfDiff != nil && len(mediaTypeDiff.SchemaDiff.OneOfDiff.Added) > 0 {
-						baseSource, revisionSource := SubschemaSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "oneOf", -1, mediaTypeDiff.SchemaDiff.OneOfDiff.Added[0].Index)
-						result = append(result, NewApiChange(
-							ResponseBodyOneOfAddedId,
-							config,
-							[]any{mediaTypeDiff.SchemaDiff.OneOfDiff.Added.String(), responseStatus},
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
+					if mediaTypeDiff.SchemaDiff.OneOfDiff != nil {
+						added := filterValidationEquivalentAddedSubschemas(
+							mediaTypeDiff.SchemaDiff.OneOfDiff.Added,
+							mediaTypeDiff.SchemaDiff.Base.OneOf,
+							mediaTypeDiff.SchemaDiff.Revision.OneOf,
+						)
+						if len(added) > 0 {
+							baseSource, revisionSource := SubschemaSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "oneOf", -1, added[0].Index)
+							result = append(result, NewApiChange(
+								ResponseBodyOneOfAddedId,
+								config,
+								[]any{added.String(), responseStatus},
+								"",
+								operationsSources,
+								operationItem.Revision,
+								operation,
+								path,
+							).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
+						}
 					}
 
 					if mediaTypeDiff.SchemaDiff.OneOfDiff != nil {
@@ -93,12 +100,17 @@ func ResponsePropertyOneOfUpdated(diffReport *diff.Diff, operationsSources *diff
 
 							propName := propertyFullName(propertyPath, propertyName)
 
-							if len(propertyDiff.OneOfDiff.Added) > 0 {
-								propBaseSource, propRevisionSource := SubschemaSources(operationsSources, operationItem, propertyDiff, "oneOf", -1, propertyDiff.OneOfDiff.Added[0].Index)
+							added := filterValidationEquivalentAddedSubschemas(
+								propertyDiff.OneOfDiff.Added,
+								propertyDiff.Base.OneOf,
+								propertyDiff.Revision.OneOf,
+							)
+							if len(added) > 0 {
+								propBaseSource, propRevisionSource := SubschemaSources(operationsSources, operationItem, propertyDiff, "oneOf", -1, added[0].Index)
 								result = append(result, NewApiChange(
 									ResponsePropertyOneOfAddedId,
 									config,
-									[]any{propertyDiff.OneOfDiff.Added.String(), propName, responseStatus},
+									[]any{added.String(), propName, responseStatus},
 									"",
 									operationsSources,
 									operationItem.Revision,

--- a/checker/check_response_property_one_of_updated.go
+++ b/checker/check_response_property_one_of_updated.go
@@ -63,9 +63,7 @@ func ResponsePropertyOneOfUpdated(diffReport *diff.Diff, operationsSources *diff
 								path,
 							).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
 						}
-					}
 
-					if mediaTypeDiff.SchemaDiff.OneOfDiff != nil {
 						deleted := filterValidationEquivalentDeletedSubschemas(
 							mediaTypeDiff.SchemaDiff.OneOfDiff.Deleted,
 							mediaTypeDiff.SchemaDiff.Base.OneOf,

--- a/checker/check_response_property_one_of_updated.go
+++ b/checker/check_response_property_one_of_updated.go
@@ -58,18 +58,25 @@ func ResponsePropertyOneOfUpdated(diffReport *diff.Diff, operationsSources *diff
 						).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
 					}
 
-					if mediaTypeDiff.SchemaDiff.OneOfDiff != nil && len(mediaTypeDiff.SchemaDiff.OneOfDiff.Deleted) > 0 {
-						baseSource, revisionSource := SubschemaSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "oneOf", mediaTypeDiff.SchemaDiff.OneOfDiff.Deleted[0].Index, -1)
-						result = append(result, NewApiChange(
-							ResponseBodyOneOfRemovedId,
-							config,
-							[]any{mediaTypeDiff.SchemaDiff.OneOfDiff.Deleted.String(), responseStatus},
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
+					if mediaTypeDiff.SchemaDiff.OneOfDiff != nil {
+						deleted := filterValidationEquivalentDeletedSubschemas(
+							mediaTypeDiff.SchemaDiff.OneOfDiff.Deleted,
+							mediaTypeDiff.SchemaDiff.Base.OneOf,
+							mediaTypeDiff.SchemaDiff.Revision.OneOf,
+						)
+						if len(deleted) > 0 {
+							baseSource, revisionSource := SubschemaSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "oneOf", deleted[0].Index, -1)
+							result = append(result, NewApiChange(
+								ResponseBodyOneOfRemovedId,
+								config,
+								[]any{deleted.String(), responseStatus},
+								"",
+								operationsSources,
+								operationItem.Revision,
+								operation,
+								path,
+							).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
+						}
 					}
 
 					CheckModifiedPropertiesDiff(
@@ -100,12 +107,17 @@ func ResponsePropertyOneOfUpdated(diffReport *diff.Diff, operationsSources *diff
 								).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
 							}
 
-							if len(propertyDiff.OneOfDiff.Deleted) > 0 {
-								propBaseSource, propRevisionSource := SubschemaSources(operationsSources, operationItem, propertyDiff, "oneOf", propertyDiff.OneOfDiff.Deleted[0].Index, -1)
+							deleted := filterValidationEquivalentDeletedSubschemas(
+								propertyDiff.OneOfDiff.Deleted,
+								propertyDiff.Base.OneOf,
+								propertyDiff.Revision.OneOf,
+							)
+							if len(deleted) > 0 {
+								propBaseSource, propRevisionSource := SubschemaSources(operationsSources, operationItem, propertyDiff, "oneOf", deleted[0].Index, -1)
 								result = append(result, NewApiChange(
 									ResponsePropertyOneOfRemovedId,
 									config,
-									[]any{propertyDiff.OneOfDiff.Deleted.String(), propName, responseStatus},
+									[]any{deleted.String(), propName, responseStatus},
 									"",
 									operationsSources,
 									operationItem.Revision,

--- a/checker/check_x_of_validation_equivalence.go
+++ b/checker/check_x_of_validation_equivalence.go
@@ -1,0 +1,47 @@
+package checker
+
+import (
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/oasdiff/diff"
+)
+
+func filterValidationEquivalentDeletedSubschemas(deleted diff.Subschemas, baseRefs, revisionRefs openapi3.SchemaRefs) diff.Subschemas {
+	result := diff.Subschemas{}
+	for _, deletedSubschema := range deleted {
+		if deletedSubschema.Index < 0 || deletedSubschema.Index >= len(baseRefs) {
+			result = append(result, deletedSubschema)
+			continue
+		}
+
+		if hasValidationEquivalentSubschema(baseRefs[deletedSubschema.Index], revisionRefs) {
+			continue
+		}
+
+		result = append(result, deletedSubschema)
+	}
+
+	return result
+}
+
+func hasValidationEquivalentSubschema(schemaRef *openapi3.SchemaRef, schemaRefs openapi3.SchemaRefs) bool {
+	// This is O(deleted x revision); x-of lists are typically short, and the
+	// conservative inline/$ref boundary keeps the extra diffing scoped.
+	for _, candidateRef := range schemaRefs {
+		if !isInlineRefactor(schemaRef, candidateRef) {
+			continue
+		}
+		if diff.SchemaRefsValidationEquivalent(schemaRef, candidateRef) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isInlineRefactor(schemaRef1, schemaRef2 *openapi3.SchemaRef) bool {
+	if schemaRef1 == nil || schemaRef2 == nil {
+		return false
+	}
+
+	return (schemaRef1.Ref == "") != (schemaRef2.Ref == "")
+}

--- a/checker/check_x_of_validation_equivalence.go
+++ b/checker/check_x_of_validation_equivalence.go
@@ -23,8 +23,26 @@ func filterValidationEquivalentDeletedSubschemas(deleted diff.Subschemas, baseRe
 	return result
 }
 
+func filterValidationEquivalentAddedSubschemas(added diff.Subschemas, baseRefs, revisionRefs openapi3.SchemaRefs) diff.Subschemas {
+	result := diff.Subschemas{}
+	for _, addedSubschema := range added {
+		if addedSubschema.Index < 0 || addedSubschema.Index >= len(revisionRefs) {
+			result = append(result, addedSubschema)
+			continue
+		}
+
+		if hasValidationEquivalentSubschema(revisionRefs[addedSubschema.Index], baseRefs) {
+			continue
+		}
+
+		result = append(result, addedSubschema)
+	}
+
+	return result
+}
+
 func hasValidationEquivalentSubschema(schemaRef *openapi3.SchemaRef, schemaRefs openapi3.SchemaRefs) bool {
-	// This is O(deleted x revision); x-of lists are typically short, and the
+	// This is O(source x candidate); x-of lists are typically short, and the
 	// conservative inline/$ref boundary keeps the extra diffing scoped.
 	for _, candidateRef := range schemaRefs {
 		if !isInlineRefactor(schemaRef, candidateRef) {

--- a/checker/check_x_of_validation_equivalence.go
+++ b/checker/check_x_of_validation_equivalence.go
@@ -20,6 +20,9 @@ func filterValidationEquivalentAddedSubschemas(added diff.Subschemas, baseRefs, 
 func filterValidationEquivalentSubschemas(subschemas diff.Subschemas, originRefs, peerRefs openapi3.SchemaRefs) diff.Subschemas {
 	result := diff.Subschemas{}
 	for _, subschema := range subschemas {
+		// Subschema.Index is set by the diff engine from a walk over originRefs,
+		// so out-of-range is an upstream invariant violation. Pass the entry
+		// through unfiltered rather than silently suppressing.
 		if subschema.Index < 0 || subschema.Index >= len(originRefs) {
 			result = append(result, subschema)
 			continue

--- a/checker/check_x_of_validation_equivalence.go
+++ b/checker/check_x_of_validation_equivalence.go
@@ -6,36 +6,30 @@ import (
 )
 
 func filterValidationEquivalentDeletedSubschemas(deleted diff.Subschemas, baseRefs, revisionRefs openapi3.SchemaRefs) diff.Subschemas {
-	result := diff.Subschemas{}
-	for _, deletedSubschema := range deleted {
-		if deletedSubschema.Index < 0 || deletedSubschema.Index >= len(baseRefs) {
-			result = append(result, deletedSubschema)
-			continue
-		}
-
-		if hasValidationEquivalentSubschema(baseRefs[deletedSubschema.Index], revisionRefs) {
-			continue
-		}
-
-		result = append(result, deletedSubschema)
-	}
-
-	return result
+	return filterValidationEquivalentSubschemas(deleted, baseRefs, revisionRefs)
 }
 
 func filterValidationEquivalentAddedSubschemas(added diff.Subschemas, baseRefs, revisionRefs openapi3.SchemaRefs) diff.Subschemas {
+	return filterValidationEquivalentSubschemas(added, revisionRefs, baseRefs)
+}
+
+// filterValidationEquivalentSubschemas keeps entries from subschemas whose
+// origin-side ref has no validation-equivalent inline/$ref peer on the other
+// side. originRefs is the side the entries came from (base for deleted,
+// revision for added); peerRefs is the side searched for a peer.
+func filterValidationEquivalentSubschemas(subschemas diff.Subschemas, originRefs, peerRefs openapi3.SchemaRefs) diff.Subschemas {
 	result := diff.Subschemas{}
-	for _, addedSubschema := range added {
-		if addedSubschema.Index < 0 || addedSubschema.Index >= len(revisionRefs) {
-			result = append(result, addedSubschema)
+	for _, subschema := range subschemas {
+		if subschema.Index < 0 || subschema.Index >= len(originRefs) {
+			result = append(result, subschema)
 			continue
 		}
 
-		if hasValidationEquivalentSubschema(revisionRefs[addedSubschema.Index], baseRefs) {
+		if hasValidationEquivalentSubschema(originRefs[subschema.Index], peerRefs) {
 			continue
 		}
 
-		result = append(result, addedSubschema)
+		result = append(result, subschema)
 	}
 
 	return result

--- a/checker/check_x_of_validation_equivalence_test.go
+++ b/checker/check_x_of_validation_equivalence_test.go
@@ -1,0 +1,279 @@
+package checker_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/oasdiff/oasdiff/checker"
+	"github.com/oasdiff/oasdiff/diff"
+	"github.com/oasdiff/oasdiff/load"
+	"github.com/stretchr/testify/require"
+)
+
+func TestXOfInlineEnumRefactorToRefDoesNotReportRemoved(t *testing.T) {
+	tests := []struct {
+		name      string
+		check     checker.BackwardCompatibilityCheck
+		removedID string
+		base      string
+		revision  string
+	}{
+		{
+			name:      "request body anyOf",
+			check:     checker.RequestPropertyAnyOfUpdatedCheck,
+			removedID: checker.RequestBodyAnyOfRemovedId,
+			base:      xOfBodySpec("request", "anyOf", false),
+			revision:  xOfBodySpec("request", "anyOf", true),
+		},
+		{
+			name:      "request property anyOf",
+			check:     checker.RequestPropertyAnyOfUpdatedCheck,
+			removedID: checker.RequestPropertyAnyOfRemovedId,
+			base:      xOfPropertySpec("request", "anyOf", false),
+			revision:  xOfPropertySpec("request", "anyOf", true),
+		},
+		{
+			name:      "response body anyOf",
+			check:     checker.ResponsePropertyAnyOfUpdatedCheck,
+			removedID: checker.ResponseBodyAnyOfRemovedId,
+			base:      xOfBodySpec("response", "anyOf", false),
+			revision:  xOfBodySpec("response", "anyOf", true),
+		},
+		{
+			name:      "response property anyOf",
+			check:     checker.ResponsePropertyAnyOfUpdatedCheck,
+			removedID: checker.ResponsePropertyAnyOfRemovedId,
+			base:      xOfPropertySpec("response", "anyOf", false),
+			revision:  xOfPropertySpec("response", "anyOf", true),
+		},
+		{
+			name:      "request body oneOf",
+			check:     checker.RequestPropertyOneOfUpdatedCheck,
+			removedID: checker.RequestBodyOneOfRemovedId,
+			base:      xOfBodySpec("request", "oneOf", false),
+			revision:  xOfBodySpec("request", "oneOf", true),
+		},
+		{
+			name:      "request property oneOf",
+			check:     checker.RequestPropertyOneOfUpdatedCheck,
+			removedID: checker.RequestPropertyOneOfRemovedId,
+			base:      xOfPropertySpec("request", "oneOf", false),
+			revision:  xOfPropertySpec("request", "oneOf", true),
+		},
+		{
+			name:      "response body oneOf",
+			check:     checker.ResponsePropertyOneOfUpdated,
+			removedID: checker.ResponseBodyOneOfRemovedId,
+			base:      xOfBodySpec("response", "oneOf", false),
+			revision:  xOfBodySpec("response", "oneOf", true),
+		},
+		{
+			name:      "response property oneOf",
+			check:     checker.ResponsePropertyOneOfUpdated,
+			removedID: checker.ResponsePropertyOneOfRemovedId,
+			base:      xOfPropertySpec("response", "oneOf", false),
+			revision:  xOfPropertySpec("response", "oneOf", true),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			base, revision := loadSpecPairFromStrings(t, test.base, test.revision)
+			diffReport, operationsSources, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), base, revision)
+			require.NoError(t, err)
+
+			changes := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(test.check), diffReport, operationsSources, checker.INFO)
+			require.False(t, containsId(changes, test.removedID))
+		})
+	}
+}
+
+func TestXOfComponentRenameRefactorStillReportsRemoved(t *testing.T) {
+	tests := []struct {
+		name      string
+		keyword   string
+		check     checker.BackwardCompatibilityCheck
+		removedID string
+	}{
+		{
+			name:      "anyOf",
+			keyword:   "anyOf",
+			check:     checker.RequestPropertyAnyOfUpdatedCheck,
+			removedID: checker.RequestPropertyAnyOfRemovedId,
+		},
+		{
+			name:      "oneOf",
+			keyword:   "oneOf",
+			check:     checker.RequestPropertyOneOfUpdatedCheck,
+			removedID: checker.RequestPropertyOneOfRemovedId,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			base, revision := loadSpecPairFromStrings(
+				t,
+				xOfComponentRenameSpec(test.keyword, "UserRoleV1"),
+				xOfComponentRenameSpec(test.keyword, "UserRole"),
+			)
+			diffReport, operationsSources, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), base, revision)
+			require.NoError(t, err)
+
+			changes := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(test.check), diffReport, operationsSources, checker.INFO)
+			require.True(t, containsId(changes, test.removedID))
+		})
+	}
+}
+
+func loadSpecPairFromStrings(t *testing.T, base, revision string) (baseSpec, revisionSpec *load.SpecInfo) {
+	t.Helper()
+
+	dir := t.TempDir()
+	baseFile := filepath.Join(dir, "base.yaml")
+	revisionFile := filepath.Join(dir, "revision.yaml")
+	require.NoError(t, os.WriteFile(baseFile, []byte(base), 0644))
+	require.NoError(t, os.WriteFile(revisionFile, []byte(revision), 0644))
+
+	baseSpec, err := open(baseFile)
+	require.NoError(t, err)
+	revisionSpec, err = open(revisionFile)
+	require.NoError(t, err)
+
+	return baseSpec, revisionSpec
+}
+
+func xOfBodySpec(direction, keyword string, withRef bool) string {
+	return fmt.Sprintf(`openapi: 3.1.0
+info:
+  title: Repro
+  version: 1.0.0
+paths:
+  /users:
+    %s
+components:
+  schemas:
+%s
+`, operationSpec(direction, keyword, false), userRoleComponents("Role", xOfSchema(keyword, withRef), withRef))
+}
+
+func xOfPropertySpec(direction, keyword string, withRef bool) string {
+	schema := fmt.Sprintf(`      type: object
+      properties:
+        role:
+%s`, indent(xOfSchema(keyword, withRef), 10))
+
+	return fmt.Sprintf(`openapi: 3.1.0
+info:
+  title: Repro
+  version: 1.0.0
+paths:
+  /users:
+    %s
+components:
+  schemas:
+%s
+`, operationSpec(direction, keyword, true), userRoleComponents("Payload", schema, withRef))
+}
+
+func xOfComponentRenameSpec(keyword, component string) string {
+	return fmt.Sprintf(`openapi: 3.1.0
+info:
+  title: Repro
+  version: 1.0.0
+paths:
+  /users:
+    put:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Payload"
+      responses:
+        "200":
+          description: OK
+components:
+  schemas:
+    Payload:
+      type: object
+      properties:
+        role:
+          %s:
+            - $ref: "#/components/schemas/%s"
+            - type: "null"
+    %s:
+      type: string
+      enum: [user, superadmin]
+`, keyword, component, component)
+}
+
+func operationSpec(direction, keyword string, withProperty bool) string {
+	schemaRef := "#/components/schemas/Role"
+	if withProperty {
+		schemaRef = "#/components/schemas/Payload"
+	}
+
+	if direction == "request" {
+		return fmt.Sprintf(`put:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "%s"
+      responses:
+        "200":
+          description: OK`, schemaRef)
+	}
+
+	return fmt.Sprintf(`get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "%s"`, schemaRef)
+}
+
+func userRoleComponents(name, schema string, withRef bool) string {
+	components := fmt.Sprintf(`    %s:
+%s`, name, indent(schema, 6))
+	if withRef {
+		components += `    UserRole:
+      type: string
+      enum: [user, superadmin]
+      title: UserRole
+`
+	}
+
+	return components
+}
+
+func xOfSchema(keyword string, withRef bool) string {
+	if withRef {
+		return fmt.Sprintf(`%s:
+  - $ref: "#/components/schemas/UserRole"
+  - type: "null"
+`, keyword)
+	}
+
+	return fmt.Sprintf(`%s:
+  - type: string
+    enum: [user, superadmin]
+  - type: "null"
+`, keyword)
+}
+
+func indent(value string, spaces int) string {
+	prefix := fmt.Sprintf("%*s", spaces, "")
+	result := ""
+	for _, line := range strings.Split(value, "\n") {
+		if line == "" {
+			continue
+		}
+		result += prefix + line + "\n"
+	}
+	return result
+}

--- a/checker/check_x_of_validation_equivalence_test.go
+++ b/checker/check_x_of_validation_equivalence_test.go
@@ -13,10 +13,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestXOfInlineEnumRefactorToRefDoesNotReportRemoved(t *testing.T) {
+func TestXOfInlineEnumRefactorToRefDoesNotReportAddedOrRemoved(t *testing.T) {
 	tests := []struct {
 		name      string
 		check     checker.BackwardCompatibilityCheck
+		addedID   string
 		removedID string
 		base      string
 		revision  string
@@ -24,6 +25,7 @@ func TestXOfInlineEnumRefactorToRefDoesNotReportRemoved(t *testing.T) {
 		{
 			name:      "request body anyOf",
 			check:     checker.RequestPropertyAnyOfUpdatedCheck,
+			addedID:   checker.RequestBodyAnyOfAddedId,
 			removedID: checker.RequestBodyAnyOfRemovedId,
 			base:      xOfBodySpec("request", "anyOf", false),
 			revision:  xOfBodySpec("request", "anyOf", true),
@@ -31,6 +33,7 @@ func TestXOfInlineEnumRefactorToRefDoesNotReportRemoved(t *testing.T) {
 		{
 			name:      "request property anyOf",
 			check:     checker.RequestPropertyAnyOfUpdatedCheck,
+			addedID:   checker.RequestPropertyAnyOfAddedId,
 			removedID: checker.RequestPropertyAnyOfRemovedId,
 			base:      xOfPropertySpec("request", "anyOf", false),
 			revision:  xOfPropertySpec("request", "anyOf", true),
@@ -38,6 +41,7 @@ func TestXOfInlineEnumRefactorToRefDoesNotReportRemoved(t *testing.T) {
 		{
 			name:      "response body anyOf",
 			check:     checker.ResponsePropertyAnyOfUpdatedCheck,
+			addedID:   checker.ResponseBodyAnyOfAddedId,
 			removedID: checker.ResponseBodyAnyOfRemovedId,
 			base:      xOfBodySpec("response", "anyOf", false),
 			revision:  xOfBodySpec("response", "anyOf", true),
@@ -45,6 +49,7 @@ func TestXOfInlineEnumRefactorToRefDoesNotReportRemoved(t *testing.T) {
 		{
 			name:      "response property anyOf",
 			check:     checker.ResponsePropertyAnyOfUpdatedCheck,
+			addedID:   checker.ResponsePropertyAnyOfAddedId,
 			removedID: checker.ResponsePropertyAnyOfRemovedId,
 			base:      xOfPropertySpec("response", "anyOf", false),
 			revision:  xOfPropertySpec("response", "anyOf", true),
@@ -52,6 +57,7 @@ func TestXOfInlineEnumRefactorToRefDoesNotReportRemoved(t *testing.T) {
 		{
 			name:      "request body oneOf",
 			check:     checker.RequestPropertyOneOfUpdatedCheck,
+			addedID:   checker.RequestBodyOneOfAddedId,
 			removedID: checker.RequestBodyOneOfRemovedId,
 			base:      xOfBodySpec("request", "oneOf", false),
 			revision:  xOfBodySpec("request", "oneOf", true),
@@ -59,6 +65,7 @@ func TestXOfInlineEnumRefactorToRefDoesNotReportRemoved(t *testing.T) {
 		{
 			name:      "request property oneOf",
 			check:     checker.RequestPropertyOneOfUpdatedCheck,
+			addedID:   checker.RequestPropertyOneOfAddedId,
 			removedID: checker.RequestPropertyOneOfRemovedId,
 			base:      xOfPropertySpec("request", "oneOf", false),
 			revision:  xOfPropertySpec("request", "oneOf", true),
@@ -66,6 +73,7 @@ func TestXOfInlineEnumRefactorToRefDoesNotReportRemoved(t *testing.T) {
 		{
 			name:      "response body oneOf",
 			check:     checker.ResponsePropertyOneOfUpdated,
+			addedID:   checker.ResponseBodyOneOfAddedId,
 			removedID: checker.ResponseBodyOneOfRemovedId,
 			base:      xOfBodySpec("response", "oneOf", false),
 			revision:  xOfBodySpec("response", "oneOf", true),
@@ -73,6 +81,7 @@ func TestXOfInlineEnumRefactorToRefDoesNotReportRemoved(t *testing.T) {
 		{
 			name:      "response property oneOf",
 			check:     checker.ResponsePropertyOneOfUpdated,
+			addedID:   checker.ResponsePropertyOneOfAddedId,
 			removedID: checker.ResponsePropertyOneOfRemovedId,
 			base:      xOfPropertySpec("response", "oneOf", false),
 			revision:  xOfPropertySpec("response", "oneOf", true),
@@ -86,6 +95,7 @@ func TestXOfInlineEnumRefactorToRefDoesNotReportRemoved(t *testing.T) {
 			require.NoError(t, err)
 
 			changes := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(test.check), diffReport, operationsSources, checker.INFO)
+			require.False(t, containsId(changes, test.addedID))
 			require.False(t, containsId(changes, test.removedID))
 		})
 	}

--- a/data/checker/request_body_any_of_media_type_base.yaml
+++ b/data/checker/request_body_any_of_media_type_base.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.0
+info:
+  title: ACME
+  version: 1.0.0
+
+paths:
+  /pets:
+    post:
+      operationId: updatePets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: "#/components/schemas/Dog"
+                - $ref: "#/components/schemas/Cat"
+          application/xml:
+            schema:
+              anyOf:
+                - $ref: "#/components/schemas/Dog"
+                - $ref: "#/components/schemas/Cat"
+      responses:
+        "200":
+          description: Updated
+
+components:
+  schemas:
+    Dog:
+      type: object
+      properties:
+        name:
+          type: string
+    Cat:
+      type: object
+      properties:
+        name:
+          type: string
+    Rabbit:
+      type: object
+      properties:
+        name:
+          type: string

--- a/data/checker/request_body_any_of_media_type_revision.yaml
+++ b/data/checker/request_body_any_of_media_type_revision.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.0
+info:
+  title: ACME
+  version: 1.0.0
+
+paths:
+  /pets:
+    post:
+      operationId: updatePets
+      requestBody:
+        content:
+          application/json:
+            schema:
+              anyOf:
+                - $ref: "#/components/schemas/Dog"
+                - $ref: "#/components/schemas/Rabbit"
+          application/xml:
+            schema:
+              anyOf:
+                - $ref: "#/components/schemas/Dog"
+                - $ref: "#/components/schemas/Rabbit"
+      responses:
+        "200":
+          description: Updated
+
+components:
+  schemas:
+    Dog:
+      type: object
+      properties:
+        name:
+          type: string
+    Cat:
+      type: object
+      properties:
+        name:
+          type: string
+    Rabbit:
+      type: object
+      properties:
+        name:
+          type: string

--- a/data/checker/request_property_any_of_ref_inline_enum_base.yaml
+++ b/data/checker/request_property_any_of_ref_inline_enum_base.yaml
@@ -1,0 +1,36 @@
+openapi: 3.1.0
+info:
+  title: Repro
+  version: 1.0.0
+
+paths:
+  /users/{user_id}:
+    put:
+      parameters:
+        - name: user_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AdminUserUpdateRequest"
+      responses:
+        "200":
+          description: OK
+
+components:
+  schemas:
+    AdminUserUpdateRequest:
+      type: object
+      properties:
+        role:
+          anyOf:
+            - type: string
+              enum:
+                - user
+                - superadmin
+            - type: "null"
+          title: Role

--- a/data/checker/request_property_any_of_ref_inline_enum_revision.yaml
+++ b/data/checker/request_property_any_of_ref_inline_enum_revision.yaml
@@ -1,0 +1,39 @@
+openapi: 3.1.0
+info:
+  title: Repro
+  version: 1.0.0
+
+paths:
+  /users/{user_id}:
+    put:
+      parameters:
+        - name: user_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AdminUserUpdateRequest"
+      responses:
+        "200":
+          description: OK
+
+components:
+  schemas:
+    AdminUserUpdateRequest:
+      type: object
+      properties:
+        role:
+          anyOf:
+            - $ref: "#/components/schemas/UserRole"
+            - type: "null"
+
+    UserRole:
+      type: string
+      enum:
+        - user
+        - superadmin
+      title: UserRole

--- a/diff/schema_validation_equivalence.go
+++ b/diff/schema_validation_equivalence.go
@@ -17,113 +17,101 @@ func SchemaRefsValidationEquivalent(schemaRef1, schemaRef2 *openapi3.SchemaRef) 
 }
 
 func schemaDiffHasValidationChanges(schemaDiff *SchemaDiff) bool {
-	if schemaDiff == nil {
-		return false
-	}
-
-	if schemaDiff.SchemaAdded ||
-		schemaDiff.SchemaDeleted ||
-		schemaDiff.CircularRefDiff ||
-		!schemaDiff.ExtensionsDiff.Empty() ||
-		subschemasDiffHasValidationChanges(schemaDiff.OneOfDiff) ||
-		subschemasDiffHasValidationChanges(schemaDiff.AnyOfDiff) ||
-		subschemasDiffHasValidationChanges(schemaDiff.AllOfDiff) ||
-		schemaDiffHasValidationChanges(schemaDiff.NotDiff) ||
-		!schemaDiff.TypeDiff.Empty() ||
-		!schemaDiff.ListOfTypesDiff.Empty() ||
-		!schemaDiff.FormatDiff.Empty() ||
-		!schemaDiff.EnumDiff.Empty() ||
-		!schemaDiff.AdditionalPropertiesAllowedDiff.Empty() ||
-		!schemaDiff.UniqueItemsDiff.Empty() ||
-		!schemaDiff.ExclusiveMinDiff.Empty() ||
-		!schemaDiff.ExclusiveMaxDiff.Empty() ||
-		!schemaDiff.NullableDiff.Empty() ||
-		!schemaDiff.ReadOnlyDiff.Empty() ||
-		!schemaDiff.WriteOnlyDiff.Empty() ||
-		!schemaDiff.AllowEmptyValueDiff.Empty() ||
-		!schemaDiff.XMLDiff.Empty() ||
-		!schemaDiff.DeprecatedDiff.Empty() ||
-		!schemaDiff.MinDiff.Empty() ||
-		!schemaDiff.MaxDiff.Empty() ||
-		!schemaDiff.MultipleOfDiff.Empty() ||
-		!schemaDiff.MinLengthDiff.Empty() ||
-		!schemaDiff.MaxLengthDiff.Empty() ||
-		!schemaDiff.PatternDiff.Empty() ||
-		!schemaDiff.MinItemsDiff.Empty() ||
-		!schemaDiff.MaxItemsDiff.Empty() ||
-		schemaDiffHasValidationChanges(schemaDiff.ItemsDiff) ||
-		!schemaDiff.RequiredDiff.Empty() ||
-		schemasDiffHasValidationChanges(schemaDiff.PropertiesDiff) ||
-		!schemaDiff.MinPropsDiff.Empty() ||
-		!schemaDiff.MaxPropsDiff.Empty() ||
-		schemaDiffHasValidationChanges(schemaDiff.AdditionalPropertiesDiff) ||
-		!schemaDiff.DiscriminatorDiff.Empty() ||
-		!schemaDiff.ConstDiff.Empty() ||
-		subschemasDiffHasValidationChanges(schemaDiff.PrefixItemsDiff) ||
-		schemaDiffHasValidationChanges(schemaDiff.ContainsDiff) ||
-		!schemaDiff.MinContainsDiff.Empty() ||
-		!schemaDiff.MaxContainsDiff.Empty() ||
-		schemasDiffHasValidationChanges(schemaDiff.PatternPropertiesDiff) ||
-		schemasDiffHasValidationChanges(schemaDiff.DependentSchemasDiff) ||
-		schemaDiffHasValidationChanges(schemaDiff.PropertyNamesDiff) ||
-		!schemaDiff.UnevaluatedItemsAllowedDiff.Empty() ||
-		schemaDiffHasValidationChanges(schemaDiff.UnevaluatedItemsDiff) ||
-		!schemaDiff.UnevaluatedPropertiesAllowedDiff.Empty() ||
-		schemaDiffHasValidationChanges(schemaDiff.UnevaluatedPropertiesDiff) ||
-		schemaDiffHasValidationChanges(schemaDiff.IfDiff) ||
-		schemaDiffHasValidationChanges(schemaDiff.ThenDiff) ||
-		schemaDiffHasValidationChanges(schemaDiff.ElseDiff) ||
-		!schemaDiff.DependentRequiredDiff.Empty() ||
-		!schemaDiff.SchemaIDDiff.Empty() ||
-		!schemaDiff.AnchorDiff.Empty() ||
-		!schemaDiff.DynamicRefDiff.Empty() ||
-		!schemaDiff.DynamicAnchorDiff.Empty() ||
-		!schemaDiff.ContentMediaTypeDiff.Empty() ||
-		!schemaDiff.ContentEncodingDiff.Empty() ||
-		schemaDiffHasValidationChanges(schemaDiff.ContentSchemaDiff) ||
-		schemasDiffHasValidationChanges(schemaDiff.DefsDiff) ||
-		!schemaDiff.SchemaDialectDiff.Empty() {
-		return true
-	}
-
-	return false
+	validationDiff := schemaDiffWithoutAnnotationChanges(schemaDiff)
+	return !validationDiff.Empty()
 }
 
-func subschemasDiffHasValidationChanges(subschemasDiff *SubschemasDiff) bool {
-	if subschemasDiff == nil {
-		return false
+func schemaDiffWithoutAnnotationChanges(schemaDiff *SchemaDiff) *SchemaDiff {
+	if schemaDiff == nil {
+		return nil
 	}
 
-	if len(subschemasDiff.Added) > 0 || len(subschemasDiff.Deleted) > 0 {
-		return true
+	result := *schemaDiff
+
+	result.TitleDiff = nil
+	result.DescriptionDiff = nil
+	result.DefaultDiff = nil
+	result.ExampleDiff = nil
+	result.ExternalDocsDiff = nil
+	result.ExamplesDiff = nil
+	result.CommentDiff = nil
+
+	result.OneOfDiff = subschemasDiffWithoutAnnotationChanges(schemaDiff.OneOfDiff)
+	result.AnyOfDiff = subschemasDiffWithoutAnnotationChanges(schemaDiff.AnyOfDiff)
+	result.AllOfDiff = subschemasDiffWithoutAnnotationChanges(schemaDiff.AllOfDiff)
+	result.NotDiff = schemaDiffWithoutAnnotationChanges(schemaDiff.NotDiff)
+	result.ItemsDiff = schemaDiffWithoutAnnotationChanges(schemaDiff.ItemsDiff)
+	result.PropertiesDiff = schemasDiffWithoutAnnotationChanges(schemaDiff.PropertiesDiff)
+	result.AdditionalPropertiesDiff = schemaDiffWithoutAnnotationChanges(schemaDiff.AdditionalPropertiesDiff)
+	result.PrefixItemsDiff = subschemasDiffWithoutAnnotationChanges(schemaDiff.PrefixItemsDiff)
+	result.ContainsDiff = schemaDiffWithoutAnnotationChanges(schemaDiff.ContainsDiff)
+	result.PatternPropertiesDiff = schemasDiffWithoutAnnotationChanges(schemaDiff.PatternPropertiesDiff)
+	result.DependentSchemasDiff = schemasDiffWithoutAnnotationChanges(schemaDiff.DependentSchemasDiff)
+	result.PropertyNamesDiff = schemaDiffWithoutAnnotationChanges(schemaDiff.PropertyNamesDiff)
+	result.UnevaluatedItemsDiff = schemaDiffWithoutAnnotationChanges(schemaDiff.UnevaluatedItemsDiff)
+	result.UnevaluatedPropertiesDiff = schemaDiffWithoutAnnotationChanges(schemaDiff.UnevaluatedPropertiesDiff)
+	result.IfDiff = schemaDiffWithoutAnnotationChanges(schemaDiff.IfDiff)
+	result.ThenDiff = schemaDiffWithoutAnnotationChanges(schemaDiff.ThenDiff)
+	result.ElseDiff = schemaDiffWithoutAnnotationChanges(schemaDiff.ElseDiff)
+	result.ContentSchemaDiff = schemaDiffWithoutAnnotationChanges(schemaDiff.ContentSchemaDiff)
+	result.DefsDiff = schemasDiffWithoutAnnotationChanges(schemaDiff.DefsDiff)
+
+	if result.Empty() {
+		return nil
 	}
+
+	return &result
+}
+
+func subschemasDiffWithoutAnnotationChanges(subschemasDiff *SubschemasDiff) *SubschemasDiff {
+	if subschemasDiff == nil {
+		return nil
+	}
+
+	result := *subschemasDiff
+	result.Modified = ModifiedSubschemas{}
 
 	for _, modified := range subschemasDiff.Modified {
 		if modified == nil {
 			continue
 		}
-		if schemaDiffHasValidationChanges(modified.Diff) {
-			return true
+
+		schemaDiff := schemaDiffWithoutAnnotationChanges(modified.Diff)
+		if schemaDiff == nil {
+			continue
 		}
+
+		modifiedCopy := *modified
+		modifiedCopy.Diff = schemaDiff
+		result.Modified = append(result.Modified, &modifiedCopy)
 	}
 
-	return false
+	if result.Empty() {
+		return nil
+	}
+
+	return &result
 }
 
-func schemasDiffHasValidationChanges(schemasDiff *SchemasDiff) bool {
+func schemasDiffWithoutAnnotationChanges(schemasDiff *SchemasDiff) *SchemasDiff {
 	if schemasDiff == nil {
-		return false
+		return nil
 	}
 
-	if len(schemasDiff.Added) > 0 || len(schemasDiff.Deleted) > 0 {
-		return true
-	}
+	result := *schemasDiff
+	result.Modified = ModifiedSchemasMap{}
 
-	for _, schemaDiff := range schemasDiff.Modified {
-		if schemaDiffHasValidationChanges(schemaDiff) {
-			return true
+	for name, schemaDiff := range schemasDiff.Modified {
+		validationDiff := schemaDiffWithoutAnnotationChanges(schemaDiff)
+		if validationDiff == nil {
+			continue
 		}
+		result.Modified[name] = validationDiff
 	}
 
-	return false
+	if result.Empty() {
+		return nil
+	}
+
+	return &result
 }

--- a/diff/schema_validation_equivalence.go
+++ b/diff/schema_validation_equivalence.go
@@ -1,0 +1,129 @@
+package diff
+
+import "github.com/getkin/kin-openapi/openapi3"
+
+// SchemaRefsValidationEquivalent reports whether two resolved schema refs have
+// the same validation contract according to oasdiff's schema diff model.
+// Annotation-only changes such as title, description, examples, default, and
+// comments are ignored. Checker-significant metadata such as deprecated is
+// treated as a contract change.
+func SchemaRefsValidationEquivalent(schemaRef1, schemaRef2 *openapi3.SchemaRef) bool {
+	schemaDiff, err := getSchemaDiff(NewConfig(), newState(), schemaRef1, schemaRef2)
+	if err != nil {
+		return false
+	}
+
+	return !schemaDiffHasValidationChanges(schemaDiff)
+}
+
+func schemaDiffHasValidationChanges(schemaDiff *SchemaDiff) bool {
+	if schemaDiff == nil {
+		return false
+	}
+
+	if schemaDiff.SchemaAdded ||
+		schemaDiff.SchemaDeleted ||
+		schemaDiff.CircularRefDiff ||
+		!schemaDiff.ExtensionsDiff.Empty() ||
+		subschemasDiffHasValidationChanges(schemaDiff.OneOfDiff) ||
+		subschemasDiffHasValidationChanges(schemaDiff.AnyOfDiff) ||
+		subschemasDiffHasValidationChanges(schemaDiff.AllOfDiff) ||
+		schemaDiffHasValidationChanges(schemaDiff.NotDiff) ||
+		!schemaDiff.TypeDiff.Empty() ||
+		!schemaDiff.ListOfTypesDiff.Empty() ||
+		!schemaDiff.FormatDiff.Empty() ||
+		!schemaDiff.EnumDiff.Empty() ||
+		!schemaDiff.AdditionalPropertiesAllowedDiff.Empty() ||
+		!schemaDiff.UniqueItemsDiff.Empty() ||
+		!schemaDiff.ExclusiveMinDiff.Empty() ||
+		!schemaDiff.ExclusiveMaxDiff.Empty() ||
+		!schemaDiff.NullableDiff.Empty() ||
+		!schemaDiff.ReadOnlyDiff.Empty() ||
+		!schemaDiff.WriteOnlyDiff.Empty() ||
+		!schemaDiff.AllowEmptyValueDiff.Empty() ||
+		!schemaDiff.XMLDiff.Empty() ||
+		!schemaDiff.DeprecatedDiff.Empty() ||
+		!schemaDiff.MinDiff.Empty() ||
+		!schemaDiff.MaxDiff.Empty() ||
+		!schemaDiff.MultipleOfDiff.Empty() ||
+		!schemaDiff.MinLengthDiff.Empty() ||
+		!schemaDiff.MaxLengthDiff.Empty() ||
+		!schemaDiff.PatternDiff.Empty() ||
+		!schemaDiff.MinItemsDiff.Empty() ||
+		!schemaDiff.MaxItemsDiff.Empty() ||
+		schemaDiffHasValidationChanges(schemaDiff.ItemsDiff) ||
+		!schemaDiff.RequiredDiff.Empty() ||
+		schemasDiffHasValidationChanges(schemaDiff.PropertiesDiff) ||
+		!schemaDiff.MinPropsDiff.Empty() ||
+		!schemaDiff.MaxPropsDiff.Empty() ||
+		schemaDiffHasValidationChanges(schemaDiff.AdditionalPropertiesDiff) ||
+		!schemaDiff.DiscriminatorDiff.Empty() ||
+		!schemaDiff.ConstDiff.Empty() ||
+		subschemasDiffHasValidationChanges(schemaDiff.PrefixItemsDiff) ||
+		schemaDiffHasValidationChanges(schemaDiff.ContainsDiff) ||
+		!schemaDiff.MinContainsDiff.Empty() ||
+		!schemaDiff.MaxContainsDiff.Empty() ||
+		schemasDiffHasValidationChanges(schemaDiff.PatternPropertiesDiff) ||
+		schemasDiffHasValidationChanges(schemaDiff.DependentSchemasDiff) ||
+		schemaDiffHasValidationChanges(schemaDiff.PropertyNamesDiff) ||
+		!schemaDiff.UnevaluatedItemsAllowedDiff.Empty() ||
+		schemaDiffHasValidationChanges(schemaDiff.UnevaluatedItemsDiff) ||
+		!schemaDiff.UnevaluatedPropertiesAllowedDiff.Empty() ||
+		schemaDiffHasValidationChanges(schemaDiff.UnevaluatedPropertiesDiff) ||
+		schemaDiffHasValidationChanges(schemaDiff.IfDiff) ||
+		schemaDiffHasValidationChanges(schemaDiff.ThenDiff) ||
+		schemaDiffHasValidationChanges(schemaDiff.ElseDiff) ||
+		!schemaDiff.DependentRequiredDiff.Empty() ||
+		!schemaDiff.SchemaIDDiff.Empty() ||
+		!schemaDiff.AnchorDiff.Empty() ||
+		!schemaDiff.DynamicRefDiff.Empty() ||
+		!schemaDiff.DynamicAnchorDiff.Empty() ||
+		!schemaDiff.ContentMediaTypeDiff.Empty() ||
+		!schemaDiff.ContentEncodingDiff.Empty() ||
+		schemaDiffHasValidationChanges(schemaDiff.ContentSchemaDiff) ||
+		schemasDiffHasValidationChanges(schemaDiff.DefsDiff) ||
+		!schemaDiff.SchemaDialectDiff.Empty() {
+		return true
+	}
+
+	return false
+}
+
+func subschemasDiffHasValidationChanges(subschemasDiff *SubschemasDiff) bool {
+	if subschemasDiff == nil {
+		return false
+	}
+
+	if len(subschemasDiff.Added) > 0 || len(subschemasDiff.Deleted) > 0 {
+		return true
+	}
+
+	for _, modified := range subschemasDiff.Modified {
+		if modified == nil {
+			continue
+		}
+		if schemaDiffHasValidationChanges(modified.Diff) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func schemasDiffHasValidationChanges(schemasDiff *SchemasDiff) bool {
+	if schemasDiff == nil {
+		return false
+	}
+
+	if len(schemasDiff.Added) > 0 || len(schemasDiff.Deleted) > 0 {
+		return true
+	}
+
+	for _, schemaDiff := range schemasDiff.Modified {
+		if schemaDiffHasValidationChanges(schemaDiff) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/diff/schema_validation_equivalence_test.go
+++ b/diff/schema_validation_equivalence_test.go
@@ -1,0 +1,80 @@
+package diff_test
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/oasdiff/diff"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchemaRefsValidationEquivalent_IgnoresTitle(t *testing.T) {
+	base := &openapi3.SchemaRef{
+		Value: &openapi3.Schema{
+			Type: &openapi3.Types{"string"},
+			Enum: []any{"user", "superadmin"},
+		},
+	}
+	revision := &openapi3.SchemaRef{
+		Ref: "#/components/schemas/UserRole",
+		Value: &openapi3.Schema{
+			Type:  &openapi3.Types{"string"},
+			Enum:  []any{"user", "superadmin"},
+			Title: "UserRole",
+		},
+	}
+
+	require.True(t, diff.SchemaRefsValidationEquivalent(base, revision))
+}
+
+func TestSchemaRefsValidationEquivalent_DetectsValidationChange(t *testing.T) {
+	base := &openapi3.SchemaRef{
+		Value: &openapi3.Schema{
+			Type: &openapi3.Types{"string"},
+			Enum: []any{"user", "superadmin"},
+		},
+	}
+	revision := &openapi3.SchemaRef{
+		Ref: "#/components/schemas/UserRole",
+		Value: &openapi3.Schema{
+			Type:  &openapi3.Types{"string"},
+			Enum:  []any{"user"},
+			Title: "UserRole",
+		},
+	}
+
+	require.False(t, diff.SchemaRefsValidationEquivalent(base, revision))
+}
+
+func TestSchemaRefsValidationEquivalent_DetectsDeprecatedChange(t *testing.T) {
+	base := &openapi3.SchemaRef{
+		Value: &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: openapi3.Schemas{
+				"role": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type: &openapi3.Types{"string"},
+						Enum: []any{"user", "superadmin"},
+					},
+				},
+			},
+		},
+	}
+	revision := &openapi3.SchemaRef{
+		Ref: "#/components/schemas/UserPayload",
+		Value: &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: openapi3.Schemas{
+				"role": &openapi3.SchemaRef{
+					Value: &openapi3.Schema{
+						Type:       &openapi3.Types{"string"},
+						Enum:       []any{"user", "superadmin"},
+						Deprecated: true,
+					},
+				},
+			},
+		},
+	}
+
+	require.False(t, diff.SchemaRefsValidationEquivalent(base, revision))
+}

--- a/diff/schema_validation_equivalence_test.go
+++ b/diff/schema_validation_equivalence_test.go
@@ -18,9 +18,14 @@ func TestSchemaRefsValidationEquivalent_IgnoresTitle(t *testing.T) {
 	revision := &openapi3.SchemaRef{
 		Ref: "#/components/schemas/UserRole",
 		Value: &openapi3.Schema{
-			Type:  &openapi3.Types{"string"},
-			Enum:  []any{"user", "superadmin"},
-			Title: "UserRole",
+			Type:        &openapi3.Types{"string"},
+			Enum:        []any{"user", "superadmin"},
+			Title:       "UserRole",
+			Description: "Named role enum",
+			Default:     "user",
+			Example:     "superadmin",
+			Examples:    []any{"user", "superadmin"},
+			Comment:     "generated from a named enum",
 		},
 	}
 


### PR DESCRIPTION
## Problem

`oasdiff breaking` can report false positive removed-subschema changes when an `anyOf` or `oneOf` branch is refactored from an inline enum schema to a `$ref` that points to an equivalent component schema.

This commonly happens with OpenAPI 3.1 schemas generated from Python models when a field changes from an inline literal type to a named enum. The wire contract stays the same, but the OpenAPI shape changes from an inline schema to a referenced component.

## Reproduction

Base schema branch:

```yaml
role:
  anyOf:
    - type: string
      enum:
        - user
        - superadmin
    - type: "null"
  title: Role
```

Revision schema branch:

```yaml
role:
  anyOf:
    - $ref: "#/components/schemas/UserRole"
    - type: "null"

UserRole:
  type: string
  enum:
    - user
    - superadmin
  title: UserRole
```

Before this change, running:

```bash
oasdiff breaking --format text --fail-on ERR old.yaml new.yaml
```

reported:

```text
error [request-property-any-of-removed]
removed `subschema #1` from the `role` request property `anyOf` list
```

The accepted payloads are unchanged: `{"role":"user"}`, `{"role":"superadmin"}`, `{"role":null}`, and `{}` remain valid.

## Fix

This PR filters removed `anyOf` and `oneOf` branches before reporting removed-subschema changes. When the removed branch has a validation-equivalent branch on the revision side and the change is an inline ↔ `$ref` refactor, it is not reported as a removed branch.

The same filtering is applied consistently to:

- request body schemas;
- request property schemas;
- response body schemas;
- response property schemas.

Validation equivalence is defined through the existing schema diff engine. Annotation-only differences such as `title`, `description`, `default`, `example`, `examples`, external docs, and `$comment` are ignored. Checker-significant metadata such as `deprecated` remains significant.

The equivalence logic is intentionally conservative: component `$ref` rename refactors, such as `#/components/schemas/UserRoleV1` → `#/components/schemas/UserRole`, remain out of scope even if the referenced schemas have the same shape.

For mixed cases, where one branch is an equivalent inline ↔ `$ref` refactor and another branch is genuinely removed, the output now lists only the genuinely removed branches.

## Performance

The filter runs schema diffing for deleted/revision branch pairs, so the check is O(N x M) for a given `anyOf` or `oneOf` list. These lists are typically small, and the extra work is restricted to the inline ↔ `$ref` boundary. Very large union-style schemas may pay the additional comparison cost.

## Tests

Added regression coverage for:

- inline enum → equivalent `$ref` enum inside nullable `anyOf`;
- inline enum → equivalent `$ref` enum for `anyOf` and `oneOf`;
- request/response and body/property surfaces;
- real validation changes still being detected;
- `deprecated` changes remaining checker-significant;
- component `$ref` rename refactors still being reported.

Validated with:

```bash
make lint
go test ./...
```

## Changelog

Added a `CHANGELOG.md` entry under `Unreleased / Fixed` for the behavior change.