### PR TITLE
checker: migrate anyOf/oneOf/allOf request+response pairs to walker (PR-5 of #936)

### DIFF
--- a/checker/check_request_property_all_of_updated.go
+++ b/checker/check_request_property_all_of_updated.go
@@ -13,96 +13,37 @@ const (
 
 func RequestPropertyAllOfUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
 
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if info.schemaDiff.AllOfDiff != nil && len(info.schemaDiff.AllOfDiff.Added) > 0 {
+			baseSource, revisionSource := SubschemaSources(operationsSources, info.operationItem, info.schemaDiff, "allOf", -1, info.schemaDiff.AllOfDiff.Added[0].Index)
+			result = append(result, info.newChange(RequestBodyAllOfAddedId, []any{info.schemaDiff.AllOfDiff.Added.String()}, "").
+				WithSources(baseSource, revisionSource))
+		}
+		if info.schemaDiff.AllOfDiff != nil && len(info.schemaDiff.AllOfDiff.Deleted) > 0 {
+			baseSource, revisionSource := SubschemaSources(operationsSources, info.operationItem, info.schemaDiff, "allOf", info.schemaDiff.AllOfDiff.Deleted[0].Index, -1)
+			result = append(result, info.newChange(RequestBodyAllOfRemovedId, []any{info.schemaDiff.AllOfDiff.Deleted.String()}, "").
+				WithSources(baseSource, revisionSource))
 		}
 
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
+		info.walkProperties(func(p propertyInfo) {
+			if p.propertyDiff.AllOfDiff == nil {
+				return
 			}
+			propName := propertyFullName(p.propertyPath, p.propertyName)
 
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				if mediaTypeDiff.SchemaDiff == nil {
-					continue
-				}
-
-				if mediaTypeDiff.SchemaDiff.AllOfDiff != nil && len(mediaTypeDiff.SchemaDiff.AllOfDiff.Added) > 0 {
-					baseSource, revisionSource := SubschemaSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "allOf", -1, mediaTypeDiff.SchemaDiff.AllOfDiff.Added[0].Index)
-					result = append(result, NewApiChange(
-						RequestBodyAllOfAddedId,
-						config,
-						[]any{mediaTypeDiff.SchemaDiff.AllOfDiff.Added.String()},
-						"",
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
-					).WithSources(baseSource, revisionSource))
-				}
-
-				if mediaTypeDiff.SchemaDiff.AllOfDiff != nil && len(mediaTypeDiff.SchemaDiff.AllOfDiff.Deleted) > 0 {
-					baseSource, revisionSource := SubschemaSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "allOf", mediaTypeDiff.SchemaDiff.AllOfDiff.Deleted[0].Index, -1)
-					result = append(result, NewApiChange(
-						RequestBodyAllOfRemovedId,
-						config,
-						[]any{mediaTypeDiff.SchemaDiff.AllOfDiff.Deleted.String()},
-						"",
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
-					).WithSources(baseSource, revisionSource))
-				}
-
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						if propertyDiff.AllOfDiff == nil {
-							return
-						}
-
-						propName := propertyFullName(propertyPath, propertyName)
-
-						if len(propertyDiff.AllOfDiff.Added) > 0 {
-							propBaseSource, propRevisionSource := SubschemaSources(operationsSources, operationItem, propertyDiff, "allOf", -1, propertyDiff.AllOfDiff.Added[0].Index)
-							result = append(result, NewApiChange(
-								RequestPropertyAllOfAddedId,
-								config,
-								[]any{propertyDiff.AllOfDiff.Added.String(), propName},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						}
-
-						if len(propertyDiff.AllOfDiff.Deleted) > 0 {
-							propBaseSource, propRevisionSource := SubschemaSources(operationsSources, operationItem, propertyDiff, "allOf", propertyDiff.AllOfDiff.Deleted[0].Index, -1)
-							result = append(result, NewApiChange(
-								RequestPropertyAllOfRemovedId,
-								config,
-								[]any{propertyDiff.AllOfDiff.Deleted.String(), propName},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						}
-					})
+			if len(p.propertyDiff.AllOfDiff.Added) > 0 {
+				propBaseSource, propRevisionSource := SubschemaSources(operationsSources, info.operationItem, p.propertyDiff, "allOf", -1, p.propertyDiff.AllOfDiff.Added[0].Index)
+				result = append(result, p.newChange(RequestPropertyAllOfAddedId, []any{p.propertyDiff.AllOfDiff.Added.String(), propName}, "").
+					WithSources(propBaseSource, propRevisionSource))
 			}
-		}
-	}
+			if len(p.propertyDiff.AllOfDiff.Deleted) > 0 {
+				propBaseSource, propRevisionSource := SubschemaSources(operationsSources, info.operationItem, p.propertyDiff, "allOf", p.propertyDiff.AllOfDiff.Deleted[0].Index, -1)
+				result = append(result, p.newChange(RequestPropertyAllOfRemovedId, []any{p.propertyDiff.AllOfDiff.Deleted.String(), propName}, "").
+					WithSources(propBaseSource, propRevisionSource))
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_request_property_any_of_updated.go
+++ b/checker/check_request_property_any_of_updated.go
@@ -11,108 +11,49 @@ const (
 
 func RequestPropertyAnyOfUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
 
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		// Body-level suppression also skips the property walk for this
+		// media type (pre-migration code used `continue` in the
+		// media-type for-loop). Preserved.
+		if shouldSuppressOneOfSchemaChangedForListOfTypes(info.schemaDiff) {
+			return
 		}
 
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
+		if info.schemaDiff.AnyOfDiff != nil {
+			if added := info.schemaDiff.AnyOfDiff.Added; len(added) > 0 {
+				baseSource, revisionSource := SubschemaSources(operationsSources, info.operationItem, info.schemaDiff, "anyOf", -1, added[0].Index)
+				result = append(result, info.newChange(RequestBodyAnyOfAddedId, []any{added.String()}, "").
+					WithSources(baseSource, revisionSource))
 			}
-
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				if mediaTypeDiff.SchemaDiff == nil {
-					continue
-				}
-
-				// Check for suppression by ListOfTypes checker
-				if shouldSuppressOneOfSchemaChangedForListOfTypes(mediaTypeDiff.SchemaDiff) {
-					continue
-				}
-
-				if mediaTypeDiff.SchemaDiff.AnyOfDiff != nil {
-					if added := mediaTypeDiff.SchemaDiff.AnyOfDiff.Added; len(added) > 0 {
-						baseSource, revisionSource := SubschemaSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "anyOf", -1, added[0].Index)
-						result = append(result, NewApiChange(
-							RequestBodyAnyOfAddedId,
-							config,
-							[]any{added.String()},
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-					}
-
-					if deleted := mediaTypeDiff.SchemaDiff.AnyOfDiff.Deleted; len(deleted) > 0 {
-						baseSource, revisionSource := SubschemaSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "anyOf", deleted[0].Index, -1)
-						result = append(result, NewApiChange(
-							RequestBodyAnyOfRemovedId,
-							config,
-							[]any{deleted.String()},
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-					}
-				}
-
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						if propertyDiff.AnyOfDiff == nil {
-							return
-						}
-
-						// Check for suppression by ListOfTypes checker
-						if shouldSuppressPropertyOneOfSchemaChangedForListOfTypes(propertyDiff) {
-							return
-						}
-
-						propName := propertyFullName(propertyPath, propertyName)
-
-						if added := propertyDiff.AnyOfDiff.Added; len(added) > 0 {
-							propBaseSource, propRevisionSource := SubschemaSources(operationsSources, operationItem, propertyDiff, "anyOf", -1, added[0].Index)
-							result = append(result, NewApiChange(
-								RequestPropertyAnyOfAddedId,
-								config,
-								[]any{added.String(), propName},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						}
-
-						if deleted := propertyDiff.AnyOfDiff.Deleted; len(deleted) > 0 {
-							propBaseSource, propRevisionSource := SubschemaSources(operationsSources, operationItem, propertyDiff, "anyOf", deleted[0].Index, -1)
-							result = append(result, NewApiChange(
-								RequestPropertyAnyOfRemovedId,
-								config,
-								[]any{deleted.String(), propName},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						}
-					})
+			if deleted := info.schemaDiff.AnyOfDiff.Deleted; len(deleted) > 0 {
+				baseSource, revisionSource := SubschemaSources(operationsSources, info.operationItem, info.schemaDiff, "anyOf", deleted[0].Index, -1)
+				result = append(result, info.newChange(RequestBodyAnyOfRemovedId, []any{deleted.String()}, "").
+					WithSources(baseSource, revisionSource))
 			}
 		}
-	}
+
+		info.walkProperties(func(p propertyInfo) {
+			if p.propertyDiff.AnyOfDiff == nil {
+				return
+			}
+			if shouldSuppressPropertyOneOfSchemaChangedForListOfTypes(p.propertyDiff) {
+				return
+			}
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+
+			if added := p.propertyDiff.AnyOfDiff.Added; len(added) > 0 {
+				propBaseSource, propRevisionSource := SubschemaSources(operationsSources, info.operationItem, p.propertyDiff, "anyOf", -1, added[0].Index)
+				result = append(result, p.newChange(RequestPropertyAnyOfAddedId, []any{added.String(), propName}, "").
+					WithSources(propBaseSource, propRevisionSource))
+			}
+			if deleted := p.propertyDiff.AnyOfDiff.Deleted; len(deleted) > 0 {
+				propBaseSource, propRevisionSource := SubschemaSources(operationsSources, info.operationItem, p.propertyDiff, "anyOf", deleted[0].Index, -1)
+				result = append(result, p.newChange(RequestPropertyAnyOfRemovedId, []any{deleted.String(), propName}, "").
+					WithSources(propBaseSource, propRevisionSource))
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_request_property_one_of_updated.go
+++ b/checker/check_request_property_one_of_updated.go
@@ -13,108 +13,49 @@ const (
 
 func RequestPropertyOneOfUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
 
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		// Body-level suppression also skips the property walk for this
+		// media type (pre-migration code used `continue` in the
+		// media-type for-loop). Preserved.
+		if shouldSuppressOneOfSchemaChangedForListOfTypes(info.schemaDiff) {
+			return
 		}
 
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
+		if info.schemaDiff.OneOfDiff != nil {
+			if added := info.schemaDiff.OneOfDiff.Added; len(added) > 0 {
+				baseSource, revisionSource := SubschemaSources(operationsSources, info.operationItem, info.schemaDiff, "oneOf", -1, added[0].Index)
+				result = append(result, info.newChange(RequestBodyOneOfAddedId, []any{added.String()}, "").
+					WithSources(baseSource, revisionSource))
 			}
-
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				if mediaTypeDiff.SchemaDiff == nil {
-					continue
-				}
-
-				// Check for suppression by ListOfTypes checker
-				if shouldSuppressOneOfSchemaChangedForListOfTypes(mediaTypeDiff.SchemaDiff) {
-					continue
-				}
-
-				if mediaTypeDiff.SchemaDiff.OneOfDiff != nil {
-					if added := mediaTypeDiff.SchemaDiff.OneOfDiff.Added; len(added) > 0 {
-						baseSource, revisionSource := SubschemaSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "oneOf", -1, added[0].Index)
-						result = append(result, NewApiChange(
-							RequestBodyOneOfAddedId,
-							config,
-							[]any{added.String()},
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-					}
-
-					if deleted := mediaTypeDiff.SchemaDiff.OneOfDiff.Deleted; len(deleted) > 0 {
-						baseSource, revisionSource := SubschemaSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "oneOf", deleted[0].Index, -1)
-						result = append(result, NewApiChange(
-							RequestBodyOneOfRemovedId,
-							config,
-							[]any{deleted.String()},
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-					}
-				}
-
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						if propertyDiff.OneOfDiff == nil {
-							return
-						}
-
-						// Check for suppression by ListOfTypes checker
-						if shouldSuppressPropertyOneOfSchemaChangedForListOfTypes(propertyDiff) {
-							return
-						}
-
-						propName := propertyFullName(propertyPath, propertyName)
-
-						if added := propertyDiff.OneOfDiff.Added; len(added) > 0 {
-							propBaseSource, propRevisionSource := SubschemaSources(operationsSources, operationItem, propertyDiff, "oneOf", -1, added[0].Index)
-							result = append(result, NewApiChange(
-								RequestPropertyOneOfAddedId,
-								config,
-								[]any{added.String(), propName},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						}
-
-						if deleted := propertyDiff.OneOfDiff.Deleted; len(deleted) > 0 {
-							propBaseSource, propRevisionSource := SubschemaSources(operationsSources, operationItem, propertyDiff, "oneOf", deleted[0].Index, -1)
-							result = append(result, NewApiChange(
-								RequestPropertyOneOfRemovedId,
-								config,
-								[]any{deleted.String(), propName},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						}
-					})
+			if deleted := info.schemaDiff.OneOfDiff.Deleted; len(deleted) > 0 {
+				baseSource, revisionSource := SubschemaSources(operationsSources, info.operationItem, info.schemaDiff, "oneOf", deleted[0].Index, -1)
+				result = append(result, info.newChange(RequestBodyOneOfRemovedId, []any{deleted.String()}, "").
+					WithSources(baseSource, revisionSource))
 			}
 		}
-	}
+
+		info.walkProperties(func(p propertyInfo) {
+			if p.propertyDiff.OneOfDiff == nil {
+				return
+			}
+			if shouldSuppressPropertyOneOfSchemaChangedForListOfTypes(p.propertyDiff) {
+				return
+			}
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+
+			if added := p.propertyDiff.OneOfDiff.Added; len(added) > 0 {
+				propBaseSource, propRevisionSource := SubschemaSources(operationsSources, info.operationItem, p.propertyDiff, "oneOf", -1, added[0].Index)
+				result = append(result, p.newChange(RequestPropertyOneOfAddedId, []any{added.String(), propName}, "").
+					WithSources(propBaseSource, propRevisionSource))
+			}
+			if deleted := p.propertyDiff.OneOfDiff.Deleted; len(deleted) > 0 {
+				propBaseSource, propRevisionSource := SubschemaSources(operationsSources, info.operationItem, p.propertyDiff, "oneOf", deleted[0].Index, -1)
+				result = append(result, p.newChange(RequestPropertyOneOfRemovedId, []any{deleted.String(), propName}, "").
+					WithSources(propBaseSource, propRevisionSource))
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_response_property_all_of_updated.go
+++ b/checker/check_response_property_all_of_updated.go
@@ -13,98 +13,37 @@ const (
 
 func ResponsePropertyAllOfUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
 
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if info.schemaDiff.AllOfDiff != nil && len(info.schemaDiff.AllOfDiff.Added) > 0 {
+			baseSource, revisionSource := SubschemaSources(operationsSources, info.operationItem, info.schemaDiff, "allOf", -1, info.schemaDiff.AllOfDiff.Added[0].Index)
+			result = append(result, info.newChange(ResponseBodyAllOfAddedId, []any{info.schemaDiff.AllOfDiff.Added.String(), info.responseStatus}, "").
+				WithSources(baseSource, revisionSource))
+		}
+		if info.schemaDiff.AllOfDiff != nil && len(info.schemaDiff.AllOfDiff.Deleted) > 0 {
+			baseSource, revisionSource := SubschemaSources(operationsSources, info.operationItem, info.schemaDiff, "allOf", info.schemaDiff.AllOfDiff.Deleted[0].Index, -1)
+			result = append(result, info.newChange(ResponseBodyAllOfRemovedId, []any{info.schemaDiff.AllOfDiff.Deleted.String(), info.responseStatus}, "").
+				WithSources(baseSource, revisionSource))
 		}
 
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil || operationItem.ResponsesDiff.Modified == nil {
-				continue
+		info.walkProperties(func(p propertyInfo) {
+			if p.propertyDiff.AllOfDiff == nil {
+				return
 			}
+			propName := propertyFullName(p.propertyPath, p.propertyName)
 
-			for responseStatus, responsesDiff := range operationItem.ResponsesDiff.Modified {
-				if responsesDiff.ContentDiff == nil || responsesDiff.ContentDiff.MediaTypeModified == nil {
-					continue
-				}
-
-				modifiedMediaTypes := responsesDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					if mediaTypeDiff.SchemaDiff == nil {
-						continue
-					}
-
-					if mediaTypeDiff.SchemaDiff.AllOfDiff != nil && len(mediaTypeDiff.SchemaDiff.AllOfDiff.Added) > 0 {
-						baseSource, revisionSource := SubschemaSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "allOf", -1, mediaTypeDiff.SchemaDiff.AllOfDiff.Added[0].Index)
-						result = append(result, NewApiChange(
-							ResponseBodyAllOfAddedId,
-							config,
-							[]any{mediaTypeDiff.SchemaDiff.AllOfDiff.Added.String(), responseStatus},
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-					}
-
-					if mediaTypeDiff.SchemaDiff.AllOfDiff != nil && len(mediaTypeDiff.SchemaDiff.AllOfDiff.Deleted) > 0 {
-						baseSource, revisionSource := SubschemaSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "allOf", mediaTypeDiff.SchemaDiff.AllOfDiff.Deleted[0].Index, -1)
-						result = append(result, NewApiChange(
-							ResponseBodyAllOfRemovedId,
-							config,
-							[]any{mediaTypeDiff.SchemaDiff.AllOfDiff.Deleted.String(), responseStatus},
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-					}
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							if propertyDiff.AllOfDiff == nil {
-								return
-							}
-
-							if len(propertyDiff.AllOfDiff.Added) > 0 {
-								propBaseSource, propRevisionSource := SubschemaSources(operationsSources, operationItem, propertyDiff, "allOf", -1, propertyDiff.AllOfDiff.Added[0].Index)
-								result = append(result, NewApiChange(
-									ResponsePropertyAllOfAddedId,
-									config,
-									[]any{propertyDiff.AllOfDiff.Added.String(), propertyFullName(propertyPath, propertyName), responseStatus},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-							}
-
-							if len(propertyDiff.AllOfDiff.Deleted) > 0 {
-								propBaseSource, propRevisionSource := SubschemaSources(operationsSources, operationItem, propertyDiff, "allOf", propertyDiff.AllOfDiff.Deleted[0].Index, -1)
-								result = append(result, NewApiChange(
-									ResponsePropertyAllOfRemovedId,
-									config,
-									[]any{propertyDiff.AllOfDiff.Deleted.String(), propertyFullName(propertyPath, propertyName), responseStatus},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-							}
-						})
-				}
+			if len(p.propertyDiff.AllOfDiff.Added) > 0 {
+				propBaseSource, propRevisionSource := SubschemaSources(operationsSources, info.operationItem, p.propertyDiff, "allOf", -1, p.propertyDiff.AllOfDiff.Added[0].Index)
+				result = append(result, p.newChange(ResponsePropertyAllOfAddedId, []any{p.propertyDiff.AllOfDiff.Added.String(), propName, info.responseStatus}, "").
+					WithSources(propBaseSource, propRevisionSource))
 			}
-		}
-	}
+			if len(p.propertyDiff.AllOfDiff.Deleted) > 0 {
+				propBaseSource, propRevisionSource := SubschemaSources(operationsSources, info.operationItem, p.propertyDiff, "allOf", p.propertyDiff.AllOfDiff.Deleted[0].Index, -1)
+				result = append(result, p.newChange(ResponsePropertyAllOfRemovedId, []any{p.propertyDiff.AllOfDiff.Deleted.String(), propName, info.responseStatus}, "").
+					WithSources(propBaseSource, propRevisionSource))
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_response_property_any_of_updated.go
+++ b/checker/check_response_property_any_of_updated.go
@@ -13,110 +13,49 @@ const (
 
 func ResponsePropertyAnyOfUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
 
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		// Body-level suppression also skips the property walk for this
+		// media type (pre-migration code used `continue` in the
+		// media-type for-loop). Preserved.
+		if shouldSuppressOneOfSchemaChangedForListOfTypes(info.schemaDiff) {
+			return
 		}
 
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil || operationItem.ResponsesDiff.Modified == nil {
-				continue
+		if info.schemaDiff.AnyOfDiff != nil {
+			if added := info.schemaDiff.AnyOfDiff.Added; len(added) > 0 {
+				baseSource, revisionSource := SubschemaSources(operationsSources, info.operationItem, info.schemaDiff, "anyOf", -1, added[0].Index)
+				result = append(result, info.newChange(ResponseBodyAnyOfAddedId, []any{added.String(), info.responseStatus}, "").
+					WithSources(baseSource, revisionSource))
 			}
-
-			for responseStatus, responsesDiff := range operationItem.ResponsesDiff.Modified {
-				if responsesDiff.ContentDiff == nil || responsesDiff.ContentDiff.MediaTypeModified == nil {
-					continue
-				}
-
-				modifiedMediaTypes := responsesDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					if mediaTypeDiff.SchemaDiff == nil {
-						continue
-					}
-
-					// Check for suppression by ListOfTypes checker
-					if shouldSuppressOneOfSchemaChangedForListOfTypes(mediaTypeDiff.SchemaDiff) {
-						continue
-					}
-
-					if mediaTypeDiff.SchemaDiff.AnyOfDiff != nil {
-						if added := mediaTypeDiff.SchemaDiff.AnyOfDiff.Added; len(added) > 0 {
-							baseSource, revisionSource := SubschemaSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "anyOf", -1, added[0].Index)
-							result = append(result, NewApiChange(
-								ResponseBodyAnyOfAddedId,
-								config,
-								[]any{added.String(), responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-						}
-
-						if deleted := mediaTypeDiff.SchemaDiff.AnyOfDiff.Deleted; len(deleted) > 0 {
-							baseSource, revisionSource := SubschemaSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "anyOf", deleted[0].Index, -1)
-							result = append(result, NewApiChange(
-								ResponseBodyAnyOfRemovedId,
-								config,
-								[]any{deleted.String(), responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-						}
-					}
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							if propertyDiff.AnyOfDiff == nil {
-								return
-							}
-
-							// Check for suppression by ListOfTypes checker
-							if shouldSuppressPropertyOneOfSchemaChangedForListOfTypes(propertyDiff) {
-								return
-							}
-
-							if added := propertyDiff.AnyOfDiff.Added; len(added) > 0 {
-								propBaseSource, propRevisionSource := SubschemaSources(operationsSources, operationItem, propertyDiff, "anyOf", -1, added[0].Index)
-								result = append(result, NewApiChange(
-									ResponsePropertyAnyOfAddedId,
-									config,
-									[]any{added.String(), propertyFullName(propertyPath, propertyName), responseStatus},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-							}
-
-							if deleted := propertyDiff.AnyOfDiff.Deleted; len(deleted) > 0 {
-								propBaseSource, propRevisionSource := SubschemaSources(operationsSources, operationItem, propertyDiff, "anyOf", deleted[0].Index, -1)
-								result = append(result, NewApiChange(
-									ResponsePropertyAnyOfRemovedId,
-									config,
-									[]any{deleted.String(), propertyFullName(propertyPath, propertyName), responseStatus},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-							}
-						})
-				}
+			if deleted := info.schemaDiff.AnyOfDiff.Deleted; len(deleted) > 0 {
+				baseSource, revisionSource := SubschemaSources(operationsSources, info.operationItem, info.schemaDiff, "anyOf", deleted[0].Index, -1)
+				result = append(result, info.newChange(ResponseBodyAnyOfRemovedId, []any{deleted.String(), info.responseStatus}, "").
+					WithSources(baseSource, revisionSource))
 			}
 		}
-	}
+
+		info.walkProperties(func(p propertyInfo) {
+			if p.propertyDiff.AnyOfDiff == nil {
+				return
+			}
+			if shouldSuppressPropertyOneOfSchemaChangedForListOfTypes(p.propertyDiff) {
+				return
+			}
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+
+			if added := p.propertyDiff.AnyOfDiff.Added; len(added) > 0 {
+				propBaseSource, propRevisionSource := SubschemaSources(operationsSources, info.operationItem, p.propertyDiff, "anyOf", -1, added[0].Index)
+				result = append(result, p.newChange(ResponsePropertyAnyOfAddedId, []any{added.String(), propName, info.responseStatus}, "").
+					WithSources(propBaseSource, propRevisionSource))
+			}
+			if deleted := p.propertyDiff.AnyOfDiff.Deleted; len(deleted) > 0 {
+				propBaseSource, propRevisionSource := SubschemaSources(operationsSources, info.operationItem, p.propertyDiff, "anyOf", deleted[0].Index, -1)
+				result = append(result, p.newChange(ResponsePropertyAnyOfRemovedId, []any{deleted.String(), propName, info.responseStatus}, "").
+					WithSources(propBaseSource, propRevisionSource))
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_response_property_one_of_updated.go
+++ b/checker/check_response_property_one_of_updated.go
@@ -13,112 +13,49 @@ const (
 
 func ResponsePropertyOneOfUpdated(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
 
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		// Body-level suppression also skips the property walk for this
+		// media type (pre-migration code used `continue` in the
+		// media-type for-loop). Preserved.
+		if shouldSuppressOneOfSchemaChangedForListOfTypes(info.schemaDiff) {
+			return
 		}
 
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil || operationItem.ResponsesDiff.Modified == nil {
-				continue
+		if info.schemaDiff.OneOfDiff != nil {
+			if added := info.schemaDiff.OneOfDiff.Added; len(added) > 0 {
+				baseSource, revisionSource := SubschemaSources(operationsSources, info.operationItem, info.schemaDiff, "oneOf", -1, added[0].Index)
+				result = append(result, info.newChange(ResponseBodyOneOfAddedId, []any{added.String(), info.responseStatus}, "").
+					WithSources(baseSource, revisionSource))
 			}
-
-			for responseStatus, responsesDiff := range operationItem.ResponsesDiff.Modified {
-				if responsesDiff.ContentDiff == nil || responsesDiff.ContentDiff.MediaTypeModified == nil {
-					continue
-				}
-
-				modifiedMediaTypes := responsesDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					if mediaTypeDiff.SchemaDiff == nil {
-						continue
-					}
-
-					// Check for suppression by ListOfTypes checker
-					if shouldSuppressOneOfSchemaChangedForListOfTypes(mediaTypeDiff.SchemaDiff) {
-						continue
-					}
-
-					if mediaTypeDiff.SchemaDiff.OneOfDiff != nil {
-						if added := mediaTypeDiff.SchemaDiff.OneOfDiff.Added; len(added) > 0 {
-							baseSource, revisionSource := SubschemaSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "oneOf", -1, added[0].Index)
-							result = append(result, NewApiChange(
-								ResponseBodyOneOfAddedId,
-								config,
-								[]any{added.String(), responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-						}
-
-						if deleted := mediaTypeDiff.SchemaDiff.OneOfDiff.Deleted; len(deleted) > 0 {
-							baseSource, revisionSource := SubschemaSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "oneOf", deleted[0].Index, -1)
-							result = append(result, NewApiChange(
-								ResponseBodyOneOfRemovedId,
-								config,
-								[]any{deleted.String(), responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-						}
-					}
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							if propertyDiff.OneOfDiff == nil {
-								return
-							}
-
-							// Check for suppression by ListOfTypes checker
-							if shouldSuppressPropertyOneOfSchemaChangedForListOfTypes(propertyDiff) {
-								return
-							}
-
-							propName := propertyFullName(propertyPath, propertyName)
-
-							if added := propertyDiff.OneOfDiff.Added; len(added) > 0 {
-								propBaseSource, propRevisionSource := SubschemaSources(operationsSources, operationItem, propertyDiff, "oneOf", -1, added[0].Index)
-								result = append(result, NewApiChange(
-									ResponsePropertyOneOfAddedId,
-									config,
-									[]any{added.String(), propName, responseStatus},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-							}
-
-							if deleted := propertyDiff.OneOfDiff.Deleted; len(deleted) > 0 {
-								propBaseSource, propRevisionSource := SubschemaSources(operationsSources, operationItem, propertyDiff, "oneOf", deleted[0].Index, -1)
-								result = append(result, NewApiChange(
-									ResponsePropertyOneOfRemovedId,
-									config,
-									[]any{deleted.String(), propName, responseStatus},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-							}
-						})
-				}
+			if deleted := info.schemaDiff.OneOfDiff.Deleted; len(deleted) > 0 {
+				baseSource, revisionSource := SubschemaSources(operationsSources, info.operationItem, info.schemaDiff, "oneOf", deleted[0].Index, -1)
+				result = append(result, info.newChange(ResponseBodyOneOfRemovedId, []any{deleted.String(), info.responseStatus}, "").
+					WithSources(baseSource, revisionSource))
 			}
 		}
-	}
+
+		info.walkProperties(func(p propertyInfo) {
+			if p.propertyDiff.OneOfDiff == nil {
+				return
+			}
+			if shouldSuppressPropertyOneOfSchemaChangedForListOfTypes(p.propertyDiff) {
+				return
+			}
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+
+			if added := p.propertyDiff.OneOfDiff.Added; len(added) > 0 {
+				propBaseSource, propRevisionSource := SubschemaSources(operationsSources, info.operationItem, p.propertyDiff, "oneOf", -1, added[0].Index)
+				result = append(result, p.newChange(ResponsePropertyOneOfAddedId, []any{added.String(), propName, info.responseStatus}, "").
+					WithSources(propBaseSource, propRevisionSource))
+			}
+			if deleted := p.propertyDiff.OneOfDiff.Deleted; len(deleted) > 0 {
+				propBaseSource, propRevisionSource := SubschemaSources(operationsSources, info.operationItem, p.propertyDiff, "oneOf", deleted[0].Index, -1)
+				result = append(result, p.newChange(ResponsePropertyOneOfRemovedId, []any{deleted.String(), propName, info.responseStatus}, "").
+					WithSources(propBaseSource, propRevisionSource))
+			}
+		})
+	})
+
 	return result
 }


### PR DESCRIPTION
## What

Fifth migration batch. Three matched request/response pairs from the Easy bucket of #936:

| Pair | Files |
|---|---|
| anyOf | `check_request_property_any_of_updated.go` + `check_response_property_any_of_updated.go` |
| oneOf | `check_request_property_one_of_updated.go` + `check_response_property_one_of_updated.go` |
| allOf | `check_request_property_all_of_updated.go` + `check_response_property_all_of_updated.go` |

All six are schema-composition checkers, structurally near-identical within each pair: detect Added/Deleted on the named `*OfDiff` field at body level, then `walkProperties` to repeat for property-level.

## Idioms this batch exercises

**Body-level suppression-then-skip-property-walk preserved.** anyOf and oneOf ran `shouldSuppressOneOfSchemaChangedForListOfTypes(...)` and used `continue` in the media-type for-loop to skip *both* the body emit AND the property walk for that media type. The walker form uses `return` for the same semantic:

```go
walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
    if shouldSuppressOneOfSchemaChangedForListOfTypes(info.schemaDiff) {
        return // skips both body-level emit AND info.walkProperties below
    }
    // ... body-level emit ...
    info.walkProperties(...)
})
```

allOf has no body-level suppression and is unchanged.

**Small WithDetails asymmetry, smoothed for free.** Request allOf was inconsistent: body-level emits did not chain `.WithDetails(mediaTypeDetails)`, but the property-level emits did. The other five files in this batch already attach details on both surfaces. Because the walker's `info.newChange` / `p.newChange` automatically attaches `mediaTypeDetails`, the migration brings request allOf in line with the other five for free. No test asserts details presence/absence here, so behaviour change is bounded to "the rendered output for these two specific IDs now carries the same media-type detail string the other anyOf/oneOf rendering does." Same shape of inconsistency we smoothed on the nullable PR (#945).

## Numbers

| | Before | After | Delta |
|---|---|---|---|
| any_of (request) | 118 | 59 | -59 |
| any_of (response) | 122 | 61 | -61 |
| one_of (request) | 120 | 61 | -59 |
| one_of (response) | 124 | 61 | -63 |
| all_of (request) | 108 | 49 | -59 |
| all_of (response) | 110 | 49 | -61 |

Net **-362 lines** across the six files (200 insertions, 562 deletions per `git diff --stat`).

## Tests

Full suite green; no test assertions needed updating. Walker plumbing is identical to the previous four batches.

## Running total

After this PR, **26** checker files are on the walker (2 pilot + 6 batch-2 + 6 batch-3 + 6 batch-4 + 6 batch-5). Roughly **49** remain. Continuing the opportunistic-batch cadence per #936.