### PR TITLE
checker: migrate three more matched pairs to the media-type walker (PR-2 of #936)

### DIFF
--- a/checker/check_request_property_default_value_changed.go
+++ b/checker/check_request_property_default_value_changed.go
@@ -15,84 +15,43 @@ const (
 
 func RequestPropertyDefaultValueChangedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
+
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if info.schemaDiff.DefaultDiff != nil {
+			defaultValueDiff := info.schemaDiff.DefaultDiff
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "default")
+			append1 := func(messageId string, a ...any) {
+				result = append(result, info.newChange(messageId, a, "").WithSources(baseSource, revisionSource))
 			}
-
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				if mediaTypeDiff.SchemaDiff == nil {
-					continue
-				}
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "default")
-				appendResultItem := func(messageId string, a ...any) {
-					result = append(result, NewApiChange(
-						messageId,
-						config,
-						a,
-						"",
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
-					).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-				}
-				if mediaTypeDiff.SchemaDiff.DefaultDiff != nil {
-					defaultValueDiff := mediaTypeDiff.SchemaDiff.DefaultDiff
-
-					if defaultValueDiff.From == nil {
-						appendResultItem(RequestBodyDefaultValueAddedId, mediaType, defaultValueDiff.To)
-					} else if defaultValueDiff.To == nil {
-						appendResultItem(RequestBodyDefaultValueRemovedId, mediaType, defaultValueDiff.From)
-					} else {
-						appendResultItem(RequestBodyDefaultValueChangedId, mediaType, defaultValueDiff.From, defaultValueDiff.To)
-					}
-				}
-
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						if propertyDiff == nil || propertyDiff.DefaultDiff == nil {
-							return
-						}
-
-						defaultValueDiff := propertyDiff.DefaultDiff
-						propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "default")
-
-						appendPropResultItem := func(messageId string, a ...any) {
-							result = append(result, NewApiChange(
-								messageId,
-								config,
-								a,
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						}
-
-						if defaultValueDiff.From == nil {
-							appendPropResultItem(RequestPropertyDefaultValueAddedId, propertyName, defaultValueDiff.To)
-						} else if defaultValueDiff.To == nil {
-							appendPropResultItem(RequestPropertyDefaultValueRemovedId, propertyName, defaultValueDiff.From)
-						} else {
-							appendPropResultItem(RequestPropertyDefaultValueChangedId, propertyName, defaultValueDiff.From, defaultValueDiff.To)
-						}
-					})
+			if defaultValueDiff.From == nil {
+				append1(RequestBodyDefaultValueAddedId, info.mediaType, defaultValueDiff.To)
+			} else if defaultValueDiff.To == nil {
+				append1(RequestBodyDefaultValueRemovedId, info.mediaType, defaultValueDiff.From)
+			} else {
+				append1(RequestBodyDefaultValueChangedId, info.mediaType, defaultValueDiff.From, defaultValueDiff.To)
 			}
 		}
