### PR TITLE
checker: migrate min_items, type_changed, nullable pairs to walker + fix nullable source-attachment asymmetry (PR-4 of #936)

### DIFF
--- a/checker/check_request_property_became_not_nuallable.go
+++ b/checker/check_request_property_became_not_nuallable.go
@@ -17,6 +17,7 @@ const (
 //   - Body-level OpenAPI-3.1 type-array transitions do not.
 //   - Property-level NullableDiff emissions do not.
 //   - Property-level OpenAPI-3.1 type-array transitions do.
+//
 // This inconsistency predates the walker; preserved as-is to keep the
 // migration a pure refactor.
 func RequestPropertyBecameNotNullableCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {

--- a/checker/check_request_property_became_not_nuallable.go
+++ b/checker/check_request_property_became_not_nuallable.go
@@ -11,140 +11,56 @@ const (
 	RequestPropertyBecomeNullableId    = "request-property-became-nullable"
 )
 
+// Source-attachment behaviour is intentionally non-uniform here, matching the
+// pre-migration code:
+//   - Body-level NullableDiff emissions carry .WithSources(...).
+//   - Body-level OpenAPI-3.1 type-array transitions do not.
+//   - Property-level NullableDiff emissions do not.
+//   - Property-level OpenAPI-3.1 type-array transitions do.
+// This inconsistency predates the walker; preserved as-is to keep the
+// migration a pure refactor.
 func RequestPropertyBecameNotNullableCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
 
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if info.schemaDiff.NullableDiff != nil {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "nullable")
+			if info.schemaDiff.NullableDiff.From == true {
+				result = append(result, info.newChange(RequestBodyBecomeNotNullableId, nil, "").
+					WithSources(baseSource, revisionSource))
+			} else if info.schemaDiff.NullableDiff.To == true {
+				result = append(result, info.newChange(RequestBodyBecomeNullableId, nil, "").
+					WithSources(baseSource, revisionSource))
 			}
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				if mediaTypeDiff.SchemaDiff == nil {
-					continue
-				}
-				baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "nullable")
-
-				if mediaTypeDiff.SchemaDiff.NullableDiff != nil {
-					if mediaTypeDiff.SchemaDiff.NullableDiff.From == true {
-						result = append(result, NewApiChange(
-							RequestBodyBecomeNotNullableId,
-							config,
-							nil,
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-					} else if mediaTypeDiff.SchemaDiff.NullableDiff.To == true {
-						result = append(result, NewApiChange(
-							RequestBodyBecomeNullableId,
-							config,
-							nil,
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-					}
-				} else if nullRemovedFromTypeArray(mediaTypeDiff.SchemaDiff.TypeDiff) {
-					// OpenAPI 3.1: type changed from ["string", "null"] to "string"
-					result = append(result, NewApiChange(
-						RequestBodyBecomeNotNullableId,
-						config,
-						nil,
-						"",
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
-					).WithDetails(mediaTypeDetails))
-				} else if nullAddedToTypeArray(mediaTypeDiff.SchemaDiff.TypeDiff) {
-					// OpenAPI 3.1: type changed from "string" to ["string", "null"]
-					result = append(result, NewApiChange(
-						RequestBodyBecomeNullableId,
-						config,
-						nil,
-						"",
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
-					).WithDetails(mediaTypeDetails))
-				}
-
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						propName := propertyFullName(propertyPath, propertyName)
-						propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "nullable")
-
-						nullableDiff := propertyDiff.NullableDiff
-						if nullableDiff != nil {
-							if nullableDiff.From == true {
-								result = append(result, NewApiChange(
-									RequestPropertyBecomeNotNullableId,
-									config,
-									[]any{propName},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithDetails(mediaTypeDetails))
-							} else if nullableDiff.To == true {
-								result = append(result, NewApiChange(
-									RequestPropertyBecomeNullableId,
-									config,
-									[]any{propName},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithDetails(mediaTypeDetails))
-							}
-						} else if nullRemovedFromTypeArray(propertyDiff.TypeDiff) {
-							// OpenAPI 3.1: type changed from ["string", "null"] to "string"
-							result = append(result, NewApiChange(
-								RequestPropertyBecomeNotNullableId,
-								config,
-								[]any{propName},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						} else if nullAddedToTypeArray(propertyDiff.TypeDiff) {
-							// OpenAPI 3.1: type changed from "string" to ["string", "null"]
-							result = append(result, NewApiChange(
-								RequestPropertyBecomeNullableId,
-								config,
-								[]any{propName},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						}
-
-					})
-			}
+		} else if nullRemovedFromTypeArray(info.schemaDiff.TypeDiff) {
+			// OpenAPI 3.1: type changed from ["string", "null"] to "string"
+			result = append(result, info.newChange(RequestBodyBecomeNotNullableId, nil, ""))
+		} else if nullAddedToTypeArray(info.schemaDiff.TypeDiff) {
+			// OpenAPI 3.1: type changed from "string" to ["string", "null"]
+			result = append(result, info.newChange(RequestBodyBecomeNullableId, nil, ""))
 		}
-	}
+
+		info.walkProperties(func(p propertyInfo) {
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+
+			nullableDiff := p.propertyDiff.NullableDiff
+			if nullableDiff != nil {
+				if nullableDiff.From == true {
+					result = append(result, p.newChange(RequestPropertyBecomeNotNullableId, []any{propName}, ""))
+				} else if nullableDiff.To == true {
+					result = append(result, p.newChange(RequestPropertyBecomeNullableId, []any{propName}, ""))
+				}
+			} else if nullRemovedFromTypeArray(p.propertyDiff.TypeDiff) {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "nullable")
+				result = append(result, p.newChange(RequestPropertyBecomeNotNullableId, []any{propName}, "").
+					WithSources(propBaseSource, propRevisionSource))
+			} else if nullAddedToTypeArray(p.propertyDiff.TypeDiff) {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "nullable")
+				result = append(result, p.newChange(RequestPropertyBecomeNullableId, []any{propName}, "").
+					WithSources(propBaseSource, propRevisionSource))
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_request_property_became_not_nuallable.go
+++ b/checker/check_request_property_became_not_nuallable.go
@@ -11,21 +11,12 @@ const (
 	RequestPropertyBecomeNullableId    = "request-property-became-nullable"
 )
 
-// Source-attachment behaviour is intentionally non-uniform here, matching the
-// pre-migration code:
-//   - Body-level NullableDiff emissions carry .WithSources(...).
-//   - Body-level OpenAPI-3.1 type-array transitions do not.
-//   - Property-level NullableDiff emissions do not.
-//   - Property-level OpenAPI-3.1 type-array transitions do.
-//
-// This inconsistency predates the walker; preserved as-is to keep the
-// migration a pure refactor.
 func RequestPropertyBecameNotNullableCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
 
 	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "nullable")
 		if info.schemaDiff.NullableDiff != nil {
-			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "nullable")
 			if info.schemaDiff.NullableDiff.From == true {
 				result = append(result, info.newChange(RequestBodyBecomeNotNullableId, nil, "").
 					WithSources(baseSource, revisionSource))
@@ -35,28 +26,31 @@ func RequestPropertyBecameNotNullableCheck(diffReport *diff.Diff, operationsSour
 			}
 		} else if nullRemovedFromTypeArray(info.schemaDiff.TypeDiff) {
 			// OpenAPI 3.1: type changed from ["string", "null"] to "string"
-			result = append(result, info.newChange(RequestBodyBecomeNotNullableId, nil, ""))
+			result = append(result, info.newChange(RequestBodyBecomeNotNullableId, nil, "").
+				WithSources(baseSource, revisionSource))
 		} else if nullAddedToTypeArray(info.schemaDiff.TypeDiff) {
 			// OpenAPI 3.1: type changed from "string" to ["string", "null"]
-			result = append(result, info.newChange(RequestBodyBecomeNullableId, nil, ""))
+			result = append(result, info.newChange(RequestBodyBecomeNullableId, nil, "").
+				WithSources(baseSource, revisionSource))
 		}
 
 		info.walkProperties(func(p propertyInfo) {
 			propName := propertyFullName(p.propertyPath, p.propertyName)
+			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "nullable")
 
 			nullableDiff := p.propertyDiff.NullableDiff
 			if nullableDiff != nil {
 				if nullableDiff.From == true {
-					result = append(result, p.newChange(RequestPropertyBecomeNotNullableId, []any{propName}, ""))
+					result = append(result, p.newChange(RequestPropertyBecomeNotNullableId, []any{propName}, "").
+						WithSources(propBaseSource, propRevisionSource))
 				} else if nullableDiff.To == true {
-					result = append(result, p.newChange(RequestPropertyBecomeNullableId, []any{propName}, ""))
+					result = append(result, p.newChange(RequestPropertyBecomeNullableId, []any{propName}, "").
+						WithSources(propBaseSource, propRevisionSource))
 				}
 			} else if nullRemovedFromTypeArray(p.propertyDiff.TypeDiff) {
-				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "nullable")
 				result = append(result, p.newChange(RequestPropertyBecomeNotNullableId, []any{propName}, "").
 					WithSources(propBaseSource, propRevisionSource))
 			} else if nullAddedToTypeArray(p.propertyDiff.TypeDiff) {
-				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "nullable")
 				result = append(result, p.newChange(RequestPropertyBecomeNullableId, []any{propName}, "").
 					WithSources(propBaseSource, propRevisionSource))
 			}

--- a/checker/check_request_property_min_items_increased.go
+++ b/checker/check_request_property_min_items_increased.go
@@ -11,78 +11,38 @@ const (
 
 func RequestPropertyMinItemsIncreasedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if minItemsDiff := info.schemaDiff.MinItemsDiff; minItemsDiff != nil &&
+			minItemsDiff.From != nil && minItemsDiff.To != nil && IsIncreasedValue(minItemsDiff) {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "minItems")
+			result = append(result, info.newChange(
+				RequestBodyMinItemsIncreasedId,
+				[]any{minItemsDiff.To},
+				"",
+			).WithSources(baseSource, revisionSource))
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
+
+		info.walkProperties(func(p propertyInfo) {
+			minItemsDiff := p.propertyDiff.MinItemsDiff
+			if minItemsDiff == nil || minItemsDiff.From == nil || minItemsDiff.To == nil {
+				return
+			}
+			if p.propertyDiff.Revision.ReadOnly {
+				return
+			}
+			if !IsIncreasedValue(minItemsDiff) {
+				return
 			}
 
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				if mediaTypeDiff.SchemaDiff == nil {
-					continue
-				}
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "minItems")
-				if mediaTypeDiff.SchemaDiff.MinItemsDiff != nil {
-					minItemsDiff := mediaTypeDiff.SchemaDiff.MinItemsDiff
-					if minItemsDiff.From != nil &&
-						minItemsDiff.To != nil {
-						if IsIncreasedValue(minItemsDiff) {
-							result = append(result, NewApiChange(
-								RequestBodyMinItemsIncreasedId,
-								config,
-								[]any{minItemsDiff.To},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-						}
-					}
-				}
+			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "minItems")
+			result = append(result, p.newChange(
+				RequestPropertyMinItemsIncreasedId,
+				[]any{propertyFullName(p.propertyPath, p.propertyName), minItemsDiff.To},
+				"",
+			).WithSources(propBaseSource, propRevisionSource))
+		})
+	})
 
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						minItemsDiff := propertyDiff.MinItemsDiff
-						if minItemsDiff == nil {
-							return
-						}
-						if minItemsDiff.From == nil ||
-							minItemsDiff.To == nil {
-							return
-						}
-						if propertyDiff.Revision.ReadOnly {
-							return
-						}
-						if !IsIncreasedValue(minItemsDiff) {
-							return
-						}
-
-						propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "minItems")
-						result = append(result, NewApiChange(
-							RequestPropertyMinItemsIncreasedId,
-							config,
-							[]any{propertyFullName(propertyPath, propertyName), minItemsDiff.To},
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-					})
-			}
-		}
-	}
 	return result
 }

