### PR TITLE
checker: migrate list_of_types, pattern, pattern_properties pairs to walker (PR-7 of #936)

### DIFF
--- a/checker/check_request_property_list_of_types_changed.go
+++ b/checker/check_request_property_list_of_types_changed.go
@@ -13,61 +13,35 @@ const (
 
 func RequestPropertyListOfTypesChangedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
+
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		opInfo := newOpInfoFromDiff(config, info.operationItem, operationsSources, info.method, info.path)
+
+		// Body-level
+		result = append(result, checkBodyListOfTypesChange(
+			opInfo,
+			info.schemaDiff,
+			info.mediaType,
+			"",   // responseStatus not applicable for requests
+			true, // isRequest
+		)...)
+
+		// Property-level
+		info.walkProperties(func(p propertyInfo) {
+			if p.propertyDiff.Revision == nil || p.propertyDiff.Revision.ReadOnly {
+				return
 			}
-			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
+			result = append(result, checkPropertyListOfTypesChange(
+				opInfo,
+				p.propertyPath,
+				p.propertyName,
+				p.propertyDiff,
+				info.mediaType,
+				"",   // responseStatus not applicable for requests
+				true, // isRequest
+			)...)
+		})
+	})
 
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				if mediaTypeDiff.SchemaDiff == nil {
-					continue
-				}
-
-				// Check request body schema
-				changes := checkBodyListOfTypesChange(
-					opInfo,
-					mediaTypeDiff.SchemaDiff,
-					mediaType,
-					"",   // responseStatus not applicable for requests
-					true, // isRequest
-				)
-				result = append(result, changes...)
-
-				// Check request body properties
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						if propertyDiff.Revision == nil {
-							return
-						}
-						if propertyDiff.Revision.ReadOnly {
-							return
-						}
-
-						changes := checkPropertyListOfTypesChange(
-							opInfo,
-							propertyPath,
-							propertyName,
-							propertyDiff,
-							mediaType,
-							"",   // responseStatus not applicable for requests
-							true, // isRequest
-						)
-						result = append(result, changes...)
-					})
-			}
-		}
-	}
 	return result
 }

--- a/checker/check_request_property_pattern_added_or_changed.go
+++ b/checker/check_request_property_pattern_added_or_changed.go
@@ -13,79 +13,44 @@ const (
 
 func RequestPropertyPatternUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
+
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		info.walkProperties(func(p propertyInfo) {
+			patternDiff := p.propertyDiff.PatternDiff
+			if patternDiff == nil {
+				return
 			}
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						patternDiff := propertyDiff.PatternDiff
-						if patternDiff == nil {
-							return
-						}
 
-						propName := propertyFullName(propertyPath, propertyName)
-						propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "pattern")
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "pattern")
 
-						if patternDiff.To == "" {
-							result = append(result, NewApiChange(
-								RequestPropertyPatternRemovedId,
-								config,
-								[]any{patternDiff.From, propName},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						} else if patternDiff.From == "" {
-							result = append(result, NewApiChange(
-								RequestPropertyPatternAddedId,
-								config,
-								[]any{patternDiff.To, propName},
-								PatternAddedCommentId,
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						} else {
-
-							id := RequestPropertyPatternChangedId
-							comment := PatternChangedCommentId
-
-							if patternDiff.To == ".*" {
-								id = RequestPropertyPatternGeneralizedId
-								comment = ""
-							}
-
-							result = append(result, NewApiChange(
-								id,
-								config,
-								[]any{propName, patternDiff.From, patternDiff.To},
-								comment,
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						}
-					})
+			if patternDiff.To == "" {
+				result = append(result, p.newChange(
+					RequestPropertyPatternRemovedId,
+					[]any{patternDiff.From, propName},
+					"",
+				).WithSources(propBaseSource, propRevisionSource))
+			} else if patternDiff.From == "" {
+				result = append(result, p.newChange(
+					RequestPropertyPatternAddedId,
+					[]any{patternDiff.To, propName},
+					PatternAddedCommentId,
+				).WithSources(propBaseSource, propRevisionSource))
+			} else {
+				id := RequestPropertyPatternChangedId
+				comment := PatternChangedCommentId
+				if patternDiff.To == ".*" {
+					id = RequestPropertyPatternGeneralizedId
+					comment = ""
+				}
+				result = append(result, p.newChange(
+					id,
+					[]any{propName, patternDiff.From, patternDiff.To},
+					comment,
+				).WithSources(propBaseSource, propRevisionSource))
 			}
-		}
-	}
+		})
+	})
+
 	return result
 }