-	}
+
+		info.walkProperties(func(p propertyInfo) {
+			if p.propertyDiff == nil || p.propertyDiff.DefaultDiff == nil {
+				return
+			}
+
+			defaultValueDiff := p.propertyDiff.DefaultDiff
+			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "default")
+			appendProp := func(messageId string, a ...any) {
+				result = append(result, p.newChange(messageId, a, "").WithSources(propBaseSource, propRevisionSource))
+			}
+
+			if defaultValueDiff.From == nil {
+				appendProp(RequestPropertyDefaultValueAddedId, p.propertyName, defaultValueDiff.To)
+			} else if defaultValueDiff.To == nil {
+				appendProp(RequestPropertyDefaultValueRemovedId, p.propertyName, defaultValueDiff.From)
+			} else {
+				appendProp(RequestPropertyDefaultValueChangedId, p.propertyName, defaultValueDiff.From, defaultValueDiff.To)
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_request_property_max_length_set.go
+++ b/checker/check_request_property_max_length_set.go
@@ -11,73 +11,35 @@ const (
 
 func RequestPropertyMaxLengthSetCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if maxLengthDiff := info.schemaDiff.MaxLengthDiff; maxLengthDiff != nil &&
+			maxLengthDiff.From == nil && maxLengthDiff.To != nil {
+			_, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "maxLength")
+			result = append(result, info.newChange(
+				RequestBodyMaxLengthSetId,
+				[]any{maxLengthDiff.To},
+				commentId(RequestBodyMaxLengthSetId),
+			).WithSources(nil, revisionSource))
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
+
+		info.walkProperties(func(p propertyInfo) {
+			maxLengthDiff := p.propertyDiff.MaxLengthDiff
+			if maxLengthDiff == nil || maxLengthDiff.From != nil || maxLengthDiff.To == nil {
+				return
+			}
+			if p.propertyDiff.Revision.ReadOnly {
+				return
 			}
 
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				if mediaTypeDiff.SchemaDiff == nil {
-					continue
-				}
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				_, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "maxLength")
-				if mediaTypeDiff.SchemaDiff.MaxLengthDiff != nil {
-					maxLengthDiff := mediaTypeDiff.SchemaDiff.MaxLengthDiff
-					if maxLengthDiff.From == nil &&
-						maxLengthDiff.To != nil {
-						result = append(result, NewApiChange(
-							RequestBodyMaxLengthSetId,
-							config,
-							[]any{maxLengthDiff.To},
-							commentId(RequestBodyMaxLengthSetId),
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-					}
-				}
+			_, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "maxLength")
+			result = append(result, p.newChange(
+				RequestPropertyMaxLengthSetId,
+				[]any{propertyFullName(p.propertyPath, p.propertyName), maxLengthDiff.To},
+				commentId(RequestPropertyMaxLengthSetId),
+			).WithSources(nil, propRevisionSource))
+		})
+	})
 
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						maxLengthDiff := propertyDiff.MaxLengthDiff
-						if maxLengthDiff == nil {
-							return
-						}
-						if maxLengthDiff.From != nil ||
-							maxLengthDiff.To == nil {
-							return
-						}
-						if propertyDiff.Revision.ReadOnly {
-							return
-						}
-
-						_, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "maxLength")
-						result = append(result, NewApiChange(
-							RequestPropertyMaxLengthSetId,
-							config,
-							[]any{propertyFullName(propertyPath, propertyName), maxLengthDiff.To},
-							commentId(RequestPropertyMaxLengthSetId),
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(nil, propRevisionSource).WithDetails(mediaTypeDetails))
-					})
-			}
-		}
-	}
 	return result
 }

--- a/checker/check_request_property_min_length_updated.go
+++ b/checker/check_request_property_min_length_updated.go
@@ -13,98 +13,41 @@ const (
 
 func RequestPropertyMinLengthUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if minLengthDiff := info.schemaDiff.MinLengthDiff; minLengthDiff != nil &&
+			minLengthDiff.From != nil && minLengthDiff.To != nil {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "minLength")
+			id := RequestBodyMinLengthDecreasedId
+			if IsIncreasedValue(minLengthDiff) {
+				id = RequestBodyMinLengthIncreasedId
+			}
+			result = append(result, info.newChange(
+				id,
+				[]any{minLengthDiff.From, minLengthDiff.To},
+				"",
+			).WithSources(baseSource, revisionSource))
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
+
+		info.walkProperties(func(p propertyInfo) {
+			minLengthDiff := p.propertyDiff.MinLengthDiff
+			if minLengthDiff == nil || minLengthDiff.From == nil || minLengthDiff.To == nil {
+				return
 			}
 
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				if mediaTypeDiff.SchemaDiff == nil {
-					continue
-				}
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "minLength")
-				if mediaTypeDiff.SchemaDiff.MinLengthDiff != nil {
-					minLengthDiff := mediaTypeDiff.SchemaDiff.MinLengthDiff
-					if minLengthDiff.From != nil &&
-						minLengthDiff.To != nil {
-						if IsIncreasedValue(minLengthDiff) {
-							result = append(result, NewApiChange(
-								RequestBodyMinLengthIncreasedId,
-								config,
-								[]any{minLengthDiff.From, minLengthDiff.To},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-						} else {
-							result = append(result, NewApiChange(
-								RequestBodyMinLengthDecreasedId,
-								config,
-								[]any{minLengthDiff.From, minLengthDiff.To},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-						}
-					}
-				}
-
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						minLengthDiff := propertyDiff.MinLengthDiff
-						if minLengthDiff == nil {
-							return
-						}
-						if minLengthDiff.From == nil ||
-							minLengthDiff.To == nil {
-							return
-						}
-
-						propName := propertyFullName(propertyPath, propertyName)
-						propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "minLength")
-
-						if IsDecreasedValue(minLengthDiff) {
-							result = append(result, NewApiChange(
-								RequestPropertyMinLengthDecreasedId,
-								config,
-								[]any{propName, minLengthDiff.From, minLengthDiff.To},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						} else {
-							result = append(result, NewApiChange(
-								RequestPropertyMinLengthIncreasedId,
-								config,
-								[]any{propName, minLengthDiff.From, minLengthDiff.To},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						}
-					})
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "minLength")
+			id := RequestPropertyMinLengthIncreasedId
+			if IsDecreasedValue(minLengthDiff) {
+				id = RequestPropertyMinLengthDecreasedId
 			}
-		}
-	}
+			result = append(result, p.newChange(
+				id,
+				[]any{propName, minLengthDiff.From, minLengthDiff.To},
+				"",
+			).WithSources(propBaseSource, propRevisionSource))
+		})
+	})
+
 	return result
 }