--- a/checker/check_request_property_type_changed.go
+++ b/checker/check_request_property_type_changed.go
@@ -13,109 +13,70 @@ const (
 
 func RequestPropertyTypeChangedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
+
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		schemaDiff := info.schemaDiff
+		typeDiff := schemaDiff.TypeDiff
+		formatDiff := schemaDiff.FormatDiff
+
+		if !typeDiff.Empty() || !formatDiff.Empty() {
+			// Body-level suppression also skips the property walk for this
+			// media type (the pre-migration code used a `continue` in the
+			// media-type for-loop, which had that effect). Preserved.
+			if shouldSuppressTypeChangedForListOfTypes(schemaDiff) {
+				return
+			}
+			// Suppress null-only type changes (handled by nullable checkers).
+			if isNullTypeChange(typeDiff) && formatDiff.Empty() {
+				return
 			}
 
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				if mediaTypeDiff.SchemaDiff == nil {
-					continue
-				}
-
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				schemaDiff := mediaTypeDiff.SchemaDiff
-				baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, schemaDiff, "type")
-				typeDiff := schemaDiff.TypeDiff
-				formatDiff := schemaDiff.FormatDiff
-
-				if !typeDiff.Empty() || !formatDiff.Empty() {
-
-					id := RequestBodyTypeGeneralizedId
-
-					// Check for suppression by ListOfTypes checker
-					if shouldSuppressTypeChangedForListOfTypes(schemaDiff) {
-						continue
-					}
-
-					// Suppress null-only type changes (handled by nullable checkers)
-					if isNullTypeChange(typeDiff) && formatDiff.Empty() {
-						continue
-					}
-
-					if breakingTypeFormatChangedInRequestProperty(typeDiff, formatDiff, mediaType, schemaDiff) {
-						id = RequestBodyTypeChangedId
-					}
-
-					result = append(result, NewApiChange(
-						id,
-						config,
-						[]any{getBaseType(schemaDiff), getBaseFormat(schemaDiff), getRevisionType(schemaDiff), getRevisionFormat(schemaDiff)},
-						"",
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
-					).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-				}
-
-				CheckModifiedPropertiesDiff(
-					schemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						if propertyDiff.Revision == nil {
-							return
-						}
-						if propertyDiff.Revision.ReadOnly {
-							return
-						}
-
-						// Check for suppression by ListOfTypes checker
-						if shouldSuppressPropertyTypeChangedForListOfTypes(propertyDiff) {
-							return
-						}
-
-						// Suppress null-only type changes (handled by nullable checkers)
-						if isNullTypeChange(propertyDiff.TypeDiff) && propertyDiff.FormatDiff.Empty() {
-							return
-						}
-
-						schemaDiff := propertyDiff
-						typeDiff := schemaDiff.TypeDiff
-						formatDiff := schemaDiff.FormatDiff
-
-						if !typeDiff.Empty() || !formatDiff.Empty() {
-
-							id := RequestPropertyTypeGeneralizedId
-
-							if breakingTypeFormatChangedInRequestProperty(typeDiff, formatDiff, mediaType, schemaDiff) {
-								id = RequestPropertyTypeChangedId
-							}
-
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "type")
-							result = append(result, NewApiChange(
-								id,
-								config,
-								[]any{propertyFullName(propertyPath, propertyName), getBaseType(schemaDiff), getBaseFormat(schemaDiff), getRevisionType(schemaDiff), getRevisionFormat(schemaDiff)},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						}
-					})
+			id := RequestBodyTypeGeneralizedId
+			if breakingTypeFormatChangedInRequestProperty(typeDiff, formatDiff, info.mediaType, schemaDiff) {
+				id = RequestBodyTypeChangedId
 			}
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, schemaDiff, "type")
+			result = append(result, info.newChange(
+				id,
+				[]any{getBaseType(schemaDiff), getBaseFormat(schemaDiff), getRevisionType(schemaDiff), getRevisionFormat(schemaDiff)},
+				"",
+			).WithSources(baseSource, revisionSource))
 		}
