### PR TITLE
checker: migrate min/max numeric and min_items pairs to media-type walker (PR-3 of #936)

### DIFF
--- a/checker/check_request_property_max_updated.go
+++ b/checker/check_request_property_max_updated.go
@@ -19,179 +19,91 @@ const (
 
 func RequestPropertyMaxDecreasedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
-			}
 
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				if mediaTypeDiff.SchemaDiff == nil {
-					continue
-				}
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "maximum")
-				if mediaTypeDiff.SchemaDiff.MaxDiff != nil {
-					maxDiff := mediaTypeDiff.SchemaDiff.MaxDiff
-					if maxDiff.From != nil &&
-						maxDiff.To != nil {
-						if IsDecreasedValue(maxDiff) {
-							result = append(result, NewApiChange(
-								RequestBodyMaxDecreasedId,
-								config,
-								[]any{maxDiff.To},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-						} else {
-							result = append(result, NewApiChange(
-								RequestBodyMaxIncreasedId,
-								config,
-								[]any{maxDiff.From, maxDiff.To},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-						}
-					}
-				}
-				if mediaTypeDiff.SchemaDiff.ExclusiveMaxDiff != nil {
-					exMaxDiff := mediaTypeDiff.SchemaDiff.ExclusiveMaxDiff
-					if exMaxDiff.From != nil &&
-						exMaxDiff.To != nil {
-						exBaseSource, exRevisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "exclusiveMaximum")
-						if IsDecreasedValue(exMaxDiff) {
-							result = append(result, NewApiChange(
-								RequestBodyExclusiveMaxDecreasedId,
-								config,
-								[]any{exMaxDiff.To},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(exBaseSource, exRevisionSource).WithDetails(mediaTypeDetails))
-						} else {
-							result = append(result, NewApiChange(
-								RequestBodyExclusiveMaxIncreasedId,
-								config,
-								[]any{exMaxDiff.From, exMaxDiff.To},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(exBaseSource, exRevisionSource).WithDetails(mediaTypeDetails))
-						}
-					}
-				}
-
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						maxDiff := propertyDiff.MaxDiff
-						if maxDiff == nil {
-							return
-						}
-						if maxDiff.From == nil ||
-							maxDiff.To == nil {
-							return
-						}
-
-						propName := propertyFullName(propertyPath, propertyName)
-
-						id := RequestPropertyMaxDecreasedId
-						if propertyDiff.Revision.ReadOnly {
-							id = RequestReadOnlyPropertyMaxDecreasedId
-						}
-
-						propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "maximum")
-						if IsDecreasedValue(maxDiff) {
-							result = append(result, NewApiChange(
-								id,
-								config,
-								[]any{propName, maxDiff.To},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						} else {
-							result = append(result, NewApiChange(
-								RequestPropertyMaxIncreasedId,
-								config,
-								[]any{propName, maxDiff.From, maxDiff.To},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						}
-
-					})
-
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						exMaxDiff := propertyDiff.ExclusiveMaxDiff
-						if exMaxDiff == nil {
-							return
-						}
-						if exMaxDiff.From == nil ||
-							exMaxDiff.To == nil {
-							return
-						}
-
-						propName := propertyFullName(propertyPath, propertyName)
-
-						id := RequestPropertyExclusiveMaxDecreasedId
-						if propertyDiff.Revision.ReadOnly {
-							id = RequestReadOnlyPropertyExclusiveMaxDecreasedId
-						}
-
-						propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "exclusiveMaximum")
-						if IsDecreasedValue(exMaxDiff) {
-							result = append(result, NewApiChange(
-								id,
-								config,
-								[]any{propName, exMaxDiff.To},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						} else {
-							result = append(result, NewApiChange(
-								RequestPropertyExclusiveMaxIncreasedId,
-								config,
-								[]any{propName, exMaxDiff.From, exMaxDiff.To},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						}
-					})
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if maxDiff := info.schemaDiff.MaxDiff; maxDiff != nil &&
+			maxDiff.From != nil && maxDiff.To != nil {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "maximum")
+			if IsDecreasedValue(maxDiff) {
+				result = append(result, info.newChange(
+					RequestBodyMaxDecreasedId,
+					[]any{maxDiff.To},
+					"",
+				).WithSources(baseSource, revisionSource))
+			} else {
+				result = append(result, info.newChange(
+					RequestBodyMaxIncreasedId,
+					[]any{maxDiff.From, maxDiff.To},
+					"",
+				).WithSources(baseSource, revisionSource))
 			}
 		}
-	}
+		if exMaxDiff := info.schemaDiff.ExclusiveMaxDiff; exMaxDiff != nil &&
+			exMaxDiff.From != nil && exMaxDiff.To != nil {
+			exBaseSource, exRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "exclusiveMaximum")
+			if IsDecreasedValue(exMaxDiff) {
+				result = append(result, info.newChange(
+					RequestBodyExclusiveMaxDecreasedId,
+					[]any{exMaxDiff.To},
+					"",
+				).WithSources(exBaseSource, exRevisionSource))
+			} else {
+				result = append(result, info.newChange(
+					RequestBodyExclusiveMaxIncreasedId,
+					[]any{exMaxDiff.From, exMaxDiff.To},
+					"",
+				).WithSources(exBaseSource, exRevisionSource))
+			}
+		}
+
+		info.walkProperties(func(p propertyInfo) {
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+
+			if maxDiff := p.propertyDiff.MaxDiff; maxDiff != nil &&
+				maxDiff.From != nil && maxDiff.To != nil {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "maximum")
+				if IsDecreasedValue(maxDiff) {
+					id := RequestPropertyMaxDecreasedId
+					if p.propertyDiff.Revision.ReadOnly {
+						id = RequestReadOnlyPropertyMaxDecreasedId
+					}
+					result = append(result, p.newChange(
+						id,
+						[]any{propName, maxDiff.To},
+						"",
+					).WithSources(propBaseSource, propRevisionSource))
+				} else {
+					result = append(result, p.newChange(
+						RequestPropertyMaxIncreasedId,
+						[]any{propName, maxDiff.From, maxDiff.To},
+						"",
+					).WithSources(propBaseSource, propRevisionSource))
+				}
+			}
+
+			if exMaxDiff := p.propertyDiff.ExclusiveMaxDiff; exMaxDiff != nil &&
+				exMaxDiff.From != nil && exMaxDiff.To != nil {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "exclusiveMaximum")
+				if IsDecreasedValue(exMaxDiff) {
+					id := RequestPropertyExclusiveMaxDecreasedId
+					if p.propertyDiff.Revision.ReadOnly {
+						id = RequestReadOnlyPropertyExclusiveMaxDecreasedId
+					}
+					result = append(result, p.newChange(
+						id,
+						[]any{propName, exMaxDiff.To},
+						"",
+					).WithSources(propBaseSource, propRevisionSource))
+				} else {
+					result = append(result, p.newChange(
+						RequestPropertyExclusiveMaxIncreasedId,
+						[]any{propName, exMaxDiff.From, exMaxDiff.To},
+						"",
+					).WithSources(propBaseSource, propRevisionSource))
+				}
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_request_property_min_items_set.go
+++ b/checker/check_request_property_min_items_set.go
@@ -11,70 +11,35 @@ const (
 
 func RequestPropertyMinItemsSetCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if minItemsDiff := info.schemaDiff.MinItemsDiff; minItemsDiff != nil &&
+			minItemsDiff.From == nil && minItemsDiff.To != nil {
+			_, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "minItems")
+			result = append(result, info.newChange(
+				RequestBodyMinItemsSetId,
+				[]any{minItemsDiff.To},
+				commentId(RequestBodyMinItemsSetId),
+			).WithSources(nil, revisionSource))
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
+
+		info.walkProperties(func(p propertyInfo) {
+			minItemsDiff := p.propertyDiff.MinItemsDiff
+			if minItemsDiff == nil || minItemsDiff.From != nil || minItemsDiff.To == nil {
+				return
+			}
+			if p.propertyDiff.Revision.ReadOnly {
+				return
 			}
 
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				if mediaTypeDiff.SchemaDiff != nil && mediaTypeDiff.SchemaDiff.MinItemsDiff != nil {
-					minItemsDiff := mediaTypeDiff.SchemaDiff.MinItemsDiff
-					if minItemsDiff.From == nil &&
-						minItemsDiff.To != nil {
-						_, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "minItems")
-						result = append(result, NewApiChange(
-							RequestBodyMinItemsSetId,
-							config,
-							[]any{minItemsDiff.To},
-							commentId(RequestBodyMinItemsSetId),
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-					}
-				}
+			_, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "minItems")
+			result = append(result, p.newChange(
+				RequestPropertyMinItemsSetId,
+				[]any{propertyFullName(p.propertyPath, p.propertyName), minItemsDiff.To},
+				commentId(RequestPropertyMinItemsSetId),
+			).WithSources(nil, propRevisionSource))
+		})
+	})
 
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						minItemsDiff := propertyDiff.MinItemsDiff
-						if minItemsDiff == nil {
-							return
-						}
-						if minItemsDiff.From != nil ||
-							minItemsDiff.To == nil {
-							return
-						}
-						if propertyDiff.Revision.ReadOnly {
-							return
-						}
-
-						_, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "minItems")
-						result = append(result, NewApiChange(
-							RequestPropertyMinItemsSetId,
-							config,
-							[]any{propertyFullName(propertyPath, propertyName), minItemsDiff.To},
-							commentId(RequestPropertyMinItemsSetId),
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(nil, propRevisionSource).WithDetails(mediaTypeDetails))
-					})
-			}
-		}
-	}
 	return result
 }