--- a/checker/check_response_property_default_value_changed.go
+++ b/checker/check_response_property_default_value_changed.go
@@ -15,83 +15,42 @@ const (
 
 func ResponsePropertyDefaultValueChangedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil || operationItem.ResponsesDiff.Modified == nil {
-				continue
+
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if info.schemaDiff.DefaultDiff != nil {
+			defaultValueDiff := info.schemaDiff.DefaultDiff
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "default")
+			append1 := func(messageId string, a ...any) {
+				result = append(result, info.newChange(messageId, a, "").WithSources(baseSource, revisionSource))
 			}
-
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff.ContentDiff == nil ||
-					responseDiff.ContentDiff.MediaTypeModified == nil {
-					continue
-				}
-
-				modifiedMediaTypes := responseDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					if mediaTypeDiff.SchemaDiff != nil && mediaTypeDiff.SchemaDiff.DefaultDiff != nil {
-						baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "default")
-						appendResultItem := func(messageId string, a ...any) {
-							result = append(result, NewApiChange(
-								messageId,
-								config,
-								a,
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-						}
-						defaultValueDiff := mediaTypeDiff.SchemaDiff.DefaultDiff
-						if defaultValueDiff.From == nil {
-							appendResultItem(ResponseBodyDefaultValueAddedId, mediaType, defaultValueDiff.To, responseStatus)
-						} else if defaultValueDiff.To == nil {
-							appendResultItem(ResponseBodyDefaultValueRemovedId, mediaType, defaultValueDiff.From, responseStatus)
-						} else {
-							appendResultItem(ResponseBodyDefaultValueChangedId, mediaType, defaultValueDiff.From, defaultValueDiff.To, responseStatus)
-						}
-					}
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							if propertyDiff == nil || propertyDiff.Revision == nil || propertyDiff.DefaultDiff == nil {
-								return
-							}
-
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "default")
-							appendResultItem := func(messageId string, a ...any) {
-								result = append(result, NewApiChange(
-									messageId,
-									config,
-									a,
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-							}
-							defaultValueDiff := propertyDiff.DefaultDiff
-							if defaultValueDiff.From == nil {
-								appendResultItem(ResponsePropertyDefaultValueAddedId, propertyName, defaultValueDiff.To, responseStatus)
-							} else if defaultValueDiff.To == nil {
-								appendResultItem(ResponsePropertyDefaultValueRemovedId, propertyName, defaultValueDiff.From, responseStatus)
-							} else {
-								appendResultItem(ResponsePropertyDefaultValueChangedId, propertyName, defaultValueDiff.From, defaultValueDiff.To, responseStatus)
-							}
-						})
-				}
+			if defaultValueDiff.From == nil {
+				append1(ResponseBodyDefaultValueAddedId, info.mediaType, defaultValueDiff.To, info.responseStatus)
+			} else if defaultValueDiff.To == nil {
+				append1(ResponseBodyDefaultValueRemovedId, info.mediaType, defaultValueDiff.From, info.responseStatus)
+			} else {
+				append1(ResponseBodyDefaultValueChangedId, info.mediaType, defaultValueDiff.From, defaultValueDiff.To, info.responseStatus)
 			}
 		}