-	}
+
+		info.walkProperties(func(p propertyInfo) {
+			if p.propertyDiff.Revision == nil {
+				return
+			}
+			if p.propertyDiff.Revision.ReadOnly {
+				return
+			}
+
+			if shouldSuppressPropertyTypeChangedForListOfTypes(p.propertyDiff) {
+				return
+			}
+			if isNullTypeChange(p.propertyDiff.TypeDiff) && p.propertyDiff.FormatDiff.Empty() {
+				return
+			}
+
+			propSchemaDiff := p.propertyDiff
+			propTypeDiff := propSchemaDiff.TypeDiff
+			propFormatDiff := propSchemaDiff.FormatDiff
+
+			if !propTypeDiff.Empty() || !propFormatDiff.Empty() {
+				id := RequestPropertyTypeGeneralizedId
+				if breakingTypeFormatChangedInRequestProperty(propTypeDiff, propFormatDiff, info.mediaType, propSchemaDiff) {
+					id = RequestPropertyTypeChangedId
+				}
+
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "type")
+				result = append(result, p.newChange(
+					id,
+					[]any{propertyFullName(p.propertyPath, p.propertyName), getBaseType(propSchemaDiff), getBaseFormat(propSchemaDiff), getRevisionType(propSchemaDiff), getRevisionFormat(propSchemaDiff)},
+					"",
+				).WithSources(propBaseSource, propRevisionSource))
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_response_property_became_nuallable.go
+++ b/checker/check_response_property_became_nuallable.go
@@ -9,98 +9,46 @@ const (
 	ResponseBodyBecameNullableId     = "response-body-became-nullable"
 )
 
+// Mirrors the request-side became-not-nullable shape: NullableDiff emissions
+// carry .WithSources(...), OpenAPI-3.1 type-array transitions do not. The
+// asymmetry predates the walker; preserved as-is.
 func ResponsePropertyBecameNullableCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if info.schemaDiff.NullableDiff != nil && info.schemaDiff.NullableDiff.To == true {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "nullable")
+			result = append(result, info.newChange(ResponseBodyBecameNullableId, nil, "").
+				WithSources(baseSource, revisionSource))
+		} else if nullAddedToTypeArray(info.schemaDiff.TypeDiff) {
+			// OpenAPI 3.1: type changed from "string" to ["string", "null"]
+			result = append(result, info.newChange(ResponseBodyBecameNullableId, nil, ""))
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
 
-			if operationItem.ResponsesDiff == nil {
-				continue
-			}
-
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff.ContentDiff == nil ||
-					responseDiff.ContentDiff.MediaTypeModified == nil {
-					continue
+		info.walkProperties(func(p propertyInfo) {
+			nullableDiff := p.propertyDiff.NullableDiff
+			if nullableDiff != nil {
+				if nullableDiff.To != true {
+					return
 				}
-
-				modifiedMediaTypes := responseDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					if mediaTypeDiff.SchemaDiff == nil {
-						continue
-					}
-
-					if mediaTypeDiff.SchemaDiff.NullableDiff != nil && mediaTypeDiff.SchemaDiff.NullableDiff.To == true {
-						baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "nullable")
-						result = append(result, NewApiChange(
-							ResponseBodyBecameNullableId,
-							config,
-							nil,
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-					} else if nullAddedToTypeArray(mediaTypeDiff.SchemaDiff.TypeDiff) {
-						// OpenAPI 3.1: type changed from "string" to ["string", "null"]
-						result = append(result, NewApiChange(
-							ResponseBodyBecameNullableId,
-							config,
-							nil,
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithDetails(mediaTypeDetails))
-					}
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							nullableDiff := propertyDiff.NullableDiff
-							if nullableDiff != nil {
-								if nullableDiff.To != true {
-									return
-								}
-								propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "nullable")
-								result = append(result, NewApiChange(
-									ResponsePropertyBecameNullableId,
-									config,
-									[]any{propertyFullName(propertyPath, propertyName), responseStatus},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-								return
-							}
-							// OpenAPI 3.1: type changed from "string" to ["string", "null"]
-							if nullAddedToTypeArray(propertyDiff.TypeDiff) {
-								result = append(result, NewApiChange(
-									ResponsePropertyBecameNullableId,
-									config,
-									[]any{propertyFullName(propertyPath, propertyName), responseStatus},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithDetails(mediaTypeDetails))
-							}
-						})
-				}
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "nullable")
+				result = append(result, p.newChange(
+					ResponsePropertyBecameNullableId,
+					[]any{propertyFullName(p.propertyPath, p.propertyName), info.responseStatus},
+					"",
+				).WithSources(propBaseSource, propRevisionSource))
+				return
 			}
-		}
-	}
+			// OpenAPI 3.1: type changed from "string" to ["string", "null"]
+			if nullAddedToTypeArray(p.propertyDiff.TypeDiff) {
+				result = append(result, p.newChange(
+					ResponsePropertyBecameNullableId,
+					[]any{propertyFullName(p.propertyPath, p.propertyName), info.responseStatus},
+					"",
+				))
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_response_property_became_nuallable.go
+++ b/checker/check_response_property_became_nuallable.go
@@ -9,29 +9,27 @@ const (
 	ResponseBodyBecameNullableId     = "response-body-became-nullable"
 )
 
-// Mirrors the request-side became-not-nullable shape: NullableDiff emissions
-// carry .WithSources(...), OpenAPI-3.1 type-array transitions do not. The
-// asymmetry predates the walker; preserved as-is.
 func ResponsePropertyBecameNullableCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
 
 	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "nullable")
 		if info.schemaDiff.NullableDiff != nil && info.schemaDiff.NullableDiff.To == true {
-			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "nullable")
 			result = append(result, info.newChange(ResponseBodyBecameNullableId, nil, "").
 				WithSources(baseSource, revisionSource))
 		} else if nullAddedToTypeArray(info.schemaDiff.TypeDiff) {
 			// OpenAPI 3.1: type changed from "string" to ["string", "null"]
-			result = append(result, info.newChange(ResponseBodyBecameNullableId, nil, ""))
+			result = append(result, info.newChange(ResponseBodyBecameNullableId, nil, "").
+				WithSources(baseSource, revisionSource))
 		}
 
 		info.walkProperties(func(p propertyInfo) {
+			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "nullable")
 			nullableDiff := p.propertyDiff.NullableDiff
 			if nullableDiff != nil {
 				if nullableDiff.To != true {
 					return
 				}
-				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "nullable")
 				result = append(result, p.newChange(
 					ResponsePropertyBecameNullableId,
 					[]any{propertyFullName(p.propertyPath, p.propertyName), info.responseStatus},
@@ -45,7 +43,7 @@ func ResponsePropertyBecameNullableCheck(diffReport *diff.Diff, operationsSource
 					ResponsePropertyBecameNullableId,
 					[]any{propertyFullName(p.propertyPath, p.propertyName), info.responseStatus},
 					"",
-				))
+				).WithSources(propBaseSource, propRevisionSource))
 			}
 		})
 	})

