### PR TITLE
help: note git refs as a supported spec input

### DIFF
--- a/internal/flatten.go
+++ b/internal/flatten.go
@@ -18,7 +18,7 @@ func getFlattenCmd() *cobra.Command {
 		Use:   "flatten spec",
 		Short: "Merge allOf",
 		Long: `Display a flattened version of the given OpenAPI spec by merging all instances of allOf.
-Spec can be a path to a file, a URL or '-' to read standard input.
+Spec can be a path to a file, a URL, a git ref (e.g. main:openapi.yaml), or '-' to read standard input.
 `,
 		Args: cobra.ExactArgs(1),
 		RunE: getRun(runFlatten),

--- a/internal/handlers.go
+++ b/internal/handlers.go
@@ -9,13 +9,13 @@ import (
 )
 
 const specHelp = `
-Base and revision can be a path to a file, a URL, or '-' to read standard input.
+Base and revision can be a path to a file, a URL, a git ref (e.g. main:openapi.yaml), or '-' to read standard input.
 In 'composed' mode, base and revision can be a glob and oasdiff will compare matching endpoints between the two sets of files.`
 
 func getParseArgs() cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {
-			return errors.New("please specify base and revision arguments as a path to a file, a glob (in composed mode), a URL, or '-' to read standard input")
+			return errors.New("please specify base and revision arguments as a path to a file, a glob (in composed mode), a URL, a git ref (e.g. main:openapi.yaml), or '-' to read standard input")
 		}
 		if len(args) > 2 {
 			return errors.New("invalid arguments after base and revision")

--- a/internal/upgrade.go
+++ b/internal/upgrade.go
@@ -25,7 +25,7 @@ boolean exclusiveMinimum/Maximum -> numeric, example -> examples, and similar),
 then updates the openapi version string. The transforms are idempotent: an
 already-canonical spec is unchanged aside from a possible version-string bump.
 
-Spec can be a path to a file, a URL or '-' to read standard input.
+Spec can be a path to a file, a URL, a git ref (e.g. main:openapi.yaml), or '-' to read standard input.
 `,
 		Args: cobra.ExactArgs(1),
 		RunE: getRun(runUpgrade),

--- a/load/spec_info.go
+++ b/load/spec_info.go
@@ -39,7 +39,7 @@ func getVersion(spec *openapi3.T) string {
 	return spec.Info.Version
 }
 
-// NewSpecInfo creates a SpecInfo from a local file path, a URL, or stdin
+// NewSpecInfo creates a SpecInfo from a local file path, a URL, a git revision, or stdin
 func NewSpecInfo(loader *openapi3.Loader, source *Source, options ...Option) (*SpecInfo, error) {
 	specInfo, err := loadSpecInfo(loader, source)
 	if err != nil {


### PR DESCRIPTION
## Summary

oasdiff's loader accepts git revisions (`<ref>:<path>`, e.g. `main:openapi.yaml`, see [docs/GIT-REVISION.md](docs/GIT-REVISION.md)) as a spec input for every command, but several user-facing strings still described inputs as only file / URL / stdin. This adds git refs to:

- `internal/flatten.go` and `internal/upgrade.go` — command Long help
- `internal/handlers.go` — the shared `specHelp` and the base/revision "please specify ..." error
- `load/spec_info.go` — the `NewSpecInfo` doc-comment

No behavior change; help/docs text only.

## Note

The `validate` command's matching help + `docs/VALIDATE.md` are updated on the `feat/validate-command` branch (#894), since `validate` doesn't exist on `main` yet.

## Test plan

- [x] `go build ./...`