-	}
+
+		info.walkProperties(func(p propertyInfo) {
+			if p.propertyDiff == nil || p.propertyDiff.Revision == nil || p.propertyDiff.DefaultDiff == nil {
+				return
+			}
+
+			defaultValueDiff := p.propertyDiff.DefaultDiff
+			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "default")
+			appendProp := func(messageId string, a ...any) {
+				result = append(result, p.newChange(messageId, a, "").WithSources(propBaseSource, propRevisionSource))
+			}
+			if defaultValueDiff.From == nil {
+				appendProp(ResponsePropertyDefaultValueAddedId, p.propertyName, defaultValueDiff.To, info.responseStatus)
+			} else if defaultValueDiff.To == nil {
+				appendProp(ResponsePropertyDefaultValueRemovedId, p.propertyName, defaultValueDiff.From, info.responseStatus)
+			} else {
+				appendProp(ResponsePropertyDefaultValueChangedId, p.propertyName, defaultValueDiff.From, defaultValueDiff.To, info.responseStatus)
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_response_property_max_length_unset.go
+++ b/checker/check_response_property_max_length_unset.go
@@ -11,74 +11,35 @@ const (
 
 func ResponsePropertyMaxLengthUnsetCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil || operationItem.ResponsesDiff.Modified == nil {
-				continue
-			}
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff == nil ||
-					responseDiff.ContentDiff == nil ||
-					responseDiff.ContentDiff.MediaTypeModified == nil {
-					continue
-				}
-				modifiedMediaTypes := responseDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					if mediaTypeDiff.SchemaDiff != nil && mediaTypeDiff.SchemaDiff.MaxLengthDiff != nil {
-						maxLengthDiff := mediaTypeDiff.SchemaDiff.MaxLengthDiff
-						if maxLengthDiff.From != nil &&
-							maxLengthDiff.To == nil {
-							baseSource, _ := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "maxLength")
-							result = append(result, NewApiChange(
-								ResponseBodyMaxLengthUnsetId,
-								config,
-								[]any{maxLengthDiff.From},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-						}
-					}
 
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							maxLengthDiff := propertyDiff.MaxLengthDiff
-							if maxLengthDiff == nil {
-								return
-							}
-							if maxLengthDiff.To != nil ||
-								maxLengthDiff.From == nil {
-								return
-							}
-							if propertyDiff.Revision.WriteOnly {
-								return
-							}
-
-							propBaseSource, _ := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "maxLength")
-							result = append(result, NewApiChange(
-								ResponsePropertyMaxLengthUnsetId,
-								config,
-								[]any{propertyFullName(propertyPath, propertyName), maxLengthDiff.From, responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, nil).WithDetails(mediaTypeDetails))
-						})
-				}
-			}
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if maxLengthDiff := info.schemaDiff.MaxLengthDiff; maxLengthDiff != nil &&
+			maxLengthDiff.From != nil && maxLengthDiff.To == nil {
+			baseSource, _ := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "maxLength")
+			result = append(result, info.newChange(
+				ResponseBodyMaxLengthUnsetId,
+				[]any{maxLengthDiff.From},
+				"",
+			).WithSources(baseSource, nil))
 		}
-	}
+
+		info.walkProperties(func(p propertyInfo) {
+			maxLengthDiff := p.propertyDiff.MaxLengthDiff
+			if maxLengthDiff == nil || maxLengthDiff.To != nil || maxLengthDiff.From == nil {
+				return
+			}
+			if p.propertyDiff.Revision.WriteOnly {
+				return
+			}
+
+			propBaseSource, _ := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "maxLength")
+			result = append(result, p.newChange(
+				ResponsePropertyMaxLengthUnsetId,
+				[]any{propertyFullName(p.propertyPath, p.propertyName), maxLengthDiff.From, info.responseStatus},
+				"",
+			).WithSources(propBaseSource, nil))
+		})
+	})
+
 	return result
 }

--- a/checker/check_response_property_min_length_decreased.go
+++ b/checker/check_response_property_min_length_decreased.go
@@ -11,80 +11,38 @@ const (
 
 func ResponsePropertyMinLengthDecreasedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if minLengthDiff := info.schemaDiff.MinLengthDiff; minLengthDiff != nil &&
+			minLengthDiff.From != nil && minLengthDiff.To != nil && IsDecreasedValue(minLengthDiff) {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "minLength")
+			result = append(result, info.newChange(
+				ResponseBodyMinLengthDecreasedId,
+				[]any{minLengthDiff.From, minLengthDiff.To},
+				"",
+			).WithSources(baseSource, revisionSource))
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil || operationItem.ResponsesDiff.Modified == nil {
-				continue
+
+		info.walkProperties(func(p propertyInfo) {
+			minLengthDiff := p.propertyDiff.MinLengthDiff
+			if minLengthDiff == nil || minLengthDiff.To == nil || minLengthDiff.From == nil {
+				return
 			}
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff == nil ||
-					responseDiff.ContentDiff == nil ||
-					responseDiff.ContentDiff.MediaTypeModified == nil {
-					continue
-				}
-				modifiedMediaTypes := responseDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					if mediaTypeDiff.SchemaDiff != nil && mediaTypeDiff.SchemaDiff.MinLengthDiff != nil {
-						minLengthDiff := mediaTypeDiff.SchemaDiff.MinLengthDiff
-						if minLengthDiff.From != nil &&
-							minLengthDiff.To != nil {
-							if IsDecreasedValue(minLengthDiff) {
-								baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "minLength")
-								result = append(result, NewApiChange(
-									ResponseBodyMinLengthDecreasedId,
-									config,
-									[]any{minLengthDiff.From, minLengthDiff.To},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-							}
-						}
-					}
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							minLengthDiff := propertyDiff.MinLengthDiff
-							if minLengthDiff == nil {
-								return
-							}
-							if minLengthDiff.To == nil ||
-								minLengthDiff.From == nil {
-								return
-							}
-							if !IsDecreasedValue(minLengthDiff) {
-								return
-							}
-
-							if propertyDiff.Revision.WriteOnly {
-								return
-							}
-
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "minLength")
-							result = append(result, NewApiChange(
-								ResponsePropertyMinLengthDecreasedId,
-								config,
-								[]any{propertyFullName(propertyPath, propertyName), minLengthDiff.From, minLengthDiff.To, responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						})
-				}
+			if !IsDecreasedValue(minLengthDiff) {
+				return
 			}
-		}
-	}
+			if p.propertyDiff.Revision.WriteOnly {
+				return
+			}
+
+			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "minLength")
+			result = append(result, p.newChange(
+				ResponsePropertyMinLengthDecreasedId,
+				[]any{propertyFullName(p.propertyPath, p.propertyName), minLengthDiff.From, minLengthDiff.To, info.responseStatus},
+				"",
+			).WithSources(propBaseSource, propRevisionSource))
+		})
+	})
+
 	return result
 }