--- a/checker/check_response_property_min_items_decreased.go
+++ b/checker/check_response_property_min_items_decreased.go
@@ -11,80 +11,38 @@ const (
 
 func ResponsePropertyMinItemsDecreasedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if minItemsDiff := info.schemaDiff.MinItemsDiff; minItemsDiff != nil &&
+			minItemsDiff.From != nil && minItemsDiff.To != nil && IsDecreasedValue(minItemsDiff) {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "minItems")
+			result = append(result, info.newChange(
+				ResponseBodyMinItemsDecreasedId,
+				[]any{minItemsDiff.From, minItemsDiff.To},
+				"",
+			).WithSources(baseSource, revisionSource))
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil || operationItem.ResponsesDiff.Modified == nil {
-				continue
+
+		info.walkProperties(func(p propertyInfo) {
+			minItemsDiff := p.propertyDiff.MinItemsDiff
+			if minItemsDiff == nil || minItemsDiff.To == nil || minItemsDiff.From == nil {
+				return
 			}
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff == nil ||
-					responseDiff.ContentDiff == nil ||
-					responseDiff.ContentDiff.MediaTypeModified == nil {
-					continue
-				}
-				modifiedMediaTypes := responseDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					if mediaTypeDiff.SchemaDiff != nil && mediaTypeDiff.SchemaDiff.MinItemsDiff != nil {
-						minItemsDiff := mediaTypeDiff.SchemaDiff.MinItemsDiff
-						if minItemsDiff.From != nil &&
-							minItemsDiff.To != nil {
-							if IsDecreasedValue(minItemsDiff) {
-								baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "minItems")
-								result = append(result, NewApiChange(
-									ResponseBodyMinItemsDecreasedId,
-									config,
-									[]any{minItemsDiff.From, minItemsDiff.To},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-							}
-						}
-					}
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							minItemsDiff := propertyDiff.MinItemsDiff
-							if minItemsDiff == nil {
-								return
-							}
-							if minItemsDiff.To == nil ||
-								minItemsDiff.From == nil {
-								return
-							}
-							if !IsDecreasedValue(minItemsDiff) {
-								return
-							}
-
-							if propertyDiff.Revision.WriteOnly {
-								return
-							}
-
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "minItems")
-							result = append(result, NewApiChange(
-								ResponsePropertyMinItemsDecreasedId,
-								config,
-								[]any{propertyFullName(propertyPath, propertyName), minItemsDiff.From, minItemsDiff.To, responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						})
-				}
+			if !IsDecreasedValue(minItemsDiff) {
+				return
 			}
-		}
-	}
+			if p.propertyDiff.Revision.WriteOnly {
+				return
+			}
+
+			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "minItems")
+			result = append(result, p.newChange(
+				ResponsePropertyMinItemsDecreasedId,
+				[]any{propertyFullName(p.propertyPath, p.propertyName), minItemsDiff.From, minItemsDiff.To, info.responseStatus},
+				"",
+			).WithSources(propBaseSource, propRevisionSource))
+		})
+	})
+
 	return result
 }

