### PR TITLE
feat(diff): default --case-insensitive-headers to true; document opt-out defaults

### DIFF
--- a/diff/config.go
+++ b/diff/config.go
@@ -60,7 +60,7 @@ func NewConfig(opts ...Option) *Config {
 
 // WithMatchInlineRefs controls whether validation-equivalent inline/$ref
 // subschemas under anyOf/oneOf are matched as the same branch.
-// Default true. Set to false to restore the pre-1.17 behaviour where an
+// Default true. Set to false to restore the previous behaviour where an
 // inline-to-$ref refactor of an equivalent component is reported as one
 // branch added and one branch removed.
 func WithMatchInlineRefs(matchInlineRefs bool) Option {

--- a/diff/diff_x_of_test.go
+++ b/diff/diff_x_of_test.go
@@ -242,7 +242,7 @@ func TestAnyOf_InlineRefRefactor_MatchedByDefault(t *testing.T) {
 }
 
 // With --match-inline-refs=false (WithMatchInlineRefs(false)) the matcher
-// falls back to the pre-1.17 behaviour: the inline branch is reported as
+// falls back to the previous behaviour: the inline branch is reported as
 // Deleted and the $ref branch as Added.
 func TestAnyOf_InlineRefRefactor_OptOut(t *testing.T) {
 	loader := openapi3.NewLoader()

--- a/docs/DIFF.md
+++ b/docs/DIFF.md
@@ -5,6 +5,18 @@ This commmand is typically used to generate a structured diff report which can b
 
 > **Note:** `summary`, `breaking`, and `changelog` are built on the same diff engine. Most concepts and flags described here apply to those commands too. Exceptions are called out inline.
 
+## Default Comparison Behaviour
+
+oasdiff applies a few opt-out defaults so its diff matches what most users expect from a real-world API comparison, not a literal byte-level spec comparison. Each can be disabled with `--<flag>=false` if your use case needs the stricter behaviour.
+
+| Flag | Default | What it does | Detail |
+|---|---|---|---|
+| `--match-inline-refs` | `true` | Match validation-equivalent inline / `$ref` subschemas under `anyOf` / `oneOf` as the same branch. Codegen refactors that pull an inline enum into a named component report no change. | [Matching Inline and `$ref` Subschemas](#matching-inline-and-ref-subschemas) |
+| `--case-insensitive-headers` | `true` | Compare header names case-insensitively. `Content-Type` and `content-type` are the same header per RFC 7230 / 9110. | [HEADER-DIFF.md](HEADER-DIFF.md) |
+| `--allow-external-refs` | `true` | Allow the parser to resolve external `$ref`s when loading specs. Disable when processing untrusted specs to prevent SSRF. | (CLI help) |
+
+All other comparison-tuning flags (`--flatten-allof`, `--flatten-params`, `--include-path-params`, `--auto-upgrade`, ...) are opt-in (default `false`) because they transform the input or change matching semantics in ways that not every spec wants.
+
 ## Output Formats
 The default diff output format is `yaml`.  
 Additional formats can be generated using the `--format` flag:

--- a/docs/DIFF.md
+++ b/docs/DIFF.md
@@ -145,7 +145,7 @@ role:
 
 The diff reports no change for the `anyOf` list because the union of accepted payloads is identical. The same behaviour applies to `breaking` and `changelog`, which run on the same diff engine.
 
-To restore the pre-1.17 behaviour where the inline branch is reported as removed and the `$ref` branch as added, pass `--match-inline-refs=false`.
+To restore the previous behaviour where the inline branch is reported as removed and the `$ref` branch as added, pass `--match-inline-refs=false`.
 
 Annotation-only differences (`title`, `description`, `default`, `example`, `examples`, external docs, `$comment`) are ignored for the equivalence check. Differences that affect validation (including `deprecated`) are not. Component `$ref` renames (both sides `$ref`, e.g. `UserRoleV1` to `UserRole`) and inline-to-inline edits are out of scope by design: only the inline-to-`$ref` form change is treated as no-change.
 

--- a/docs/HEADER-DIFF.md
+++ b/docs/HEADER-DIFF.md
@@ -1,9 +1,9 @@
 # Case-Insensitive Header Comparison
 
-By default, oasdiff compares header names case-sensitively. This matches OpenAPI's general rule that "all field names in the specification are case sensitive".
+oasdiff compares header names case-insensitively by default, matching HTTP's wire rule that header names are case-insensitive (RFC 7230, RFC 9110). `Content-Type` and `content-type` refer to the same header and are treated as the same by the diff. The behaviour applies to header parameters (`in: header`) and response headers.
 
-On the wire, however, HTTP header names are case-insensitive (RFC 7230) — `Content-Type` and `content-type` refer to the same header. Set the `--case-insensitive-headers` flag to lowercase header names in each spec before diffing, so headers that differ only in case are treated as the same. The flag affects header parameters (`in: header`) and response headers.
+To restore case-sensitive comparison (matching OpenAPI's general rule that "all field names in the specification are case sensitive"), set `--case-insensitive-headers=false`:
 
 ```
-oasdiff diff data/header-case/base.yaml data/header-case/revision.yaml --case-insensitive-headers
+oasdiff diff data/header-case/base.yaml data/header-case/revision.yaml --case-insensitive-headers=false
 ```

--- a/internal/cmd_flags.go
+++ b/internal/cmd_flags.go
@@ -20,7 +20,7 @@ func addCommonDiffFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().Bool("match-inline-refs", true, "match validation-equivalent inline/$ref subschemas as the same anyOf/oneOf branch")
 	cmd.PersistentFlags().Bool("flatten-allof", false, "merge subschemas under allOf before diff")
 	cmd.PersistentFlags().Bool("flatten-params", false, "merge common parameters at path level with operation parameters")
-	cmd.PersistentFlags().Bool("case-insensitive-headers", false, "case-insensitive header name comparison")
+	cmd.PersistentFlags().Bool("case-insensitive-headers", true, "case-insensitive header name comparison (HTTP headers are case-insensitive per RFC 7230)")
 	cmd.PersistentFlags().StringSlice("exclude-extensions", nil, "OpenAPI Extension names to exclude from diff (e.g., x-internal)")
 	cmd.PersistentFlags().Bool("allow-external-refs", true, "allow external $refs in specs; disable to prevent SSRF when processing untrusted specs")
 	cmd.PersistentFlags().Bool("auto-upgrade", false, "canonicalize both specs to the latest OpenAPI 3.x before diffing; useful for cross-version comparisons (e.g. 3.0 vs 3.1)")

--- a/internal/run_test.go
+++ b/internal/run_test.go
@@ -301,7 +301,7 @@ func Test_BreakingChangesCaseInsensitiveHeadersDefault(t *testing.T) {
 	require.Zero(t, internal.Run(cmdToArgs("oasdiff diff ../data/header-case/base.yaml ../data/header-case/revision.yaml --fail-on-diff"), io.Discard, io.Discard))
 }
 
-// --case-insensitive-headers=false restores the pre-1.18 behaviour: the
+// --case-insensitive-headers=false restores the previous behaviour: the
 // case-only header difference is reported and --fail-on-diff exits non-zero.
 func Test_DiffCaseSensitiveHeadersOptOut(t *testing.T) {
 	exit := internal.Run(cmdToArgs("oasdiff diff ../data/header-case/base.yaml ../data/header-case/revision.yaml --case-insensitive-headers=false --fail-on-diff"), io.Discard, io.Discard)

--- a/internal/run_test.go
+++ b/internal/run_test.go
@@ -295,6 +295,19 @@ func Test_BreakingChangesCaseInsensitiveHeaders(t *testing.T) {
 	require.Zero(t, internal.Run(cmdToArgs("oasdiff diff ../data/header-case/base.yaml ../data/header-case/revision.yaml --case-insensitive-headers --fail-on-diff"), io.Discard, io.Discard))
 }
 
+// Case-insensitive header comparison is now the default; specs that differ
+// only in header case should produce no diff without any flag.
+func Test_BreakingChangesCaseInsensitiveHeadersDefault(t *testing.T) {
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff diff ../data/header-case/base.yaml ../data/header-case/revision.yaml --fail-on-diff"), io.Discard, io.Discard))
+}
+
+// --case-insensitive-headers=false restores the pre-1.18 behaviour: the
+// case-only header difference is reported and --fail-on-diff exits non-zero.
+func Test_DiffCaseSensitiveHeadersOptOut(t *testing.T) {
+	exit := internal.Run(cmdToArgs("oasdiff diff ../data/header-case/base.yaml ../data/header-case/revision.yaml --case-insensitive-headers=false --fail-on-diff"), io.Discard, io.Discard)
+	require.NotZero(t, exit, "expected non-zero exit when case-only header differences are surfaced")
+}
+
 func Test_FlattenCmdOK(t *testing.T) {
 	require.Zero(t, internal.Run(cmdToArgs("oasdiff flatten ../data/allof/simple.yaml"), io.Discard, io.Discard))
 }


### PR DESCRIPTION
## What

Flips `--case-insensitive-headers` to default `true`. Follows the same reasoning as #938 (`--match-inline-refs`): a default that contradicts the wire-level rule produces systematic false positives, and an opt-in flag is invisible to the population that hits them.

## Why this default is right

HTTP header names are case-insensitive per RFC 7230 and RFC 9110. `Content-Type` and `content-type` refer to the same header on the wire; any HTTP stack that distinguishes them is non-conformant. The previous default (case-sensitive comparison) reported false positives whenever two teams used different casing conventions for the same header.

The user who deliberately distinguishes header names by case can pass `--case-insensitive-headers=false` to restore the previous behaviour. Documented in `docs/HEADER-DIFF.md`.

## Documenting opt-out defaults centrally

Adds a `Default Comparison Behaviour` section to `docs/DIFF.md` that lists the three current opt-out flags (`--match-inline-refs`, `--case-insensitive-headers`, `--allow-external-refs`) in a single table with their rationale and links to detail. This is the first place a reader looking at "what does oasdiff diff actually do by default" can land. Without it the defaults are scattered across the CLI help, three different doc pages, and source comments.

All other comparison-tuning flags (`--flatten-allof`, `--flatten-params`, `--include-path-params`, `--auto-upgrade`, ...) remain opt-in (default `false`); the section explicitly notes that.

## Tests

- `Test_BreakingChangesCaseInsensitiveHeadersDefault` — same fixtures, no flag, no diff (the new default).
- `Test_DiffCaseSensitiveHeadersOptOut` — same fixtures with `--case-insensitive-headers=false`, the case-only difference is reported and `--fail-on-diff` exits non-zero.
- Existing `Test_BreakingChangesCaseInsensitiveHeaders` (explicit `--case-insensitive-headers` flag) still passes and is kept as a sanity check that explicit-true matches the default.

## Compatibility

Behaviour change for specs whose base and revision use different casing for the same header name: previously this surfaced as a removed/added header pair; now it is treated as no change. Anyone who relied on the old behaviour passes `--case-insensitive-headers=false`. CHANGELOG-equivalent note in the next release notes.

## Out of scope

Opting `--auto-upgrade` and other transformation flags to default-on is intentionally not included. The argument for them is weaker (they alter the input rather than just matching), and they should be considered individually if at all.