### PR DESCRIPTION
## What

Second migration off the walker (#940 + pilot #941). Six files, three matched request/response pairs from the Easy bucket of #936:

| Pair | Files |
|---|---|
| default_value | `check_request_property_default_value_changed.go` + `check_response_property_default_value_changed.go` |
| min_length | `check_request_property_min_length_updated.go` + `check_response_property_min_length_decreased.go` |
| max_length set/unset | `check_request_property_max_length_set.go` + `check_response_property_max_length_unset.go` |

## What this validates beyond the pilot

The pilot (#941) covered the basic shape: body + property emissions, request and response walkers, response status propagation. This PR exercises three further idioms migrators will encounter:

1. **Local `append` helpers.** The default_value checkers wrap the body and property emissions in an inner closure to share the eight-arg `NewApiChange` boilerplate across three branches. Post-migration, the helper now wraps a one-line `info.newChange(...)` / `p.newChange(...)` and still reads cleanly.
2. **`id := X; if cond { id = Y }` idiom.** The min_length and max_length checkers had two-branch `if IsIncreased { ... } else { ... }` blocks that each duplicated the full eight-arg `NewApiChange` block. Hoisting the id selection lets the migrated code emit once per branch instead of twice.
3. **`commentId(...)` argument.** The max_length_set checker passes a non-empty `comment` argument (the second parameter of `info.newChange`). Confirms the helper handles non-empty comments correctly.

## Numbers

| | Before | After | Delta |
|---|---|---|---|
| `check_request_property_default_value_changed.go` | 99 | 60 | -39 |
| `check_response_property_default_value_changed.go` | 98 | 56 | -42 |
| `check_request_property_min_length_updated.go` | 111 | 52 | -59 |
| `check_response_property_min_length_decreased.go` | 91 | 47 | -44 |
| `check_request_property_max_length_set.go` | 84 | 46 | -38 |
| `check_response_property_max_length_unset.go` | 85 | 46 | -39 |

Net **`-258`** lines across the pair set. Every removed line is hand-rolled plumbing.

## Why this PR is safe to land

No behaviour change. Every existing test for these checkers passes without modification:

```
TestRequestBodyDefaultValueAddedCheck
TestRequestBodyDefaultValueRemoving
TestResponsePropertyDefaultValueAddedCheck
TestResponsePropertyDefaultValueRemovedCheck
TestResponsePropertyDefaultValueUpdatedCheck
TestResponseSchemaDefaultValueUpdatedCheck
TestRequestBodyMinLengthIncreased
TestRequestBodyMinLengthDecreased
TestRequestPropertyMinLengthIncreased
TestRequestPropertyMinLengthDecreased
TestSubSchemaTraversalMinLengthChanged
TestRequestBodyMaxLengthSetCheck
TestRequestPropertyMaxLengthSetCheck
TestResponseBodyMaxLengthUnsetCheck     (existing test, still passes)
TestResponsePropertyMaxLengthUnsetCheck (existing test, still passes)
```

Full suite green.

## After this lands

Per the strategy in #936: migration switches to opportunistic. New checkers use the walker by default; existing checkers in the Medium and non-obvious buckets migrate only when touched for other reasons. No more dedicated migration PRs unless real signal surfaces (a forgotten-mediaTypeDetails-style bug in an un-migrated checker, or a maintainer touching a cluster of related un-migrated files for another reason).