--- a/checker/check_request_property_pattern_properties_updated.go
+++ b/checker/check_request_property_pattern_properties_updated.go
@@ -13,94 +13,40 @@ const (
 
 func RequestPropertyPatternPropertiesUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
+
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if info.schemaDiff.PatternPropertiesDiff != nil {
+			patPropsDiff := info.schemaDiff.PatternPropertiesDiff
+			for _, pattern := range patPropsDiff.Added {
+				revisionSource := SchemaMapItemSource(operationsSources, info.operationItem.Revision, patPropsDiff.Revision, pattern)
+				result = append(result, info.newChange(RequestBodyPatternPropertyAddedId, []any{pattern}, "").
+					WithSources(nil, revisionSource))
 			}
-
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				if mediaTypeDiff.SchemaDiff == nil {
-					continue
-				}
-
-				if mediaTypeDiff.SchemaDiff.PatternPropertiesDiff != nil {
-					patPropsDiff := mediaTypeDiff.SchemaDiff.PatternPropertiesDiff
-					for _, pattern := range patPropsDiff.Added {
-						revisionSource := SchemaMapItemSource(operationsSources, operationItem.Revision, patPropsDiff.Revision, pattern)
-						result = append(result, NewApiChange(
-							RequestBodyPatternPropertyAddedId,
-							config,
-							[]any{pattern},
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-					}
-					for _, pattern := range patPropsDiff.Deleted {
-						baseSource := SchemaMapItemSource(operationsSources, operationItem.Base, patPropsDiff.Base, pattern)
-						result = append(result, NewApiChange(
-							RequestBodyPatternPropertyRemovedId,
-							config,
-							[]any{pattern},
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-					}
-				}
-
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						if propertyDiff.PatternPropertiesDiff == nil {
-							return
-						}
-						propName := propertyFullName(propertyPath, propertyName)
-						patPropsDiff := propertyDiff.PatternPropertiesDiff
-						for _, pattern := range patPropsDiff.Added {
-							revisionSource := SchemaMapItemSource(operationsSources, operationItem.Revision, patPropsDiff.Revision, pattern)
-							result = append(result, NewApiChange(
-								RequestPropertyPatternPropertyAddedId,
-								config,
-								[]any{pattern, propName},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-						}
-						for _, pattern := range patPropsDiff.Deleted {
-							baseSource := SchemaMapItemSource(operationsSources, operationItem.Base, patPropsDiff.Base, pattern)
-							result = append(result, NewApiChange(
-								RequestPropertyPatternPropertyRemovedId,
-								config,
-								[]any{pattern, propName},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-						}
-					})
+			for _, pattern := range patPropsDiff.Deleted {
+				baseSource := SchemaMapItemSource(operationsSources, info.operationItem.Base, patPropsDiff.Base, pattern)
+				result = append(result, info.newChange(RequestBodyPatternPropertyRemovedId, []any{pattern}, "").
+					WithSources(baseSource, nil))
 			}
 		}
-	}
+
+		info.walkProperties(func(p propertyInfo) {
+			if p.propertyDiff.PatternPropertiesDiff == nil {
+				return
+			}
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+			patPropsDiff := p.propertyDiff.PatternPropertiesDiff
+			for _, pattern := range patPropsDiff.Added {
+				revisionSource := SchemaMapItemSource(operationsSources, info.operationItem.Revision, patPropsDiff.Revision, pattern)
+				result = append(result, p.newChange(RequestPropertyPatternPropertyAddedId, []any{pattern, propName}, "").
+					WithSources(nil, revisionSource))
+			}
+			for _, pattern := range patPropsDiff.Deleted {
+				baseSource := SchemaMapItemSource(operationsSources, info.operationItem.Base, patPropsDiff.Base, pattern)
+				result = append(result, p.newChange(RequestPropertyPatternPropertyRemovedId, []any{pattern, propName}, "").
+					WithSources(baseSource, nil))
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_response_pattern_added_or_changed.go
+++ b/checker/check_response_pattern_added_or_changed.go
@@ -12,68 +12,31 @@ const (
 
 func ResponsePatternAddedOrChangedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
 
-			if operationItem.ResponsesDiff == nil {
-				continue
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		info.walkProperties(func(p propertyInfo) {
+			patternDiff := p.propertyDiff.PatternDiff
+			if patternDiff == nil {
+				return
 			}
 
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff.ContentDiff == nil ||
-					responseDiff.ContentDiff.MediaTypeModified == nil {
-					continue
-				}
+			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "pattern")
+			propName := propertyFullName(p.propertyPath, p.propertyName)
 
-				modifiedMediaTypes := responseDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					if mediaTypeDiff.SchemaDiff == nil {
-						continue
-					}
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							patternDiff := propertyDiff.PatternDiff
-							if patternDiff == nil {
-								return
-							}
-
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "pattern")
-
-							propName := propertyFullName(propertyPath, propertyName)
-
-							id := ResponsePropertyPatternChangedId
-							args := []any{propName, patternDiff.From, patternDiff.To, responseStatus}
-							if patternDiff.To == "" || patternDiff.To == nil {
-								id = ResponsePropertyPatternRemovedId
-								args = []any{propName, patternDiff.From, responseStatus}
-							} else if patternDiff.From == "" || patternDiff.From == nil {
-								id = ResponsePropertyPatternAddedId
-								args = []any{propName, patternDiff.To, responseStatus}
-							}
-
-							result = append(result, NewApiChange(
-								id,
-								config,
-								args,
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						})
-				}
+			id := ResponsePropertyPatternChangedId
+			args := []any{propName, patternDiff.From, patternDiff.To, info.responseStatus}
+			if patternDiff.To == "" || patternDiff.To == nil {
+				id = ResponsePropertyPatternRemovedId
+				args = []any{propName, patternDiff.From, info.responseStatus}
+			} else if patternDiff.From == "" || patternDiff.From == nil {
+				id = ResponsePropertyPatternAddedId
+				args = []any{propName, patternDiff.To, info.responseStatus}
 			}
-		}
-	}
+
+			result = append(result, p.newChange(id, args, "").
+				WithSources(propBaseSource, propRevisionSource))
+		})
+	})
+
 	return result
 }

--- a/checker/check_response_property_list_of_types_changed.go
+++ b/checker/check_response_property_list_of_types_changed.go
@@ -13,63 +13,35 @@ const (
 
 func ResponsePropertyListOfTypesChangedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil || operationItem.ResponsesDiff.Modified == nil {
-				continue
+
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		opInfo := newOpInfoFromDiff(config, info.operationItem, operationsSources, info.method, info.path)
+
+		// Body-level
+		result = append(result, checkBodyListOfTypesChange(
+			opInfo,
+			info.schemaDiff,
+			info.mediaType,
+			info.responseStatus,
+			false, // isRequest
+		)...)
+
+		// Property-level
+		info.walkProperties(func(p propertyInfo) {
+			if p.propertyDiff == nil || p.propertyDiff.Revision == nil {
+				return
 			}
-			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
+			result = append(result, checkPropertyListOfTypesChange(
+				opInfo,
+				p.propertyPath,
+				p.propertyName,
+				p.propertyDiff,
+				info.mediaType,
+				info.responseStatus,
+				false, // isRequest
+			)...)
+		})
+	})
 
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff.ContentDiff == nil ||
-					responseDiff.ContentDiff.MediaTypeModified == nil {
-					continue
-				}
-
-				modifiedMediaTypes := responseDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					if mediaTypeDiff.SchemaDiff == nil {
-						continue
-					}
-
-					// Check response body schema
-					changes := checkBodyListOfTypesChange(
-						opInfo,
-						mediaTypeDiff.SchemaDiff,
-						mediaType,
-						responseStatus,
-						false, // isRequest
-					)
-					result = append(result, changes...)
-
-					// Check response body properties
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							if propertyDiff == nil || propertyDiff.Revision == nil {
-								return
-							}
-
-							changes := checkPropertyListOfTypesChange(
-								opInfo,
-								propertyPath,
-								propertyName,
-								propertyDiff,
-								mediaType,
-								responseStatus,
-								false, // isRequest
-							)
-							result = append(result, changes...)
-						})
-				}
-			}
-		}
-	}
 	return result
 }