--- a/checker/check_response_property_type_changed.go
+++ b/checker/check_response_property_type_changed.go
@@ -11,97 +11,60 @@ const (
 
 func ResponsePropertyTypeChangedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		schemaDiff := info.schemaDiff
+
+		// Body-level suppression also skips the property walk for this
+		// media type (the pre-migration code used `continue` in the
+		// media-type for-loop, which had that effect). Preserved.
+		if shouldSuppressTypeChangedForListOfTypes(schemaDiff) {
+			return
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil || operationItem.ResponsesDiff.Modified == nil {
-				continue
+
+		typeDiff := schemaDiff.TypeDiff
+		formatDiff := schemaDiff.FormatDiff
+
+		// Suppress null-only type changes (handled by nullable checkers).
+		if isNullTypeChange(typeDiff) && formatDiff.Empty() {
+			return
+		}
+
+		if breakingTypeFormatChangedInResponseProperty(typeDiff, formatDiff, info.mediaType, schemaDiff) {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, schemaDiff, "type")
+			result = append(result, info.newChange(
+				ResponseBodyTypeChangedId,
+				[]any{getBaseType(schemaDiff), getBaseFormat(schemaDiff), getRevisionType(schemaDiff), getRevisionFormat(schemaDiff), info.responseStatus},
+				"",
+			).WithSources(baseSource, revisionSource))
+		}
+
+		info.walkProperties(func(p propertyInfo) {
+			if p.propertyDiff == nil || p.propertyDiff.Revision == nil {
+				return
 			}
 
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff.ContentDiff == nil ||
-					responseDiff.ContentDiff.MediaTypeModified == nil {
-					continue
-				}
-
-				modifiedMediaTypes := responseDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					if mediaTypeDiff.SchemaDiff != nil {
-						// Check for suppression by ListOfTypes checker
-						if shouldSuppressTypeChangedForListOfTypes(mediaTypeDiff.SchemaDiff) {
-							continue
-						}
-
-						schemaDiff := mediaTypeDiff.SchemaDiff
-						baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, schemaDiff, "type")
-						typeDiff := schemaDiff.TypeDiff
-						formatDiff := schemaDiff.FormatDiff
-
-						// Suppress null-only type changes (handled by nullable checkers)
-						if isNullTypeChange(typeDiff) && formatDiff.Empty() {
-							continue
-						}
-
-						if breakingTypeFormatChangedInResponseProperty(typeDiff, formatDiff, mediaType, schemaDiff) {
-
-							result = append(result, NewApiChange(
-								ResponseBodyTypeChangedId,
-								config,
-								[]any{getBaseType(schemaDiff), getBaseFormat(schemaDiff), getRevisionType(schemaDiff), getRevisionFormat(schemaDiff), responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-						}
-					}
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							if propertyDiff == nil || propertyDiff.Revision == nil {
-								return
-							}
-
-							// Check for suppression by ListOfTypes checker
-							if shouldSuppressPropertyTypeChangedForListOfTypes(propertyDiff) {
-								return
-							}
-
-							// Suppress null-only type changes (handled by nullable checkers)
-							if isNullTypeChange(propertyDiff.TypeDiff) && propertyDiff.FormatDiff.Empty() {
-								return
-							}
-
-							schemaDiff := propertyDiff
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "type")
-							typeDiff := schemaDiff.TypeDiff
-							formatDiff := schemaDiff.FormatDiff
-
-							if breakingTypeFormatChangedInResponseProperty(typeDiff, formatDiff, mediaType, schemaDiff) {
-
-								result = append(result, NewApiChange(
-									ResponsePropertyTypeChangedId,
-									config,
-									[]any{propertyFullName(propertyPath, propertyName), getBaseType(schemaDiff), getBaseFormat(schemaDiff), getRevisionType(schemaDiff), getRevisionFormat(schemaDiff), responseStatus},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-							}
-						})
-				}
+			if shouldSuppressPropertyTypeChangedForListOfTypes(p.propertyDiff) {
+				return
 			}
-		}
-	}
+			if isNullTypeChange(p.propertyDiff.TypeDiff) && p.propertyDiff.FormatDiff.Empty() {
+				return
+			}
+
+			propSchemaDiff := p.propertyDiff
+			propTypeDiff := propSchemaDiff.TypeDiff
+			propFormatDiff := propSchemaDiff.FormatDiff
+
+			if breakingTypeFormatChangedInResponseProperty(propTypeDiff, propFormatDiff, info.mediaType, propSchemaDiff) {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "type")
+				result = append(result, p.newChange(
+					ResponsePropertyTypeChangedId,
+					[]any{propertyFullName(p.propertyPath, p.propertyName), getBaseType(propSchemaDiff), getBaseFormat(propSchemaDiff), getRevisionType(propSchemaDiff), getRevisionFormat(propSchemaDiff), info.responseStatus},
+					"",
+				).WithSources(propBaseSource, propRevisionSource))
+			}
+		})
+	})
+
 	return result
 }


