### PR TITLE
formatters: emit diff_empty in JSON/YAML wrapper; suggest 'oasdiff diff' in CLI

### DIFF
--- a/formatters/format_json.go
+++ b/formatters/format_json.go
@@ -30,7 +30,7 @@ func (f JSONFormatter) RenderSummary(diff *diff.Diff, opts RenderOpts) ([]byte, 
 }
 
 func (f JSONFormatter) RenderChangelog(changes checker.Changes, opts RenderOpts, _, _ string) ([]byte, error) {
-	return printJSON(adaptStructure(NewChanges(changes, f.Localizer), opts.WrapInObject))
+	return printJSON(adaptStructure(NewChanges(changes, f.Localizer), opts))
 }
 
 func (f JSONFormatter) RenderChecks(checks Checks, opts RenderOpts) ([]byte, error) {
@@ -62,10 +62,20 @@ func printJSON(output any) ([]byte, error) {
 	return bytes, nil
 }
 
-func adaptStructure(output any, wrapInObject bool) any {
-	if wrapInObject {
-		output = map[string]any{"changes": output}
+// adaptStructure wraps the changes list in an object when the caller asks
+// for the wrapped shape (used by oasdiff-service so the response carries
+// extra signals alongside the change list). The bare-array shape ignores
+// opts to preserve the existing CLI JSON output.
+//
+// diff_empty is true when the underlying diff found no changes at all,
+// so consumers can distinguish "specs are identical" from "specs differ
+// but no breaking-change / changelog rule fired."
+func adaptStructure(output any, opts RenderOpts) any {
+	if opts.WrapInObject {
+		return map[string]any{
+			"changes":    output,
+			"diff_empty": opts.DiffEmpty,
+		}
 	}
-
 	return output
 }

--- a/formatters/format_json_test.go
+++ b/formatters/format_json_test.go
@@ -68,6 +68,27 @@ func TestJsonFormatter_RenderSummary(t *testing.T) {
 	require.Equal(t, `{"diff":false}`, string(out))
 }
 
+func TestJsonFormatter_RenderChangelog_WrappedCarriesDiffEmpty(t *testing.T) {
+	// When WrapInObject is set, the JSON wrapper carries diff_empty alongside
+	// the changes list so HTTP consumers can distinguish "specs are identical"
+	// from "specs differ but no rule fired."
+	emptyOut, err := jsonFormatter.RenderChangelog(checker.Changes{}, formatters.RenderOpts{WrapInObject: true, DiffEmpty: true}, "", "")
+	require.NoError(t, err)
+	require.JSONEq(t, `{"changes":[], "diff_empty":true}`, string(emptyOut))
+
+	differOut, err := jsonFormatter.RenderChangelog(checker.Changes{}, formatters.RenderOpts{WrapInObject: true, DiffEmpty: false}, "", "")
+	require.NoError(t, err)
+	require.JSONEq(t, `{"changes":[], "diff_empty":false}`, string(differOut))
+}
+
+func TestJsonFormatter_RenderChangelog_BareArrayIgnoresOpts(t *testing.T) {
+	// Without WrapInObject the output is a bare JSON array. DiffEmpty has
+	// nowhere to live and is ignored, preserving the existing CLI shape.
+	out, err := jsonFormatter.RenderChangelog(checker.Changes{}, formatters.RenderOpts{DiffEmpty: false}, "", "")
+	require.NoError(t, err)
+	require.Equal(t, "[]", string(out))
+}
+
 func TestJsonFormatter_RenderChangelog_WithSources(t *testing.T) {
 	testChanges := checker.Changes{
 		checker.ApiChange{

--- a/formatters/format_singleline.go
+++ b/formatters/format_singleline.go
@@ -25,9 +25,9 @@ func (f SingleLineFormatter) RenderChangelog(changes checker.Changes, opts Rende
 		if opts.DiffEmpty {
 			_, _ = fmt.Fprint(result, "No changes detected")
 		} else if opts.IsBreaking {
-			_, _ = fmt.Fprint(result, "No breaking changes to report, but the specs are different")
+			_, _ = fmt.Fprint(result, "No breaking changes to report, but the specs are different. Run 'oasdiff diff' to see structural differences.")
 		} else {
-			_, _ = fmt.Fprint(result, "No changes to report, but the specs are different")
+			_, _ = fmt.Fprint(result, "No changes to report, but the specs are different. Run 'oasdiff diff' to see structural differences.")
 		}
 		return result.Bytes(), nil
 	}

--- a/formatters/format_singleline_test.go
+++ b/formatters/format_singleline_test.go
@@ -36,13 +36,14 @@ func TestSingleLineFormatter_RenderChangelog(t *testing.T) {
 func TestSingleLineFormatter_RenderChangelog_EmptyChangesDifferentSpecs(t *testing.T) {
 	out, err := singleLineFormatter.RenderChangelog(checker.Changes{}, formatters.RenderOpts{}, "", "")
 	require.NoError(t, err)
-	require.Equal(t, "No changes to report, but the specs are different", string(out))
+	// Singleline keeps everything on one line: period separator, no newline.
+	require.Equal(t, "No changes to report, but the specs are different. Run 'oasdiff diff' to see structural differences.", string(out))
 }
 
 func TestSingleLineFormatter_RenderChangelog_EmptyChangesDifferentSpecs_BreakingMode(t *testing.T) {
 	out, err := singleLineFormatter.RenderChangelog(checker.Changes{}, formatters.RenderOpts{IsBreaking: true}, "", "")
 	require.NoError(t, err)
-	require.Equal(t, "No breaking changes to report, but the specs are different", string(out))
+	require.Equal(t, "No breaking changes to report, but the specs are different. Run 'oasdiff diff' to see structural differences.", string(out))
 }
 
 func TestSingleLineFormatter_NotImplemented(t *testing.T) {

--- a/formatters/format_text.go
+++ b/formatters/format_text.go
@@ -33,9 +33,9 @@ func (f TEXTFormatter) RenderChangelog(changes checker.Changes, opts RenderOpts,
 		if opts.DiffEmpty {
 			_, _ = fmt.Fprint(result, "No changes detected")
 		} else if opts.IsBreaking {
-			_, _ = fmt.Fprint(result, "No breaking changes to report, but the specs are different")
+			_, _ = fmt.Fprint(result, "No breaking changes to report, but the specs are different.\nRun 'oasdiff diff' to see structural differences.")
 		} else {
-			_, _ = fmt.Fprint(result, "No changes to report, but the specs are different")
+			_, _ = fmt.Fprint(result, "No changes to report, but the specs are different.\nRun 'oasdiff diff' to see structural differences.")
 		}
 		return result.Bytes(), nil
 	}

--- a/formatters/format_text_test.go
+++ b/formatters/format_text_test.go
@@ -50,13 +50,21 @@ func TestTextFormatter_RenderChecks(t *testing.T) {
 func TestTextFormatter_RenderChangelog_EmptyChangesDifferentSpecs(t *testing.T) {
 	out, err := textFormatter.RenderChangelog(checker.Changes{}, formatters.RenderOpts{}, "", "")
 	require.NoError(t, err)
-	require.Equal(t, "No changes to report, but the specs are different", string(out))
+	require.Equal(t, "No changes to report, but the specs are different.\nRun 'oasdiff diff' to see structural differences.", string(out))
 }
 
 func TestTextFormatter_RenderChangelog_EmptyChangesDifferentSpecs_BreakingMode(t *testing.T) {
 	out, err := textFormatter.RenderChangelog(checker.Changes{}, formatters.RenderOpts{IsBreaking: true}, "", "")
 	require.NoError(t, err)
-	require.Equal(t, "No breaking changes to report, but the specs are different", string(out))
+	require.Equal(t, "No breaking changes to report, but the specs are different.\nRun 'oasdiff diff' to see structural differences.", string(out))
+}
+
+func TestTextFormatter_RenderChangelog_EmptyChangesIdenticalSpecs(t *testing.T) {
+	// DiffEmpty=true takes precedence; suggestion is suppressed because
+	// there's nothing for `oasdiff diff` to show.
+	out, err := textFormatter.RenderChangelog(checker.Changes{}, formatters.RenderOpts{DiffEmpty: true, IsBreaking: true}, "", "")
+	require.NoError(t, err)
+	require.Equal(t, "No changes detected", string(out))
 }
 
 func TestTextFormatter_RenderDiff(t *testing.T) {

--- a/formatters/format_yaml.go
+++ b/formatters/format_yaml.go
@@ -30,7 +30,7 @@ func (f YAMLFormatter) RenderSummary(diff *diff.Diff, opts RenderOpts) ([]byte, 
 }
 
 func (f YAMLFormatter) RenderChangelog(changes checker.Changes, opts RenderOpts, _, _ string) ([]byte, error) {
-	return printYAML(adaptStructure(NewChanges(changes, f.Localizer), opts.WrapInObject))
+	return printYAML(adaptStructure(NewChanges(changes, f.Localizer), opts))
 }
 
 func (f YAMLFormatter) RenderChecks(checks Checks, opts RenderOpts) ([]byte, error) {


### PR DESCRIPTION
Two related changes that surface a previously-hidden signal: the specs differ even when no breaking-change / changelog rule fired. The signal lands in two places, each formatted for its audience.

## 1. JSON / YAML wrapper now carries `diff_empty`

When `WrapInObject` is set (the oasdiff-service path), the wrapped payload becomes:

```json
{"changes":[...], "diff_empty": false}
```

so HTTP consumers can distinguish "specs are identical" from "specs differ but the changelog/breaking checker filtered everything out."

Bare-array output (the default for the CLI's `-f json` / `-f yaml`) is unchanged, so existing piped-JSON consumers see no shape change.

`adaptStructure` now takes the full `RenderOpts` so it can read both `WrapInObject` and `DiffEmpty` without growing a parameter per signal.

## 2. Terminal formatters now suggest `oasdiff diff`

In the "changes are empty but the underlying diff is not" branch, `format_text` and `format_singleline` append a short pointer to the action the user can take next:

```
No breaking changes to report, but the specs are different.
Run 'oasdiff diff' to see structural differences.
```

- `format_text` uses a newline separator (two lines visually).
- `format_singleline` keeps everything on one line (period separator) so it stays parseable as one record.

The HTML and Markdown templates are intentionally untouched. Those outputs commonly end up embedded in PR comments and other reports where the reader has no shell to "run" anything.

## Tests

Tests added for both wrapper variants (empty vs differ) and for the new text / singleline suffix. Existing assertions updated for the new wording. Full suite green, vet clean, fmt clean.

## Follow-ups

This unlocks two follow-ups in the dependent repos, in order:

1. oasdiff-service threads `diffEmpty` through `calcChangelog` → `writeChangelogResponse` → `RenderOpts.DiffEmpty` so the JSON wrapper actually carries a meaningful value.
2. w3 reads `diff_empty` from the response and, when changes are empty but specs differ, points the visitor at Diff mode.