--- a/checker/check_response_property_pattern_properties_updated.go
+++ b/checker/check_response_property_pattern_properties_updated.go
@@ -13,98 +13,40 @@ const (
 
 func ResponsePropertyPatternPropertiesUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil || operationItem.ResponsesDiff.Modified == nil {
-				continue
+
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if info.schemaDiff.PatternPropertiesDiff != nil {
+			patPropsDiff := info.schemaDiff.PatternPropertiesDiff
+			for _, pattern := range patPropsDiff.Added {
+				revisionSource := SchemaMapItemSource(operationsSources, info.operationItem.Revision, patPropsDiff.Revision, pattern)
+				result = append(result, info.newChange(ResponseBodyPatternPropertyAddedId, []any{pattern, info.responseStatus}, "").
+					WithSources(nil, revisionSource))
 			}
-
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff.ContentDiff == nil || responseDiff.ContentDiff.MediaTypeModified == nil {
-					continue
-				}
-
-				modifiedMediaTypes := responseDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					if mediaTypeDiff.SchemaDiff == nil {
-						continue
-					}
-
-					if mediaTypeDiff.SchemaDiff.PatternPropertiesDiff != nil {
-						patPropsDiff := mediaTypeDiff.SchemaDiff.PatternPropertiesDiff
-						for _, pattern := range patPropsDiff.Added {
-							revisionSource := SchemaMapItemSource(operationsSources, operationItem.Revision, patPropsDiff.Revision, pattern)
-							result = append(result, NewApiChange(
-								ResponseBodyPatternPropertyAddedId,
-								config,
-								[]any{pattern, responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-						}
-						for _, pattern := range patPropsDiff.Deleted {
-							baseSource := SchemaMapItemSource(operationsSources, operationItem.Base, patPropsDiff.Base, pattern)
-							result = append(result, NewApiChange(
-								ResponseBodyPatternPropertyRemovedId,
-								config,
-								[]any{pattern, responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-						}
-					}
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							if propertyDiff.PatternPropertiesDiff == nil {
-								return
-							}
-							propName := propertyFullName(propertyPath, propertyName)
-							patPropsDiff := propertyDiff.PatternPropertiesDiff
-							for _, pattern := range patPropsDiff.Added {
-								revisionSource := SchemaMapItemSource(operationsSources, operationItem.Revision, patPropsDiff.Revision, pattern)
-								result = append(result, NewApiChange(
-									ResponsePropertyPatternPropertyAddedId,
-									config,
-									[]any{pattern, propName, responseStatus},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-							}
-							for _, pattern := range patPropsDiff.Deleted {
-								baseSource := SchemaMapItemSource(operationsSources, operationItem.Base, patPropsDiff.Base, pattern)
-								result = append(result, NewApiChange(
-									ResponsePropertyPatternPropertyRemovedId,
-									config,
-									[]any{pattern, propName, responseStatus},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-							}
-						})
-				}
+			for _, pattern := range patPropsDiff.Deleted {
+				baseSource := SchemaMapItemSource(operationsSources, info.operationItem.Base, patPropsDiff.Base, pattern)
+				result = append(result, info.newChange(ResponseBodyPatternPropertyRemovedId, []any{pattern, info.responseStatus}, "").
+					WithSources(baseSource, nil))
 			}
 		}
-	}
+
+		info.walkProperties(func(p propertyInfo) {
+			if p.propertyDiff.PatternPropertiesDiff == nil {
+				return
+			}
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+			patPropsDiff := p.propertyDiff.PatternPropertiesDiff
+			for _, pattern := range patPropsDiff.Added {
+				revisionSource := SchemaMapItemSource(operationsSources, info.operationItem.Revision, patPropsDiff.Revision, pattern)
+				result = append(result, p.newChange(ResponsePropertyPatternPropertyAddedId, []any{pattern, propName, info.responseStatus}, "").
+					WithSources(nil, revisionSource))
+			}
+			for _, pattern := range patPropsDiff.Deleted {
+				baseSource := SchemaMapItemSource(operationsSources, info.operationItem.Base, patPropsDiff.Base, pattern)
+				result = append(result, p.newChange(ResponsePropertyPatternPropertyRemovedId, []any{pattern, propName, info.responseStatus}, "").
+					WithSources(baseSource, nil))
+			}
+		})
+	})
+
 	return result
 }


### PR DESCRIPTION
## What

Seventh migration batch. Three matched request/response pairs.

| Pair | Files |
|---|---|
| list_of_types | `check_request_property_list_of_types_changed.go` + `check_response_property_list_of_types_changed.go` |
| pattern | `check_request_property_pattern_added_or_changed.go` + `check_response_pattern_added_or_changed.go` |
| pattern_properties | `check_request_property_pattern_properties_updated.go` + `check_response_property_pattern_properties_updated.go` |

## Per-pair notes

- **list_of_types** delegates to helper funcs (`checkBodyListOfTypesChange`, `checkPropertyListOfTypesChange`) that already take an `opInfo`. The walker callback builds `opInfo` from info-derived fields and passes it through unchanged. Helper signatures untouched.
- **pattern** (`added_or_changed`) is property-level only — no body emit. The walker callback skips straight to `walkProperties`.
- **pattern_properties** emits at both body and property levels, both via `Added` / `Deleted` on `PatternPropertiesDiff` with `SchemaMapItemSource`.

No asymmetries discovered in this batch; pure refactor. Existing tests pass without modification.

## Numbers

| | Before | After | Delta |
|---|---|---|---|
| list_of_types (request) | 73 | 47 | -26 |
| list_of_types (response) | 75 | 47 | -28 |
| pattern (request) | 91 | 56 | -35 |
| pattern (response) | 79 | 42 | -37 |
| pattern_properties (request) | 106 | 52 | -54 |
| pattern_properties (response) | 110 | 52 | -58 |

Net **-238 lines** across the six files (175 insertions, 413 deletions per `git diff --stat`).

## Tests

Full suite green; vet clean; fmt clean. No test assertions needed updating.

## Running total

After this PR, **38** checker files are on the walker. Roughly **37** remain.