### PR TITLE
checker: migrate const_changed pair to media-type walker (pilot of #936)

### DIFF
--- a/checker/check_request_property_const_changed.go
+++ b/checker/check_request_property_const_changed.go
@@ -15,110 +15,62 @@ const (
 
 func RequestPropertyConstChangedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
-			}
 
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				if mediaTypeDiff.SchemaDiff != nil && mediaTypeDiff.SchemaDiff.ConstDiff != nil {
-					constDiff := mediaTypeDiff.SchemaDiff.ConstDiff
-					baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "const")
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if info.schemaDiff.ConstDiff != nil {
+			constDiff := info.schemaDiff.ConstDiff
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "const")
 
-					if constDiff.From == nil {
-						result = append(result, NewApiChange(
-							RequestBodyConstAddedId,
-							config,
-							[]any{mediaType, constDiff.To},
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-					} else if constDiff.To == nil {
-						result = append(result, NewApiChange(
-							RequestBodyConstRemovedId,
-							config,
-							[]any{mediaType, constDiff.From},
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-					} else {
-						result = append(result, NewApiChange(
-							RequestBodyConstChangedId,
-							config,
-							[]any{mediaType, constDiff.From, constDiff.To},
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-					}
-				}
-
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						if propertyDiff == nil || propertyDiff.ConstDiff == nil {
-							return
-						}
-
-						constDiff := propertyDiff.ConstDiff
-						propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "const")
-
-						if constDiff.From == nil {
-							result = append(result, NewApiChange(
-								RequestPropertyConstAddedId,
-								config,
-								[]any{propertyName, constDiff.To},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(nil, propRevisionSource).WithDetails(mediaTypeDetails))
-						} else if constDiff.To == nil {
-							result = append(result, NewApiChange(
-								RequestPropertyConstRemovedId,
-								config,
-								[]any{propertyName, constDiff.From},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, nil).WithDetails(mediaTypeDetails))
-						} else {
-							result = append(result, NewApiChange(
-								RequestPropertyConstChangedId,
-								config,
-								[]any{propertyName, constDiff.From, constDiff.To},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						}
-					})
+			if constDiff.From == nil {
+				result = append(result, info.newChange(
+					RequestBodyConstAddedId,
+					[]any{info.mediaType, constDiff.To},
+					"",
+				).WithSources(nil, revisionSource))
+			} else if constDiff.To == nil {
+				result = append(result, info.newChange(
+					RequestBodyConstRemovedId,
+					[]any{info.mediaType, constDiff.From},
+					"",
+				).WithSources(baseSource, nil))
+			} else {
+				result = append(result, info.newChange(
+					RequestBodyConstChangedId,
+					[]any{info.mediaType, constDiff.From, constDiff.To},
+					"",
+				).WithSources(baseSource, revisionSource))
 			}
 		}
-	}
+
+		info.walkProperties(func(p propertyInfo) {
+			if p.propertyDiff == nil || p.propertyDiff.ConstDiff == nil {
+				return
+			}
+
+			constDiff := p.propertyDiff.ConstDiff
+			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "const")
+
+			if constDiff.From == nil {
+				result = append(result, p.newChange(
+					RequestPropertyConstAddedId,
+					[]any{p.propertyName, constDiff.To},
+					"",
+				).WithSources(nil, propRevisionSource))
+			} else if constDiff.To == nil {
+				result = append(result, p.newChange(
+					RequestPropertyConstRemovedId,
+					[]any{p.propertyName, constDiff.From},
+					"",
+				).WithSources(propBaseSource, nil))
+			} else {
+				result = append(result, p.newChange(
+					RequestPropertyConstChangedId,
+					[]any{p.propertyName, constDiff.From, constDiff.To},
+					"",
+				).WithSources(propBaseSource, propRevisionSource))
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_response_property_const_changed.go
+++ b/checker/check_response_property_const_changed.go
@@ -15,115 +15,62 @@ const (
 
 func ResponsePropertyConstChangedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil || operationItem.ResponsesDiff.Modified == nil {
-				continue
-			}
 
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff.ContentDiff == nil ||
-					responseDiff.ContentDiff.MediaTypeModified == nil {
-					continue
-				}
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if info.schemaDiff.ConstDiff != nil {
+			constDiff := info.schemaDiff.ConstDiff
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "const")
 
-				modifiedMediaTypes := responseDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					if mediaTypeDiff.SchemaDiff != nil && mediaTypeDiff.SchemaDiff.ConstDiff != nil {
-						constDiff := mediaTypeDiff.SchemaDiff.ConstDiff
-						baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "const")
-
-						if constDiff.From == nil {
-							result = append(result, NewApiChange(
-								ResponseBodyConstAddedId,
-								config,
-								[]any{mediaType, constDiff.To, responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-						} else if constDiff.To == nil {
-							result = append(result, NewApiChange(
-								ResponseBodyConstRemovedId,
-								config,
-								[]any{mediaType, constDiff.From, responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-						} else {
-							result = append(result, NewApiChange(
-								ResponseBodyConstChangedId,
-								config,
-								[]any{mediaType, constDiff.From, constDiff.To, responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-						}
-					}
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							if propertyDiff == nil || propertyDiff.Revision == nil || propertyDiff.ConstDiff == nil {
-								return
-							}
-
-							constDiff := propertyDiff.ConstDiff
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "const")
-
-							if constDiff.From == nil {
-								result = append(result, NewApiChange(
-									ResponsePropertyConstAddedId,
-									config,
-									[]any{propertyName, constDiff.To, responseStatus},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(nil, propRevisionSource).WithDetails(mediaTypeDetails))
-							} else if constDiff.To == nil {
-								result = append(result, NewApiChange(
-									ResponsePropertyConstRemovedId,
-									config,
-									[]any{propertyName, constDiff.From, responseStatus},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(propBaseSource, nil).WithDetails(mediaTypeDetails))
-							} else {
-								result = append(result, NewApiChange(
-									ResponsePropertyConstChangedId,
-									config,
-									[]any{propertyName, constDiff.From, constDiff.To, responseStatus},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-							}
-						})
-				}
+			if constDiff.From == nil {
+				result = append(result, info.newChange(
+					ResponseBodyConstAddedId,
+					[]any{info.mediaType, constDiff.To, info.responseStatus},
+					"",
+				).WithSources(nil, revisionSource))
+			} else if constDiff.To == nil {
+				result = append(result, info.newChange(
+					ResponseBodyConstRemovedId,
+					[]any{info.mediaType, constDiff.From, info.responseStatus},
+					"",
+				).WithSources(baseSource, nil))
+			} else {
+				result = append(result, info.newChange(
+					ResponseBodyConstChangedId,
+					[]any{info.mediaType, constDiff.From, constDiff.To, info.responseStatus},
+					"",
+				).WithSources(baseSource, revisionSource))
 			}
 		}
-	}
+
+		info.walkProperties(func(p propertyInfo) {
+			if p.propertyDiff == nil || p.propertyDiff.Revision == nil || p.propertyDiff.ConstDiff == nil {
+				return
+			}
+
+			constDiff := p.propertyDiff.ConstDiff
+			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "const")
+
+			if constDiff.From == nil {
+				result = append(result, p.newChange(
+					ResponsePropertyConstAddedId,
+					[]any{p.propertyName, constDiff.To, info.responseStatus},
+					"",
+				).WithSources(nil, propRevisionSource))
+			} else if constDiff.To == nil {
+				result = append(result, p.newChange(
+					ResponsePropertyConstRemovedId,
+					[]any{p.propertyName, constDiff.From, info.responseStatus},
+					"",
+				).WithSources(propBaseSource, nil))
+			} else {
+				result = append(result, p.newChange(
+					ResponsePropertyConstChangedId,
+					[]any{p.propertyName, constDiff.From, constDiff.To, info.responseStatus},
+					"",
+				).WithSources(propBaseSource, propRevisionSource))
+			}
+		})
+	})
+
 	return result
 }


### PR DESCRIPTION
## What

First migration off the walker landed in #940. Pilot scope is exactly two files, a matched request/response pair, deliberately the smallest possible PR that exercises every shape any future migration will need:

- `check_request_property_const_changed.go` (request-body walker)
- `check_response_property_const_changed.go` (response-body walker, including `ResponseStatus` propagation)

Both files have body-level emissions *and* property-level recursion, so this PR validates that `walkModifiedRequestBodySchemas` / `walkModifiedResponseSchemas`, `info.newChange`, `info.walkProperties`, and `p.newChange` all work end to end against real check IDs and real test fixtures.

## Why this PR is safe to land

No behaviour change. Every existing test for these checkers passes against the migrated code without modification:

- `TestRequestBodyConstChanged`
- `TestRequestBodyConstAdded`
- `TestRequestBodyConstRemoved`
- `TestRequestPropertyConstChanged`
- `TestResponsePropertyConstChanged`
- `TestResponsePropertyConstAdded`
- `TestResponsePropertyConstRemoved`

CI is the safety net: a migration that changes behaviour would surface as a test failure here.

## What the migration replaces

The hand-rolled prelude:

```go
for path, pathItem := range diffReport.PathsDiff.Modified {
    if pathItem.OperationsDiff == nil { continue }
    for operation, operationItem := range pathItem.OperationsDiff.Modified {
        if operationItem.RequestBodyDiff == nil || ...ContentDiff == nil || ...MediaTypeModified == nil { continue }
        for mediaType, mediaTypeDiff := range operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified {
            mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
            ...
        }
    }
}
```

becomes:

```go
walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
    ...
})
```

And each body-level emission:

```go
result = append(result, NewApiChange(
    RequestBodyConstAddedId,
    config,
    []any{mediaType, constDiff.To},
    "",
    operationsSources,
    operationItem.Revision,
    operation,
    path,
).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
```

becomes:

```go
result = append(result, info.newChange(
    RequestBodyConstAddedId,
    []any{info.mediaType, constDiff.To},
    "",
).WithSources(nil, revisionSource))
```

The bug class fixed in #930 (forgotten `WithDetails(mediaTypeDetails)`) is now structurally impossible in these two checkers.

## Numbers

| Metric | Before | After | Delta |
|---|---|---|---|
| `check_request_property_const_changed.go` | 125 lines | 80 lines | -45 |
| `check_response_property_const_changed.go` | 130 lines | 76 lines | -54 |

Net `-90` lines across the pair; every removed line is hand-rolled plumbing.

## Next step

Once this lands, the pattern is validated and migration continues under the strategy proposed in #936: opportunistic migration as checkers are touched for other reasons, plus the occasional small batch from the Easy bucket. The Medium and non-obvious checkers stay on hand-rolled preludes until naturally touched.

If the pilot surfaces feedback on the walker shape (a missing field on `mediaTypeInfo`, an awkwardness in `info.newChange`, etc.), #940 is amendable before further migration starts.