--- a/checker/check_request_property_min_updated.go
+++ b/checker/check_request_property_min_updated.go
@@ -19,179 +19,91 @@ const (
 
 func RequestPropertyMinIncreasedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
-			}
 
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				if mediaTypeDiff.SchemaDiff == nil {
-					continue
-				}
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "minimum")
-				if mediaTypeDiff.SchemaDiff.MinDiff != nil {
-					minDiff := mediaTypeDiff.SchemaDiff.MinDiff
-					if minDiff.From != nil &&
-						minDiff.To != nil {
-						if IsIncreasedValue(minDiff) {
-							result = append(result, NewApiChange(
-								RequestBodyMinIncreasedId,
-								config,
-								[]any{minDiff.To},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-						} else {
-							result = append(result, NewApiChange(
-								RequestBodyMinDecreasedId,
-								config,
-								[]any{minDiff.From, minDiff.To},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-						}
-					}
-				}
-				if mediaTypeDiff.SchemaDiff.ExclusiveMinDiff != nil {
-					exMinDiff := mediaTypeDiff.SchemaDiff.ExclusiveMinDiff
-					if exMinDiff.From != nil &&
-						exMinDiff.To != nil {
-						exBaseSource, exRevisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "exclusiveMinimum")
-						if IsIncreasedValue(exMinDiff) {
-							result = append(result, NewApiChange(
-								RequestBodyExclusiveMinIncreasedId,
-								config,
-								[]any{exMinDiff.To},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(exBaseSource, exRevisionSource).WithDetails(mediaTypeDetails))
-						} else {
-							result = append(result, NewApiChange(
-								RequestBodyExclusiveMinDecreasedId,
-								config,
-								[]any{exMinDiff.From, exMinDiff.To},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(exBaseSource, exRevisionSource).WithDetails(mediaTypeDetails))
-						}
-					}
-				}
-
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						minDiff := propertyDiff.MinDiff
-						if minDiff == nil {
-							return
-						}
-						if minDiff.From == nil ||
-							minDiff.To == nil {
-							return
-						}
-
-						propName := propertyFullName(propertyPath, propertyName)
-						propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "minimum")
-
-						if IsIncreasedValue(minDiff) {
-
-							id := RequestPropertyMinIncreasedId
-
-							if propertyDiff.Revision.ReadOnly {
-								id = RequestReadOnlyPropertyMinIncreasedId
-							}
-
-							result = append(result, NewApiChange(
-								id,
-								config,
-								[]any{propName, minDiff.To},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						} else {
-							result = append(result, NewApiChange(
-								RequestPropertyMinDecreasedId,
-								config,
-								[]any{propName, minDiff.From, minDiff.To},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						}
-					})
-
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						exMinDiff := propertyDiff.ExclusiveMinDiff
-						if exMinDiff == nil {
-							return
-						}
-						if exMinDiff.From == nil ||
-							exMinDiff.To == nil {
-							return
-						}
-
-						propName := propertyFullName(propertyPath, propertyName)
-						propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "exclusiveMinimum")
-
-						if IsIncreasedValue(exMinDiff) {
-							id := RequestPropertyExclusiveMinIncreasedId
-							if propertyDiff.Revision.ReadOnly {
-								id = RequestReadOnlyPropertyExclusiveMinIncreasedId
-							}
-							result = append(result, NewApiChange(
-								id,
-								config,
-								[]any{propName, exMinDiff.To},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						} else {
-							result = append(result, NewApiChange(
-								RequestPropertyExclusiveMinDecreasedId,
-								config,
-								[]any{propName, exMinDiff.From, exMinDiff.To},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						}
-					})
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if minDiff := info.schemaDiff.MinDiff; minDiff != nil &&
+			minDiff.From != nil && minDiff.To != nil {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "minimum")
+			if IsIncreasedValue(minDiff) {
+				result = append(result, info.newChange(
+					RequestBodyMinIncreasedId,
+					[]any{minDiff.To},
+					"",
+				).WithSources(baseSource, revisionSource))
+			} else {
+				result = append(result, info.newChange(
+					RequestBodyMinDecreasedId,
+					[]any{minDiff.From, minDiff.To},
+					"",
+				).WithSources(baseSource, revisionSource))
 			}
 		}
-	}
+		if exMinDiff := info.schemaDiff.ExclusiveMinDiff; exMinDiff != nil &&
+			exMinDiff.From != nil && exMinDiff.To != nil {
+			exBaseSource, exRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "exclusiveMinimum")
+			if IsIncreasedValue(exMinDiff) {
+				result = append(result, info.newChange(
+					RequestBodyExclusiveMinIncreasedId,
+					[]any{exMinDiff.To},
+					"",
+				).WithSources(exBaseSource, exRevisionSource))
+			} else {
+				result = append(result, info.newChange(
+					RequestBodyExclusiveMinDecreasedId,
+					[]any{exMinDiff.From, exMinDiff.To},
+					"",
+				).WithSources(exBaseSource, exRevisionSource))
+			}
+		}
+
+		info.walkProperties(func(p propertyInfo) {
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+
+			if minDiff := p.propertyDiff.MinDiff; minDiff != nil &&
+				minDiff.From != nil && minDiff.To != nil {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "minimum")
+				if IsIncreasedValue(minDiff) {
+					id := RequestPropertyMinIncreasedId
+					if p.propertyDiff.Revision.ReadOnly {
+						id = RequestReadOnlyPropertyMinIncreasedId
+					}
+					result = append(result, p.newChange(
+						id,
+						[]any{propName, minDiff.To},
+						"",
+					).WithSources(propBaseSource, propRevisionSource))
+				} else {
+					result = append(result, p.newChange(
+						RequestPropertyMinDecreasedId,
+						[]any{propName, minDiff.From, minDiff.To},
+						"",
+					).WithSources(propBaseSource, propRevisionSource))
+				}
+			}
+
+			if exMinDiff := p.propertyDiff.ExclusiveMinDiff; exMinDiff != nil &&
+				exMinDiff.From != nil && exMinDiff.To != nil {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "exclusiveMinimum")
+				if IsIncreasedValue(exMinDiff) {
+					id := RequestPropertyExclusiveMinIncreasedId
+					if p.propertyDiff.Revision.ReadOnly {
+						id = RequestReadOnlyPropertyExclusiveMinIncreasedId
+					}
+					result = append(result, p.newChange(
+						id,
+						[]any{propName, exMinDiff.To},
+						"",
+					).WithSources(propBaseSource, propRevisionSource))
+				} else {
+					result = append(result, p.newChange(
+						RequestPropertyExclusiveMinDecreasedId,
+						[]any{propName, exMinDiff.From, exMinDiff.To},
+						"",
+					).WithSources(propBaseSource, propRevisionSource))
+				}
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_response_property_max_increased.go
+++ b/checker/check_response_property_max_increased.go
@@ -13,133 +13,54 @@ const (
 
 func ResponsePropertyMaxIncreasedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if maxDiff := info.schemaDiff.MaxDiff; maxDiff != nil &&
+			maxDiff.From != nil && maxDiff.To != nil && IsIncreasedValue(maxDiff) {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "maximum")
+			result = append(result, info.newChange(
+				ResponseBodyMaxIncreasedId,
+				[]any{maxDiff.From, maxDiff.To},
+				"",
+			).WithSources(baseSource, revisionSource))
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil || operationItem.ResponsesDiff.Modified == nil {
-				continue
+		if exMaxDiff := info.schemaDiff.ExclusiveMaxDiff; exMaxDiff != nil &&
+			exMaxDiff.From != nil && exMaxDiff.To != nil && IsIncreasedValue(exMaxDiff) {
+			exBaseSource, exRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "exclusiveMaximum")
+			result = append(result, info.newChange(
+				ResponseBodyExclusiveMaxIncreasedId,
+				[]any{exMaxDiff.From, exMaxDiff.To},
+				"",
+			).WithSources(exBaseSource, exRevisionSource))
+		}
+
+		info.walkProperties(func(p propertyInfo) {
+			if p.propertyDiff.Revision.WriteOnly {
+				return
 			}
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff == nil ||
-					responseDiff.ContentDiff == nil ||
-					responseDiff.ContentDiff.MediaTypeModified == nil {
-					continue
-				}
-				modifiedMediaTypes := responseDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					if mediaTypeDiff.SchemaDiff != nil && mediaTypeDiff.SchemaDiff.MaxDiff != nil {
-						maxDiff := mediaTypeDiff.SchemaDiff.MaxDiff
-						if maxDiff.From != nil &&
-							maxDiff.To != nil {
-							if IsIncreasedValue(maxDiff) {
-								baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "maximum")
-								result = append(result, NewApiChange(
-									ResponseBodyMaxIncreasedId,
-									config,
-									[]any{maxDiff.From, maxDiff.To},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-							}
-						}
-					}
-					if mediaTypeDiff.SchemaDiff != nil && mediaTypeDiff.SchemaDiff.ExclusiveMaxDiff != nil {
-						exMaxDiff := mediaTypeDiff.SchemaDiff.ExclusiveMaxDiff
-						if exMaxDiff.From != nil &&
-							exMaxDiff.To != nil {
-							if IsIncreasedValue(exMaxDiff) {
-								exBaseSource, exRevisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "exclusiveMaximum")
-								result = append(result, NewApiChange(
-									ResponseBodyExclusiveMaxIncreasedId,
-									config,
-									[]any{exMaxDiff.From, exMaxDiff.To},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(exBaseSource, exRevisionSource).WithDetails(mediaTypeDetails))
-							}
-						}
-					}
+			propName := propertyFullName(p.propertyPath, p.propertyName)
 
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							maxDiff := propertyDiff.MaxDiff
-							if maxDiff == nil {
-								return
-							}
-							if maxDiff.To == nil ||
-								maxDiff.From == nil {
-								return
-							}
-							if !IsIncreasedValue(maxDiff) {
-								return
-							}
-
-							if propertyDiff.Revision.WriteOnly {
-								return
-							}
-
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "maximum")
-							result = append(result, NewApiChange(
-								ResponsePropertyMaxIncreasedId,
-								config,
-								[]any{propertyFullName(propertyPath, propertyName), maxDiff.From, maxDiff.To, responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						})
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							exMaxDiff := propertyDiff.ExclusiveMaxDiff
-							if exMaxDiff == nil {
-								return
-							}
-							if exMaxDiff.To == nil ||
-								exMaxDiff.From == nil {
-								return
-							}
-							if !IsIncreasedValue(exMaxDiff) {
-								return
-							}
-
-							if propertyDiff.Revision.WriteOnly {
-								return
-							}
-
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "exclusiveMaximum")
-							result = append(result, NewApiChange(
-								ResponsePropertyExclusiveMaxIncreasedId,
-								config,
-								[]any{propertyFullName(propertyPath, propertyName), exMaxDiff.From, exMaxDiff.To, responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						})
-				}
-
+			if maxDiff := p.propertyDiff.MaxDiff; maxDiff != nil &&
+				maxDiff.To != nil && maxDiff.From != nil && IsIncreasedValue(maxDiff) {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "maximum")
+				result = append(result, p.newChange(
+					ResponsePropertyMaxIncreasedId,
+					[]any{propName, maxDiff.From, maxDiff.To, info.responseStatus},
+					"",
+				).WithSources(propBaseSource, propRevisionSource))
 			}
 
-		}
-	}
+			if exMaxDiff := p.propertyDiff.ExclusiveMaxDiff; exMaxDiff != nil &&
+				exMaxDiff.To != nil && exMaxDiff.From != nil && IsIncreasedValue(exMaxDiff) {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "exclusiveMaximum")
+				result = append(result, p.newChange(
+					ResponsePropertyExclusiveMaxIncreasedId,
+					[]any{propName, exMaxDiff.From, exMaxDiff.To, info.responseStatus},
+					"",
+				).WithSources(propBaseSource, propRevisionSource))
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_response_property_min_decreased.go
+++ b/checker/check_response_property_min_decreased.go
@@ -13,131 +13,54 @@ const (
 
 func ResponsePropertyMinDecreasedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if minDiff := info.schemaDiff.MinDiff; minDiff != nil &&
+			minDiff.From != nil && minDiff.To != nil && IsDecreasedValue(minDiff) {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "minimum")
+			result = append(result, info.newChange(
+				ResponseBodyMinDecreasedId,
+				[]any{minDiff.From, minDiff.To},
+				"",
+			).WithSources(baseSource, revisionSource))
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil || operationItem.ResponsesDiff.Modified == nil {
-				continue
-			}
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff == nil ||
-					responseDiff.ContentDiff == nil ||
-					responseDiff.ContentDiff.MediaTypeModified == nil {
-					continue
-				}
-				modifiedMediaTypes := responseDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					if mediaTypeDiff.SchemaDiff != nil && mediaTypeDiff.SchemaDiff.MinDiff != nil {
-						minDiff := mediaTypeDiff.SchemaDiff.MinDiff
-						if minDiff.From != nil &&
-							minDiff.To != nil {
-							if IsDecreasedValue(minDiff) {
-								baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "minimum")
-								result = append(result, NewApiChange(
-									ResponseBodyMinDecreasedId,
-									config,
-									[]any{minDiff.From, minDiff.To},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-							}
-						}
-					}
-					if mediaTypeDiff.SchemaDiff != nil && mediaTypeDiff.SchemaDiff.ExclusiveMinDiff != nil {
-						exMinDiff := mediaTypeDiff.SchemaDiff.ExclusiveMinDiff
-						if exMinDiff.From != nil &&
-							exMinDiff.To != nil {
-							if IsDecreasedValue(exMinDiff) {
-								exBaseSource, exRevisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "exclusiveMinimum")
-								result = append(result, NewApiChange(
-									ResponseBodyExclusiveMinDecreasedId,
-									config,
-									[]any{exMinDiff.From, exMinDiff.To},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(exBaseSource, exRevisionSource).WithDetails(mediaTypeDetails))
-							}
-						}
-					}
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							minDiff := propertyDiff.MinDiff
-							if minDiff == nil {
-								return
-							}
-							if minDiff.To == nil ||
-								minDiff.From == nil {
-								return
-							}
-							if !IsDecreasedValue(minDiff) {
-								return
-							}
-
-							if propertyDiff.Revision.WriteOnly {
-								return
-							}
-
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "minimum")
-							result = append(result, NewApiChange(
-								ResponsePropertyMinDecreasedId,
-								config,
-								[]any{propertyFullName(propertyPath, propertyName), minDiff.From, minDiff.To, responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						})
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							exMinDiff := propertyDiff.ExclusiveMinDiff
-							if exMinDiff == nil {
-								return
-							}
-							if exMinDiff.To == nil ||
-								exMinDiff.From == nil {
-								return
-							}
-							if !IsDecreasedValue(exMinDiff) {
-								return
-							}
-
-							if propertyDiff.Revision.WriteOnly {
-								return
-							}
-
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "exclusiveMinimum")
-							result = append(result, NewApiChange(
-								ResponsePropertyExclusiveMinDecreasedId,
-								config,
-								[]any{propertyFullName(propertyPath, propertyName), exMinDiff.From, exMinDiff.To, responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						})
-				}
-			}
+		if exMinDiff := info.schemaDiff.ExclusiveMinDiff; exMinDiff != nil &&
+			exMinDiff.From != nil && exMinDiff.To != nil && IsDecreasedValue(exMinDiff) {
+			exBaseSource, exRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "exclusiveMinimum")
+			result = append(result, info.newChange(
+				ResponseBodyExclusiveMinDecreasedId,
+				[]any{exMinDiff.From, exMinDiff.To},
+				"",
+			).WithSources(exBaseSource, exRevisionSource))
 		}
-	}
+
+		info.walkProperties(func(p propertyInfo) {
+			if p.propertyDiff.Revision.WriteOnly {
+				return
+			}
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+
+			if minDiff := p.propertyDiff.MinDiff; minDiff != nil &&
+				minDiff.To != nil && minDiff.From != nil && IsDecreasedValue(minDiff) {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "minimum")
+				result = append(result, p.newChange(
+					ResponsePropertyMinDecreasedId,
+					[]any{propName, minDiff.From, minDiff.To, info.responseStatus},
+					"",
+				).WithSources(propBaseSource, propRevisionSource))
+			}
+
+			if exMinDiff := p.propertyDiff.ExclusiveMinDiff; exMinDiff != nil &&
+				exMinDiff.To != nil && exMinDiff.From != nil && IsDecreasedValue(exMinDiff) {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "exclusiveMinimum")
+				result = append(result, p.newChange(
+					ResponsePropertyExclusiveMinDecreasedId,
+					[]any{propName, exMinDiff.From, exMinDiff.To, info.responseStatus},
+					"",
+				).WithSources(propBaseSource, propRevisionSource))
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_response_property_min_items_unset.go
+++ b/checker/check_response_property_min_items_unset.go
@@ -11,76 +11,35 @@ const (
 
 func ResponsePropertyMinItemsUnsetCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if minItemsDiff := info.schemaDiff.MinItemsDiff; minItemsDiff != nil &&
+			minItemsDiff.From != nil && minItemsDiff.To == nil {
+			baseSource, _ := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "minItems")
+			result = append(result, info.newChange(
+				ResponseBodyMinItemsUnsetId,
+				[]any{minItemsDiff.From},
+				"",
+			).WithSources(baseSource, nil))
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil || operationItem.ResponsesDiff.Modified == nil {
-				continue
+
+		info.walkProperties(func(p propertyInfo) {
+			minItemsDiff := p.propertyDiff.MinItemsDiff
+			if minItemsDiff == nil || minItemsDiff.To != nil || minItemsDiff.From == nil {
+				return
 			}
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff == nil ||
-					responseDiff.ContentDiff == nil ||
-					responseDiff.ContentDiff.MediaTypeModified == nil {
-					continue
-				}
-				modifiedMediaTypes := responseDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					if mediaTypeDiff.SchemaDiff != nil && mediaTypeDiff.SchemaDiff.MinItemsDiff != nil {
-						minItemsDiff := mediaTypeDiff.SchemaDiff.MinItemsDiff
-						if minItemsDiff.From != nil &&
-							minItemsDiff.To == nil {
-							baseSource, _ := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "minItems")
-							result = append(result, NewApiChange(
-								ResponseBodyMinItemsUnsetId,
-								config,
-								[]any{minItemsDiff.From},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-						}
-					}
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							minItemsDiff := propertyDiff.MinItemsDiff
-							if minItemsDiff == nil {
-								return
-							}
-							if minItemsDiff.To != nil ||
-								minItemsDiff.From == nil {
-								return
-							}
-							if propertyDiff.Revision.WriteOnly {
-								return
-							}
-
-							propBaseSource, _ := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "minItems")
-							result = append(result, NewApiChange(
-								ResponsePropertyMinItemsUnsetId,
-								config,
-								[]any{propertyFullName(propertyPath, propertyName), minItemsDiff.From, responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, nil).WithDetails(mediaTypeDetails))
-						})
-				}
-
+			if p.propertyDiff.Revision.WriteOnly {
+				return
 			}
 
-		}
-	}
+			propBaseSource, _ := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "minItems")
+			result = append(result, p.newChange(
+				ResponsePropertyMinItemsUnsetId,
+				[]any{propertyFullName(p.propertyPath, p.propertyName), minItemsDiff.From, info.responseStatus},
+				"",
+			).WithSources(propBaseSource, nil))
+		})
+	})
+
 	return result
 }


