### PR TITLE
docs: link ERRORS.md to the validate command

### DIFF
--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -8,3 +8,9 @@ Oasdiff may return an error when given invalid specs, for example:
 Error: failed to load base spec from "spec.yaml": error converting YAML to JSON: yaml: line 2: mapping values are not allowed in this context
 ```
 The reason for this error is that the underlying library, [kin-openapi](https://github.com/getkin/kin-openapi), converts YAML specs to JSON before parsing them.
+
+## Invalid specs vs. spec violations
+
+`diff`, `breaking`, `changelog`, and `summary` fail only on specs they can't load or parse (the error above). They're otherwise lenient: a spec that loads but violates the OpenAPI or JSON Schema rules is still diffed.
+
+To check a single spec for compliance (invalid types, missing required fields, bad regex, unresolved `$ref`s, and similar), use [`oasdiff validate`](VALIDATE.md). It reports each violation with a stable rule ID, a severity, and a source location, and exits 102 when the spec can't be loaded at all.

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -9,6 +9,8 @@ Error: failed to load base spec from "spec.yaml": error converting YAML to JSON:
 ```
 The reason for this error is that the underlying library, [kin-openapi](https://github.com/getkin/kin-openapi), converts YAML specs to JSON before parsing them.
 
+When a spec fails to load, oasdiff exits with code `102` (`101` for invalid flags, `103` when a glob matches no specs).
+
 ## Invalid specs vs. spec violations
 
 `diff`, `breaking`, `changelog`, and `summary` fail only on specs they can't load or parse (the error above). They're otherwise lenient: a spec that loads but violates the OpenAPI or JSON Schema rules is still diffed.


### PR DESCRIPTION
## Summary
- `ERRORS.md` only showed a load/parse failure. With `oasdiff validate` now available, clarify the distinction between specs that can't be loaded (hard error) and specs that load but violate the OpenAPI / JSON Schema rules (tolerated by diff/breaking/changelog/summary).
- Point readers to [`oasdiff validate`](docs/VALIDATE.md) for a strict per-spec compliance check.

Docs-only.

## Test plan
- [ ] Rendered markdown reads correctly and the `VALIDATE.md` link resolves.