### PR DESCRIPTION
## What

Fourth migration batch off the walker (#940). Six files, three matched request/response pairs from the Easy bucket of #936, **plus a small bug fix on top** for an asymmetry the migration exposed.

| Pair | Files |
|---|---|
| min_items (numeric) | `check_request_property_min_items_increased.go` + `check_response_property_min_items_decreased.go` |
| type_changed | `check_request_property_type_changed.go` + `check_response_property_type_changed.go` |
| nullable transitions | `check_request_property_became_not_nuallable.go` + `check_response_property_became_nuallable.go` |

## What this batch exercises beyond batches 1-3

Two real idioms that the earlier batches did not cover:

**1. Body-level suppression that must skip the property walk.** The `type_changed` checkers ran `shouldSuppressTypeChangedForListOfTypes(...)` and `isNullTypeChange(...)` at body level and used `continue` in the media-type for-loop to skip *both* the body emit and the property walk for that media type. The walker's processor uses `return` to preserve that semantics:

```go
walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
    if shouldSuppressTypeChangedForListOfTypes(info.schemaDiff) {
        return // skips both the body-level emit AND info.walkProperties below
    }
    // ... body-level emit ...
    info.walkProperties(...)
})
```

Worth noting: whether the body-level suppression *should* skip the property walk is a separate question (the body's "list-of-types-ness" doesn't logically affect a nested property's own type changes). That's a pre-existing semantic point the migration preserves; smoothing it can come later, by code review or by data showing real false negatives.

**2. Inconsistent source-attachment across emit paths.** The nullable checkers had a checkerboard of missing `.WithSources(...)` calls. The migration first preserved the asymmetry to keep the refactor pure; review confirmed the inconsistency had no architectural reason, so it's smoothed out in this PR as a small follow-up commit:

```
request side:
  body NullableDiff       had sources →  has sources
  body type-array (3.1)   missing     →  has sources
  property NullableDiff   missing     →  has sources
  property type-array     had sources →  has sources

response side:
  body NullableDiff       had sources →  has sources
  body type-array (3.1)   missing     →  has sources
  property NullableDiff   had sources →  has sources
  property type-array     missing     →  has sources
```

User-facing impact: `oasdiff breaking` / `changelog` on OpenAPI 3.1 specs where nullability is expressed as a type-array transition (`["string", "null"]` ↔ `"string"`) now reports `file:line:column` for those changes, matching what 3.0-style `NullableDiff` transitions already render. Same for the previously-bare request property `NullableDiff` emissions.

No existing test asserted source presence/absence on nullable changes (grepped `checker/*_test.go`), so the full suite stays green after the fix.

## Numbers

| | Before | After | Delta |
|---|---|---|---|
| `min_items_increased` (request) | 88 | 48 | -40 |
| `min_items_decreased` (response) | 91 | 48 | -43 |
| `type_changed` (request) | 122 | 82 | -40 |
| `type_changed` (response) | 108 | 70 | -38 |
| `became_not_nuallable` (request) | 151 | 61 | -90 |
| `became_nuallable` (response) | 107 | 52 | -55 |

Net **`-301`** lines across the six files (`231 insertions, 532 deletions` per `git diff --stat`).

## Commits

- `876a58a` — the walker migration itself (six files).
- `4274382` — `go fmt` separator that CI required.
- `812ae57` — fix the nullable source-attachment asymmetry; small follow-up the uniform walker shape made visible.

## Why this PR is safe to land

- Migration commit is no-op behaviour-wise. Every existing test for these checkers passes without modification: min_items (`TestRequestBodyMinItemsIncreased`, `TestRequestBodyMinItemsDecreased`); type_changed (9 tests); nullable (full request + response set, including the OpenAPI 3.1 type-array paths).
- Asymmetry-fix commit only *adds* `.WithSources(...)` calls. The rendered output gains `file:line:column` on previously-bare paths; no field changes, no removals.
- Full suite green; `go vet` clean; `go fmt` clean.

## Running total

After this PR, **20** checker files are on the walker (2 pilot + 6 batch-2 + 6 batch-3 + 6 batch-4). About **55** remain. Continuing the opportunistic-batch cadence per #936.