### PR TITLE
checker: migrate dependent_schemas, prefix_items, if/then/else pairs to walker (PR-6 of #936)

### DIFF
--- a/checker/check_request_property_dependent_schemas_updated.go
+++ b/checker/check_request_property_dependent_schemas_updated.go
@@ -13,94 +13,40 @@ const (
 
 func RequestPropertyDependentSchemasUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
+
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if info.schemaDiff.DependentSchemasDiff != nil {
+			depSchemasDiff := info.schemaDiff.DependentSchemasDiff
+			for _, name := range depSchemasDiff.Added {
+				revisionSource := SchemaMapItemSource(operationsSources, info.operationItem.Revision, depSchemasDiff.Revision, name)
+				result = append(result, info.newChange(RequestBodyDependentSchemaAddedId, []any{name}, "").
+					WithSources(nil, revisionSource))
 			}
-
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				if mediaTypeDiff.SchemaDiff == nil {
-					continue
-				}
-
-				if mediaTypeDiff.SchemaDiff.DependentSchemasDiff != nil {
-					depSchemasDiff := mediaTypeDiff.SchemaDiff.DependentSchemasDiff
-					for _, name := range depSchemasDiff.Added {
-						revisionSource := SchemaMapItemSource(operationsSources, operationItem.Revision, depSchemasDiff.Revision, name)
-						result = append(result, NewApiChange(
-							RequestBodyDependentSchemaAddedId,
-							config,
-							[]any{name},
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-					}
-					for _, name := range depSchemasDiff.Deleted {
-						baseSource := SchemaMapItemSource(operationsSources, operationItem.Base, depSchemasDiff.Base, name)
-						result = append(result, NewApiChange(
-							RequestBodyDependentSchemaRemovedId,
-							config,
-							[]any{name},
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-					}
-				}
-
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						if propertyDiff.DependentSchemasDiff == nil {
-							return
-						}
-						propName := propertyFullName(propertyPath, propertyName)
-						depSchemasDiff := propertyDiff.DependentSchemasDiff
-						for _, name := range depSchemasDiff.Added {
-							revisionSource := SchemaMapItemSource(operationsSources, operationItem.Revision, depSchemasDiff.Revision, name)
-							result = append(result, NewApiChange(
-								RequestPropertyDependentSchemaAddedId,
-								config,
-								[]any{name, propName},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-						}
-						for _, name := range depSchemasDiff.Deleted {
-							baseSource := SchemaMapItemSource(operationsSources, operationItem.Base, depSchemasDiff.Base, name)
-							result = append(result, NewApiChange(
-								RequestPropertyDependentSchemaRemovedId,
-								config,
-								[]any{name, propName},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-						}
-					})
+			for _, name := range depSchemasDiff.Deleted {
+				baseSource := SchemaMapItemSource(operationsSources, info.operationItem.Base, depSchemasDiff.Base, name)
+				result = append(result, info.newChange(RequestBodyDependentSchemaRemovedId, []any{name}, "").
+					WithSources(baseSource, nil))
 			}
 		}
-	}
+
+		info.walkProperties(func(p propertyInfo) {
+			if p.propertyDiff.DependentSchemasDiff == nil {
+				return
+			}
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+			depSchemasDiff := p.propertyDiff.DependentSchemasDiff
+			for _, name := range depSchemasDiff.Added {
+				revisionSource := SchemaMapItemSource(operationsSources, info.operationItem.Revision, depSchemasDiff.Revision, name)
+				result = append(result, p.newChange(RequestPropertyDependentSchemaAddedId, []any{name, propName}, "").
+					WithSources(nil, revisionSource))
+			}
+			for _, name := range depSchemasDiff.Deleted {
+				baseSource := SchemaMapItemSource(operationsSources, info.operationItem.Base, depSchemasDiff.Base, name)
+				result = append(result, p.newChange(RequestPropertyDependentSchemaRemovedId, []any{name, propName}, "").
+					WithSources(baseSource, nil))
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_request_property_if_updated.go
+++ b/checker/check_request_property_if_updated.go
@@ -22,116 +22,60 @@ const (
 
 func RequestPropertyIfUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
 
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		for _, entry := range []struct {
+			schemaDiff *diff.SchemaDiff
+			addedId    string
+			removedId  string
+			field      string
+		}{
+			{info.schemaDiff.IfDiff, RequestBodyIfAddedId, RequestBodyIfRemovedId, "if"},
+			{info.schemaDiff.ThenDiff, RequestBodyThenAddedId, RequestBodyThenRemovedId, "then"},
+			{info.schemaDiff.ElseDiff, RequestBodyElseAddedId, RequestBodyElseRemovedId, "else"},
+		} {
+			if entry.schemaDiff == nil {
 				continue
 			}
-
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				if mediaTypeDiff.SchemaDiff == nil {
-					continue
-				}
-
-				for _, entry := range []struct {
-					schemaDiff *diff.SchemaDiff
-					addedId    string
-					removedId  string
-					field      string
-				}{
-					{mediaTypeDiff.SchemaDiff.IfDiff, RequestBodyIfAddedId, RequestBodyIfRemovedId, "if"},
-					{mediaTypeDiff.SchemaDiff.ThenDiff, RequestBodyThenAddedId, RequestBodyThenRemovedId, "then"},
-					{mediaTypeDiff.SchemaDiff.ElseDiff, RequestBodyElseAddedId, RequestBodyElseRemovedId, "else"},
-				} {
-					if entry.schemaDiff == nil {
-						continue
-					}
-					baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, entry.field)
-					if entry.schemaDiff.SchemaAdded {
-						result = append(result, NewApiChange(
-							entry.addedId,
-							config,
-							nil,
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-					}
-					if entry.schemaDiff.SchemaDeleted {
-						result = append(result, NewApiChange(
-							entry.removedId,
-							config,
-							nil,
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-					}
-				}
-
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						propName := propertyFullName(propertyPath, propertyName)
-
-						for _, entry := range []struct {
-							schemaDiff *diff.SchemaDiff
-							addedId    string
-							removedId  string
-							field      string
-						}{
-							{propertyDiff.IfDiff, RequestPropertyIfAddedId, RequestPropertyIfRemovedId, "if"},
-							{propertyDiff.ThenDiff, RequestPropertyThenAddedId, RequestPropertyThenRemovedId, "then"},
-							{propertyDiff.ElseDiff, RequestPropertyElseAddedId, RequestPropertyElseRemovedId, "else"},
-						} {
-							if entry.schemaDiff == nil {
-								continue
-							}
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, entry.field)
-							if entry.schemaDiff.SchemaAdded {
-								result = append(result, NewApiChange(
-									entry.addedId,
-									config,
-									[]any{propName},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(nil, propRevisionSource).WithDetails(mediaTypeDetails))
-							}
-							if entry.schemaDiff.SchemaDeleted {
-								result = append(result, NewApiChange(
-									entry.removedId,
-									config,
-									[]any{propName},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(propBaseSource, nil).WithDetails(mediaTypeDetails))
-							}
-						}
-					})
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, entry.field)
+			if entry.schemaDiff.SchemaAdded {
+				result = append(result, info.newChange(entry.addedId, nil, "").
+					WithSources(nil, revisionSource))
+			}
+			if entry.schemaDiff.SchemaDeleted {
+				result = append(result, info.newChange(entry.removedId, nil, "").
+					WithSources(baseSource, nil))
 			}
 		}
-	}
+
+		info.walkProperties(func(p propertyInfo) {
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+
+			for _, entry := range []struct {
+				schemaDiff *diff.SchemaDiff
+				addedId    string
+				removedId  string
+				field      string
+			}{
+				{p.propertyDiff.IfDiff, RequestPropertyIfAddedId, RequestPropertyIfRemovedId, "if"},
+				{p.propertyDiff.ThenDiff, RequestPropertyThenAddedId, RequestPropertyThenRemovedId, "then"},
+				{p.propertyDiff.ElseDiff, RequestPropertyElseAddedId, RequestPropertyElseRemovedId, "else"},
+			} {
+				if entry.schemaDiff == nil {
+					continue
+				}
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, entry.field)
+				if entry.schemaDiff.SchemaAdded {
+					result = append(result, p.newChange(entry.addedId, []any{propName}, "").
+						WithSources(nil, propRevisionSource))
+				}
+				if entry.schemaDiff.SchemaDeleted {
+					result = append(result, p.newChange(entry.removedId, []any{propName}, "").
+						WithSources(propBaseSource, nil))
+				}
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_request_property_prefix_items_updated.go
+++ b/checker/check_request_property_prefix_items_updated.go
@@ -13,96 +13,37 @@ const (
 
 func RequestPropertyPrefixItemsUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
 
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if info.schemaDiff.PrefixItemsDiff != nil {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "prefixItems")
+			if len(info.schemaDiff.PrefixItemsDiff.Added) > 0 {
+				result = append(result, info.newChange(RequestBodyPrefixItemsAddedId, []any{info.schemaDiff.PrefixItemsDiff.Added.String()}, "").
+					WithSources(nil, revisionSource))
 			}
-
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				if mediaTypeDiff.SchemaDiff == nil {
-					continue
-				}
-
-				if mediaTypeDiff.SchemaDiff.PrefixItemsDiff != nil {
-					baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "prefixItems")
-					if len(mediaTypeDiff.SchemaDiff.PrefixItemsDiff.Added) > 0 {
-						result = append(result, NewApiChange(
-							RequestBodyPrefixItemsAddedId,
-							config,
-							[]any{mediaTypeDiff.SchemaDiff.PrefixItemsDiff.Added.String()},
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-					}
-
-					if len(mediaTypeDiff.SchemaDiff.PrefixItemsDiff.Deleted) > 0 {
-						result = append(result, NewApiChange(
-							RequestBodyPrefixItemsRemovedId,
-							config,
-							[]any{mediaTypeDiff.SchemaDiff.PrefixItemsDiff.Deleted.String()},
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-					}
-				}
-
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						if propertyDiff.PrefixItemsDiff == nil {
-							return
-						}
-
-						propName := propertyFullName(propertyPath, propertyName)
-						propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "prefixItems")
-
-						if len(propertyDiff.PrefixItemsDiff.Added) > 0 {
-							result = append(result, NewApiChange(
-								RequestPropertyPrefixItemsAddedId,
-								config,
-								[]any{propertyDiff.PrefixItemsDiff.Added.String(), propName},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(nil, propRevisionSource).WithDetails(mediaTypeDetails))
-						}
-
-						if len(propertyDiff.PrefixItemsDiff.Deleted) > 0 {
-							result = append(result, NewApiChange(
-								RequestPropertyPrefixItemsRemovedId,
-								config,
-								[]any{propertyDiff.PrefixItemsDiff.Deleted.String(), propName},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, nil).WithDetails(mediaTypeDetails))
-						}
-					})
+			if len(info.schemaDiff.PrefixItemsDiff.Deleted) > 0 {
+				result = append(result, info.newChange(RequestBodyPrefixItemsRemovedId, []any{info.schemaDiff.PrefixItemsDiff.Deleted.String()}, "").
+					WithSources(baseSource, nil))
 			}
 		}
-	}
+
+		info.walkProperties(func(p propertyInfo) {
+			if p.propertyDiff.PrefixItemsDiff == nil {
+				return
+			}
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "prefixItems")
+
+			if len(p.propertyDiff.PrefixItemsDiff.Added) > 0 {
+				result = append(result, p.newChange(RequestPropertyPrefixItemsAddedId, []any{p.propertyDiff.PrefixItemsDiff.Added.String(), propName}, "").
+					WithSources(nil, propRevisionSource))
+			}
+			if len(p.propertyDiff.PrefixItemsDiff.Deleted) > 0 {
+				result = append(result, p.newChange(RequestPropertyPrefixItemsRemovedId, []any{p.propertyDiff.PrefixItemsDiff.Deleted.String(), propName}, "").
+					WithSources(propBaseSource, nil))
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_response_property_dependent_schemas_updated.go
+++ b/checker/check_response_property_dependent_schemas_updated.go
@@ -13,98 +13,40 @@ const (
 
 func ResponsePropertyDependentSchemasUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil || operationItem.ResponsesDiff.Modified == nil {
-				continue
+
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if info.schemaDiff.DependentSchemasDiff != nil {
+			depSchemasDiff := info.schemaDiff.DependentSchemasDiff
+			for _, name := range depSchemasDiff.Added {
+				revisionSource := SchemaMapItemSource(operationsSources, info.operationItem.Revision, depSchemasDiff.Revision, name)
+				result = append(result, info.newChange(ResponseBodyDependentSchemaAddedId, []any{name, info.responseStatus}, "").
+					WithSources(nil, revisionSource))
 			}
-
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff.ContentDiff == nil || responseDiff.ContentDiff.MediaTypeModified == nil {
-					continue
-				}
-
-				modifiedMediaTypes := responseDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					if mediaTypeDiff.SchemaDiff == nil {
-						continue
-					}
-
-					if mediaTypeDiff.SchemaDiff.DependentSchemasDiff != nil {
-						depSchemasDiff := mediaTypeDiff.SchemaDiff.DependentSchemasDiff
-						for _, name := range depSchemasDiff.Added {
-							revisionSource := SchemaMapItemSource(operationsSources, operationItem.Revision, depSchemasDiff.Revision, name)
-							result = append(result, NewApiChange(
-								ResponseBodyDependentSchemaAddedId,
-								config,
-								[]any{name, responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-						}
-						for _, name := range depSchemasDiff.Deleted {
-							baseSource := SchemaMapItemSource(operationsSources, operationItem.Base, depSchemasDiff.Base, name)
-							result = append(result, NewApiChange(
-								ResponseBodyDependentSchemaRemovedId,
-								config,
-								[]any{name, responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-						}
-					}
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							if propertyDiff.DependentSchemasDiff == nil {
-								return
-							}
-							propName := propertyFullName(propertyPath, propertyName)
-							depSchemasDiff := propertyDiff.DependentSchemasDiff
-							for _, name := range depSchemasDiff.Added {
-								revisionSource := SchemaMapItemSource(operationsSources, operationItem.Revision, depSchemasDiff.Revision, name)
-								result = append(result, NewApiChange(
-									ResponsePropertyDependentSchemaAddedId,
-									config,
-									[]any{name, propName, responseStatus},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-							}
-							for _, name := range depSchemasDiff.Deleted {
-								baseSource := SchemaMapItemSource(operationsSources, operationItem.Base, depSchemasDiff.Base, name)
-								result = append(result, NewApiChange(
-									ResponsePropertyDependentSchemaRemovedId,
-									config,
-									[]any{name, propName, responseStatus},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-							}
-						})
-				}
+			for _, name := range depSchemasDiff.Deleted {
+				baseSource := SchemaMapItemSource(operationsSources, info.operationItem.Base, depSchemasDiff.Base, name)
+				result = append(result, info.newChange(ResponseBodyDependentSchemaRemovedId, []any{name, info.responseStatus}, "").
+					WithSources(baseSource, nil))
 			}
 		}
-	}
+
+		info.walkProperties(func(p propertyInfo) {
+			if p.propertyDiff.DependentSchemasDiff == nil {
+				return
+			}
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+			depSchemasDiff := p.propertyDiff.DependentSchemasDiff
+			for _, name := range depSchemasDiff.Added {
+				revisionSource := SchemaMapItemSource(operationsSources, info.operationItem.Revision, depSchemasDiff.Revision, name)
+				result = append(result, p.newChange(ResponsePropertyDependentSchemaAddedId, []any{name, propName, info.responseStatus}, "").
+					WithSources(nil, revisionSource))
+			}
+			for _, name := range depSchemasDiff.Deleted {
+				baseSource := SchemaMapItemSource(operationsSources, info.operationItem.Base, depSchemasDiff.Base, name)
+				result = append(result, p.newChange(ResponsePropertyDependentSchemaRemovedId, []any{name, propName, info.responseStatus}, "").
+					WithSources(baseSource, nil))
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_response_property_if_updated.go
+++ b/checker/check_response_property_if_updated.go
@@ -22,120 +22,60 @@ const (
 
 func ResponsePropertyIfUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
 
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil || operationItem.ResponsesDiff.Modified == nil {
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		for _, entry := range []struct {
+			schemaDiff *diff.SchemaDiff
+			addedId    string
+			removedId  string
+			field      string
+		}{
+			{info.schemaDiff.IfDiff, ResponseBodyIfAddedId, ResponseBodyIfRemovedId, "if"},
+			{info.schemaDiff.ThenDiff, ResponseBodyThenAddedId, ResponseBodyThenRemovedId, "then"},
+			{info.schemaDiff.ElseDiff, ResponseBodyElseAddedId, ResponseBodyElseRemovedId, "else"},
+		} {
+			if entry.schemaDiff == nil {
 				continue
 			}
-
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff.ContentDiff == nil || responseDiff.ContentDiff.MediaTypeModified == nil {
-					continue
-				}
-
-				modifiedMediaTypes := responseDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					if mediaTypeDiff.SchemaDiff == nil {
-						continue
-					}
-
-					for _, entry := range []struct {
-						schemaDiff *diff.SchemaDiff
-						addedId    string
-						removedId  string
-						field      string
-					}{
-						{mediaTypeDiff.SchemaDiff.IfDiff, ResponseBodyIfAddedId, ResponseBodyIfRemovedId, "if"},
-						{mediaTypeDiff.SchemaDiff.ThenDiff, ResponseBodyThenAddedId, ResponseBodyThenRemovedId, "then"},
-						{mediaTypeDiff.SchemaDiff.ElseDiff, ResponseBodyElseAddedId, ResponseBodyElseRemovedId, "else"},
-					} {
-						if entry.schemaDiff == nil {
-							continue
-						}
-						baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, entry.field)
-						if entry.schemaDiff.SchemaAdded {
-							result = append(result, NewApiChange(
-								entry.addedId,
-								config,
-								[]any{responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-						}
-						if entry.schemaDiff.SchemaDeleted {
-							result = append(result, NewApiChange(
-								entry.removedId,
-								config,
-								[]any{responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-						}
-					}
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							propName := propertyFullName(propertyPath, propertyName)
-
-							for _, entry := range []struct {
-								schemaDiff *diff.SchemaDiff
-								addedId    string
-								removedId  string
-								field      string
-							}{
-								{propertyDiff.IfDiff, ResponsePropertyIfAddedId, ResponsePropertyIfRemovedId, "if"},
-								{propertyDiff.ThenDiff, ResponsePropertyThenAddedId, ResponsePropertyThenRemovedId, "then"},
-								{propertyDiff.ElseDiff, ResponsePropertyElseAddedId, ResponsePropertyElseRemovedId, "else"},
-							} {
-								if entry.schemaDiff == nil {
-									continue
-								}
-								propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, entry.field)
-								if entry.schemaDiff.SchemaAdded {
-									result = append(result, NewApiChange(
-										entry.addedId,
-										config,
-										[]any{propName, responseStatus},
-										"",
-										operationsSources,
-										operationItem.Revision,
-										operation,
-										path,
-									).WithSources(nil, propRevisionSource).WithDetails(mediaTypeDetails))
-								}
-								if entry.schemaDiff.SchemaDeleted {
-									result = append(result, NewApiChange(
-										entry.removedId,
-										config,
-										[]any{propName, responseStatus},
-										"",
-										operationsSources,
-										operationItem.Revision,
-										operation,
-										path,
-									).WithSources(propBaseSource, nil).WithDetails(mediaTypeDetails))
-								}
-							}
-						})
-				}
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, entry.field)
+			if entry.schemaDiff.SchemaAdded {
+				result = append(result, info.newChange(entry.addedId, []any{info.responseStatus}, "").
+					WithSources(nil, revisionSource))
+			}
+			if entry.schemaDiff.SchemaDeleted {
+				result = append(result, info.newChange(entry.removedId, []any{info.responseStatus}, "").
+					WithSources(baseSource, nil))
 			}
 		}
-	}
+
+		info.walkProperties(func(p propertyInfo) {
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+
+			for _, entry := range []struct {
+				schemaDiff *diff.SchemaDiff
+				addedId    string
+				removedId  string
+				field      string
+			}{
+				{p.propertyDiff.IfDiff, ResponsePropertyIfAddedId, ResponsePropertyIfRemovedId, "if"},
+				{p.propertyDiff.ThenDiff, ResponsePropertyThenAddedId, ResponsePropertyThenRemovedId, "then"},
+				{p.propertyDiff.ElseDiff, ResponsePropertyElseAddedId, ResponsePropertyElseRemovedId, "else"},
+			} {
+				if entry.schemaDiff == nil {
+					continue
+				}
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, entry.field)
+				if entry.schemaDiff.SchemaAdded {
+					result = append(result, p.newChange(entry.addedId, []any{propName, info.responseStatus}, "").
+						WithSources(nil, propRevisionSource))
+				}
+				if entry.schemaDiff.SchemaDeleted {
+					result = append(result, p.newChange(entry.removedId, []any{propName, info.responseStatus}, "").
+						WithSources(propBaseSource, nil))
+				}
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_response_property_prefix_items_updated.go
+++ b/checker/check_response_property_prefix_items_updated.go
@@ -13,100 +13,37 @@ const (
 
 func ResponsePropertyPrefixItemsUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
 
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil || operationItem.ResponsesDiff.Modified == nil {
-				continue
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if info.schemaDiff.PrefixItemsDiff != nil {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "prefixItems")
+			if len(info.schemaDiff.PrefixItemsDiff.Added) > 0 {
+				result = append(result, info.newChange(ResponseBodyPrefixItemsAddedId, []any{info.schemaDiff.PrefixItemsDiff.Added.String(), info.responseStatus}, "").
+					WithSources(nil, revisionSource))
 			}
-
-			for responseStatus, responsesDiff := range operationItem.ResponsesDiff.Modified {
-				if responsesDiff.ContentDiff == nil || responsesDiff.ContentDiff.MediaTypeModified == nil {
-					continue
-				}
-
-				modifiedMediaTypes := responsesDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					if mediaTypeDiff.SchemaDiff == nil {
-						continue
-					}
-
-					if mediaTypeDiff.SchemaDiff.PrefixItemsDiff != nil {
-						baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "prefixItems")
-						if len(mediaTypeDiff.SchemaDiff.PrefixItemsDiff.Added) > 0 {
-							result = append(result, NewApiChange(
-								ResponseBodyPrefixItemsAddedId,
-								config,
-								[]any{mediaTypeDiff.SchemaDiff.PrefixItemsDiff.Added.String(), responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-						}
-
-						if len(mediaTypeDiff.SchemaDiff.PrefixItemsDiff.Deleted) > 0 {
-							result = append(result, NewApiChange(
-								ResponseBodyPrefixItemsRemovedId,
-								config,
-								[]any{mediaTypeDiff.SchemaDiff.PrefixItemsDiff.Deleted.String(), responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-						}
-					}
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							if propertyDiff.PrefixItemsDiff == nil {
-								return
-							}
-
-							propName := propertyFullName(propertyPath, propertyName)
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "prefixItems")
-
-							if len(propertyDiff.PrefixItemsDiff.Added) > 0 {
-								result = append(result, NewApiChange(
-									ResponsePropertyPrefixItemsAddedId,
-									config,
-									[]any{propertyDiff.PrefixItemsDiff.Added.String(), propName, responseStatus},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(nil, propRevisionSource).WithDetails(mediaTypeDetails))
-							}
-
-							if len(propertyDiff.PrefixItemsDiff.Deleted) > 0 {
-								result = append(result, NewApiChange(
-									ResponsePropertyPrefixItemsRemovedId,
-									config,
-									[]any{propertyDiff.PrefixItemsDiff.Deleted.String(), propName, responseStatus},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(propBaseSource, nil).WithDetails(mediaTypeDetails))
-							}
-						})
-				}
+			if len(info.schemaDiff.PrefixItemsDiff.Deleted) > 0 {
+				result = append(result, info.newChange(ResponseBodyPrefixItemsRemovedId, []any{info.schemaDiff.PrefixItemsDiff.Deleted.String(), info.responseStatus}, "").
+					WithSources(baseSource, nil))
 			}
 		}
-	}
+
+		info.walkProperties(func(p propertyInfo) {
+			if p.propertyDiff.PrefixItemsDiff == nil {
+				return
+			}
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "prefixItems")
+
+			if len(p.propertyDiff.PrefixItemsDiff.Added) > 0 {
+				result = append(result, p.newChange(ResponsePropertyPrefixItemsAddedId, []any{p.propertyDiff.PrefixItemsDiff.Added.String(), propName, info.responseStatus}, "").
+					WithSources(nil, propRevisionSource))
+			}
+			if len(p.propertyDiff.PrefixItemsDiff.Deleted) > 0 {
+				result = append(result, p.newChange(ResponsePropertyPrefixItemsRemovedId, []any{p.propertyDiff.PrefixItemsDiff.Deleted.String(), propName, info.responseStatus}, "").
+					WithSources(propBaseSource, nil))
+			}
+		})
+	})
+
 	return result
 }


### PR DESCRIPTION
## What

Sixth migration batch. Three matched request/response pairs from the OpenAPI 3.1 keyword cluster:

| Pair | Files |
|---|---|
| dependent_schemas | `check_request_property_dependent_schemas_updated.go` + `check_response_property_dependent_schemas_updated.go` |
| prefix_items | `check_request_property_prefix_items_updated.go` + `check_response_property_prefix_items_updated.go` |
| if/then/else | `check_request_property_if_updated.go` + `check_response_property_if_updated.go` |

All six fit the now-standard walker shape (callback → body emit → `walkProperties` → property emit).

## Per-pair notes

- **dependent_schemas**: walks `Added`/`Deleted` on `DependentSchemasDiff`, emitting per-name changes with `SchemaMapItemSource`.
- **prefix_items**: walks `Added`/`Deleted` on `PrefixItemsDiff`, emitting with `SchemaFieldSources("prefixItems")`.
- **if/then/else**: iterates a 3-entry slice of `{IfDiff, ThenDiff, ElseDiff}` inside both body and property handlers, emitting per-field changes based on `SchemaAdded` / `SchemaDeleted`.

No asymmetries discovered in this batch; pure refactor. Existing tests pass without modification.

## Numbers

| | Before | After | Delta |
|---|---|---|---|
| dependent_schemas (request) | 106 | 52 | -54 |
| dependent_schemas (response) | 110 | 52 | -58 |
| prefix_items (request) | 108 | 49 | -59 |
| prefix_items (response) | 112 | 49 | -63 |
| if/then/else (request) | 137 | 81 | -56 |
| if/then/else (response) | 141 | 81 | -60 |

Net **-350 lines** across the six files (210 insertions, 560 deletions per `git diff --stat`).

## Tests

Full suite green; vet clean; fmt clean. No test assertions needed updating.

## Running total

After this PR, **32** checker files are on the walker (2 pilot + 6 batch-2 + 6 batch-3 + 6 batch-4 + 6 batch-5 + 6 batch-6). Roughly **43** remain.