### PR TITLE
fix: accept enum flag values case-insensitively

### DIFF
--- a/internal/enum.go
+++ b/internal/enum.go
@@ -3,8 +3,6 @@ package internal
 import (
 	"fmt"
 	"strings"
-
-	"slices"
 )
 
 type enumVal interface {
@@ -32,11 +30,17 @@ func (v *enumValue) String() string {
 	return string(*v.value)
 }
 
-// Set must have pointer receiver so it doesn't change the value of a copy
+// Set must have pointer receiver so it doesn't change the value of a copy.
+// Matching is case-insensitive; the stored value is normalized to the
+// canonical allowed value, so a user can type "warn" or "yaml" in any case
+// and downstream lookups (formatters.Lookup, checker.NewLevel) still receive
+// a known string.
 func (v *enumValue) Set(s string) error {
-	if slices.Contains(v.allowedValues, s) {
-		*v.value = s
-		return nil
+	for _, allowed := range v.allowedValues {
+		if strings.EqualFold(s, allowed) {
+			*v.value = allowed
+			return nil
+		}
 	}
 	return fmt.Errorf("%s is not one of the allowed values: %s", s, v.listOf())
 }

--- a/internal/enum_slice.go
+++ b/internal/enum_slice.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-
-	"github.com/oasdiff/oasdiff/utils"
 )
 
 // enumSliceValue is like stringSliceValue with allowed values
@@ -51,15 +49,41 @@ func writeAsCSV(vals []string) (string, error) {
 	return strings.TrimSuffix(b.String(), "\n"), nil
 }
 
-func (s *enumSliceValue) checkAllowedValues(values []string) error {
-	if notAllowed := utils.StringSetFromSlice(values).Minus(utils.StringSetFromSlice(s.allowedValues)); !notAllowed.Empty() {
+// normalizeAllowedValues maps each value to its canonical allowed value,
+// matching case-insensitively so a caller can pass any case and downstream
+// consumers still receive the exact allowed string. Values with no
+// case-insensitive match are reported as not allowed.
+func (s *enumSliceValue) normalizeAllowedValues(values []string) ([]string, error) {
+	normalized := make([]string, 0, len(values))
+	var notAllowed []string
+	for _, v := range values {
+		if canonical, ok := s.canonicalValue(v); ok {
+			normalized = append(normalized, canonical)
+		} else {
+			notAllowed = append(notAllowed, v)
+		}
+	}
+
+	if len(notAllowed) > 0 {
 		verb := "are"
 		if len(notAllowed) == 1 {
 			verb = "is"
 		}
-		return fmt.Errorf("%s %s not one of the allowed values: %s", strings.Join(notAllowed.ToStringList(), ","), verb, s.listOf())
+		return nil, fmt.Errorf("%s %s not one of the allowed values: %s", strings.Join(notAllowed, ","), verb, s.listOf())
 	}
-	return nil
+
+	return normalized, nil
+}
+
+// canonicalValue returns the allowed value equal to value (case-insensitive)
+// and whether one was found.
+func (s *enumSliceValue) canonicalValue(value string) (string, bool) {
+	for _, allowed := range s.allowedValues {
+		if strings.EqualFold(value, allowed) {
+			return allowed, true
+		}
+	}
+	return "", false
 }
 
 func (s *enumSliceValue) listOf() string {
@@ -82,7 +106,8 @@ func (s *enumSliceValue) Set(val string) error {
 		return err
 	}
 
-	if err := s.checkAllowedValues(value); err != nil {
+	value, err = s.normalizeAllowedValues(value)
+	if err != nil {
 		return err
 	}
 

--- a/internal/enum_slice_test.go
+++ b/internal/enum_slice_test.go
@@ -1,0 +1,23 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Multi-value enum flags accept their tokens in any case and normalize each
+// to the canonical allowed value, so downstream consumers receive the exact
+// allowed strings regardless of how they were typed.
+func Test_enumSliceValue_Set_CaseInsensitive(t *testing.T) {
+	v := newEnumSliceValue([]string{"info", "warn", "error"}, nil)
+	require.NoError(t, v.Set("ERROR,Warn"))
+	require.Equal(t, "error,warn", v.String())
+}
+
+func Test_enumSliceValue_Set_Invalid(t *testing.T) {
+	v := newEnumSliceValue([]string{"info", "warn", "error"}, nil)
+	err := v.Set("error,nope")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not one of the allowed values")
+}

--- a/internal/enum_test.go
+++ b/internal/enum_test.go
@@ -1,0 +1,32 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Enum flags accept their values in any case and normalize to the canonical
+// allowed value, so callers (and downstream lookups like formatters.Lookup
+// and checker.NewLevel) get a known string regardless of how it was typed.
+func Test_enumValue_Set_CaseInsensitive(t *testing.T) {
+	for _, input := range []string{"WARN", "warn", "Warn", "wArN"} {
+		v := newEnumValue([]string{"ERR", "WARN", "INFO"}, "ERR")
+		require.NoError(t, v.Set(input))
+		require.Equal(t, "WARN", v.String(), "input %q should normalize to the canonical allowed value", input)
+	}
+}
+
+// Normalization works toward a lowercase canonical too (e.g. format values).
+func Test_enumValue_Set_NormalizesToCanonical(t *testing.T) {
+	v := newEnumValue([]string{"yaml", "json"}, "yaml")
+	require.NoError(t, v.Set("JSON"))
+	require.Equal(t, "json", v.String())
+}
+
+func Test_enumValue_Set_Invalid(t *testing.T) {
+	v := newEnumValue([]string{"ERR", "WARN", "INFO"}, "ERR")
+	err := v.Set("nope")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not one of the allowed values")
+}


### PR DESCRIPTION
## Summary
- CLI enum flags now accept their values in any case. Previously `--fail-on warn`, `-f YAML`, or `--severity ERROR` were rejected; only the exact case listed in the allowed values worked.
- Both flag kinds are covered:
  - single-value flags (`enumValue`: `--format`, `--lang`, `--color`, `--fail-on`, `--level`)
  - multi-value flags (`enumSliceValue`: `--exclude-elements`, `--severity`, `--tags`)
- Matching is done with `strings.EqualFold`, and the stored value is normalized to the canonical allowed value, so consumers (`formatters.Lookup`, `checker.NewLevel`, `NewColorMode`, the localizer, etc.) keep receiving the exact string they expect regardless of how the user typed it.
- The motivating case is the level flags (`--fail-on`, `--level`), which required uppercase `ERR`/`WARN`/`INFO` even though `checker.NewLevel` already accepts lowercase.
- Invalid values still error with the same allowed-values message.

## Test plan
- [ ] `go test ./internal/...` (added `enum_test.go` and `enum_slice_test.go`: case-insensitive match, canonical normalization, invalid input)
- [ ] `oasdiff changelog --fail-on warn base.yaml rev.yaml` is accepted (was rejected)
- [ ] `oasdiff diff -f YAML base.yaml rev.yaml` is accepted
- [ ] `oasdiff checks --severity ERROR,Warn` is accepted and normalized
- [ ] `oasdiff checks --severity bogus` still errors with the allowed-values message

🤖 Generated with [Claude Code](https://claude.com/claude-code)