### PR DESCRIPTION
## What

Third migration batch off the walker (#940). Six files, three matched request/response pairs from the Easy bucket of #936:

| Pair | Files |
|---|---|
| min (numeric) | `check_request_property_min_updated.go` + `check_response_property_min_decreased.go` |
| max (numeric) | `check_request_property_max_updated.go` + `check_response_property_max_increased.go` |
| min_items | `check_request_property_min_items_set.go` + `check_response_property_min_items_unset.go` |

## What this validates beyond batches 1-2

Previous batches covered the basic emit shapes. This batch exercises one further idiom:

**Two field families per checker walked at once.** The min and max checkers each handle a regular field (`MinDiff` / `MaxDiff`) *and* an exclusive variant (`ExclusiveMinDiff` / `ExclusiveMaxDiff`). The original code called `CheckModifiedPropertiesDiff` twice — once for each field — and walked the schema tree twice. The migrated code uses a single `info.walkProperties` and checks both fields per property. Same emit set; one tree traversal instead of two.

The migration also exercises the `ReadOnly` / `WriteOnly` property-level guard, which selects between standard and read-only / write-only IDs:

```go
id := RequestPropertyMaxDecreasedId
if p.propertyDiff.Revision.ReadOnly {
    id = RequestReadOnlyPropertyMaxDecreasedId
}
result = append(result, p.newChange(id, []any{propName, maxDiff.To}, "").WithSources(...))
```

## Numbers

| | Before | After | Delta |
|---|---|---|---|
| `check_request_property_min_updated.go` | 198 | 110 | -88 |
| `check_response_property_min_decreased.go` | 144 | 64 | -80 |
| `check_request_property_max_updated.go` | 198 | 110 | -88 |
| `check_response_property_max_increased.go` | 146 | 64 | -82 |
| `check_request_property_min_items_set.go` | 81 | 45 | -36 |
| `check_response_property_min_items_unset.go` | 87 | 45 | -42 |

Net **`-416`** lines across the six files (counting only the source lines; the commit total shows `-408` accounting for unchanged-line drift).

## Why this PR is safe to land

No behaviour change. Every existing test for these checkers passes without modification (verified locally: `TestRequestPropertyMinIncreasedCheck`, `TestRequestPropertyMinDecreasedCheck`, `TestRequestReadOnlyPropertyMinIncreasedCheck`, the matching Max series, the ExclusiveMin/Max series for both request and response, and the MinItemsSet/Unset tests). Full suite green.

The combined `info.walkProperties` is the only structural change vs the original: two `CheckModifiedPropertiesDiff` calls become one. Since the original code's two callbacks did not share state and the order of emissions between min/max and exclusive variants was not observable to tests (or to localization), this is behaviour-preserving by construction.

## Running total

After this PR, **14 checker files** are on the walker (2 from the pilot + 6 from batch 2 + 6 from batch 3). About **61** remain. Per the strategy in #936, migration continues opportunistically from here unless a fresh bug class signals otherwise.
