### PR TITLE
checker: migrate property_names, content, unevaluated pairs to walker (PR-8 of #936)

### DIFF
--- a/checker/check_request_property_content_updated.go
+++ b/checker/check_request_property_content_updated.go
@@ -18,150 +18,64 @@ const (
 
 func RequestPropertyContentUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
+
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if info.schemaDiff.ContentSchemaDiff != nil {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "contentSchema")
+			if info.schemaDiff.ContentSchemaDiff.SchemaAdded {
+				result = append(result, info.newChange(RequestBodyContentSchemaAddedId, nil, "").
+					WithSources(nil, revisionSource))
 			}
-
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				if mediaTypeDiff.SchemaDiff == nil {
-					continue
-				}
-
-				if mediaTypeDiff.SchemaDiff.ContentSchemaDiff != nil {
-					baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "contentSchema")
-					if mediaTypeDiff.SchemaDiff.ContentSchemaDiff.SchemaAdded {
-						result = append(result, NewApiChange(
-							RequestBodyContentSchemaAddedId,
-							config,
-							nil,
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-					}
-					if mediaTypeDiff.SchemaDiff.ContentSchemaDiff.SchemaDeleted {
-						result = append(result, NewApiChange(
-							RequestBodyContentSchemaRemovedId,
-							config,
-							nil,
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-					}
-				}
-
-				if mediaTypeDiff.SchemaDiff.ContentMediaTypeDiff != nil {
-					baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "contentMediaType")
-					d := mediaTypeDiff.SchemaDiff.ContentMediaTypeDiff
-					result = append(result, NewApiChange(
-						RequestBodyContentMediaTypeChangedId,
-						config,
-						[]any{d.From, d.To},
-						"",
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
-					).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-				}
-
-				if mediaTypeDiff.SchemaDiff.ContentEncodingDiff != nil {
-					baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "contentEncoding")
-					d := mediaTypeDiff.SchemaDiff.ContentEncodingDiff
-					result = append(result, NewApiChange(
-						RequestBodyContentEncodingChangedId,
-						config,
-						[]any{d.From, d.To},
-						"",
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
-					).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-				}
-
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						propName := propertyFullName(propertyPath, propertyName)
-
-						if propertyDiff.ContentSchemaDiff != nil {
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "contentSchema")
-							if propertyDiff.ContentSchemaDiff.SchemaAdded {
-								result = append(result, NewApiChange(
-									RequestPropertyContentSchemaAddedId,
-									config,
-									[]any{propName},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(nil, propRevisionSource).WithDetails(mediaTypeDetails))
-							}
-							if propertyDiff.ContentSchemaDiff.SchemaDeleted {
-								result = append(result, NewApiChange(
-									RequestPropertyContentSchemaRemovedId,
-									config,
-									[]any{propName},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(propBaseSource, nil).WithDetails(mediaTypeDetails))
-							}
-						}
-
-						if propertyDiff.ContentMediaTypeDiff != nil {
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "contentMediaType")
-							d := propertyDiff.ContentMediaTypeDiff
-							result = append(result, NewApiChange(
-								RequestPropertyContentMediaTypeChangedId,
-								config,
-								[]any{propName, d.From, d.To},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						}
-
-						if propertyDiff.ContentEncodingDiff != nil {
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "contentEncoding")
-							d := propertyDiff.ContentEncodingDiff
-							result = append(result, NewApiChange(
-								RequestPropertyContentEncodingChangedId,
-								config,
-								[]any{propName, d.From, d.To},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						}
-					})
+			if info.schemaDiff.ContentSchemaDiff.SchemaDeleted {
+				result = append(result, info.newChange(RequestBodyContentSchemaRemovedId, nil, "").
+					WithSources(baseSource, nil))
 			}
 		}
-	}
+
+		if info.schemaDiff.ContentMediaTypeDiff != nil {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "contentMediaType")
+			d := info.schemaDiff.ContentMediaTypeDiff
+			result = append(result, info.newChange(RequestBodyContentMediaTypeChangedId, []any{d.From, d.To}, "").
+				WithSources(baseSource, revisionSource))
+		}
+
+		if info.schemaDiff.ContentEncodingDiff != nil {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "contentEncoding")
+			d := info.schemaDiff.ContentEncodingDiff
+			result = append(result, info.newChange(RequestBodyContentEncodingChangedId, []any{d.From, d.To}, "").
+				WithSources(baseSource, revisionSource))
+		}
+
+		info.walkProperties(func(p propertyInfo) {
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+
+			if p.propertyDiff.ContentSchemaDiff != nil {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "contentSchema")
+				if p.propertyDiff.ContentSchemaDiff.SchemaAdded {
+					result = append(result, p.newChange(RequestPropertyContentSchemaAddedId, []any{propName}, "").
+						WithSources(nil, propRevisionSource))
+				}
+				if p.propertyDiff.ContentSchemaDiff.SchemaDeleted {
+					result = append(result, p.newChange(RequestPropertyContentSchemaRemovedId, []any{propName}, "").
+						WithSources(propBaseSource, nil))
+				}
+			}
+
+			if p.propertyDiff.ContentMediaTypeDiff != nil {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "contentMediaType")
+				d := p.propertyDiff.ContentMediaTypeDiff
+				result = append(result, p.newChange(RequestPropertyContentMediaTypeChangedId, []any{propName, d.From, d.To}, "").
+					WithSources(propBaseSource, propRevisionSource))
+			}
+
+			if p.propertyDiff.ContentEncodingDiff != nil {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "contentEncoding")
+				d := p.propertyDiff.ContentEncodingDiff
+				result = append(result, p.newChange(RequestPropertyContentEncodingChangedId, []any{propName, d.From, d.To}, "").
+					WithSources(propBaseSource, propRevisionSource))
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_request_property_property_names_updated.go
+++ b/checker/check_request_property_property_names_updated.go
@@ -13,90 +13,36 @@ const (
 
 func RequestPropertyPropertyNamesUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
+
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if info.schemaDiff.PropertyNamesDiff != nil {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "propertyNames")
+			if info.schemaDiff.PropertyNamesDiff.SchemaAdded {
+				result = append(result, info.newChange(RequestBodyPropertyNamesAddedId, nil, "").
+					WithSources(nil, revisionSource))
 			}
-
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				if mediaTypeDiff.SchemaDiff == nil {
-					continue
-				}
-
-				if mediaTypeDiff.SchemaDiff.PropertyNamesDiff != nil {
-					baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "propertyNames")
-					if mediaTypeDiff.SchemaDiff.PropertyNamesDiff.SchemaAdded {
-						result = append(result, NewApiChange(
-							RequestBodyPropertyNamesAddedId,
-							config,
-							nil,
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-					}
-					if mediaTypeDiff.SchemaDiff.PropertyNamesDiff.SchemaDeleted {
-						result = append(result, NewApiChange(
-							RequestBodyPropertyNamesRemovedId,
-							config,
-							nil,
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-					}
-				}
-
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						if propertyDiff.PropertyNamesDiff == nil {
-							return
-						}
-						propName := propertyFullName(propertyPath, propertyName)
-						propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "propertyNames")
-						if propertyDiff.PropertyNamesDiff.SchemaAdded {
-							result = append(result, NewApiChange(
-								RequestPropertyPropertyNamesAddedId,
-								config,
-								[]any{propName},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(nil, propRevisionSource).WithDetails(mediaTypeDetails))
-						}
-						if propertyDiff.PropertyNamesDiff.SchemaDeleted {
-							result = append(result, NewApiChange(
-								RequestPropertyPropertyNamesRemovedId,
-								config,
-								[]any{propName},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, nil).WithDetails(mediaTypeDetails))
-						}
-					})
+			if info.schemaDiff.PropertyNamesDiff.SchemaDeleted {
+				result = append(result, info.newChange(RequestBodyPropertyNamesRemovedId, nil, "").
+					WithSources(baseSource, nil))
 			}
 		}
-	}
+
+		info.walkProperties(func(p propertyInfo) {
+			if p.propertyDiff.PropertyNamesDiff == nil {
+				return
+			}
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "propertyNames")
+			if p.propertyDiff.PropertyNamesDiff.SchemaAdded {
+				result = append(result, p.newChange(RequestPropertyPropertyNamesAddedId, []any{propName}, "").
+					WithSources(nil, propRevisionSource))
+			}
+			if p.propertyDiff.PropertyNamesDiff.SchemaDeleted {
+				result = append(result, p.newChange(RequestPropertyPropertyNamesRemovedId, []any{propName}, "").
+					WithSources(propBaseSource, nil))
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_request_property_unevaluated_updated.go
+++ b/checker/check_request_property_unevaluated_updated.go
@@ -18,146 +18,60 @@ const (
 
 func RequestPropertyUnevaluatedUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
+
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if info.schemaDiff.UnevaluatedItemsDiff != nil {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "unevaluatedItems")
+			if info.schemaDiff.UnevaluatedItemsDiff.SchemaAdded {
+				result = append(result, info.newChange(RequestBodyUnevaluatedItemsAddedId, nil, "").
+					WithSources(nil, revisionSource))
 			}
-
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				if mediaTypeDiff.SchemaDiff == nil {
-					continue
-				}
-
-				if mediaTypeDiff.SchemaDiff.UnevaluatedItemsDiff != nil {
-					baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "unevaluatedItems")
-					if mediaTypeDiff.SchemaDiff.UnevaluatedItemsDiff.SchemaAdded {
-						result = append(result, NewApiChange(
-							RequestBodyUnevaluatedItemsAddedId,
-							config,
-							nil,
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-					}
-					if mediaTypeDiff.SchemaDiff.UnevaluatedItemsDiff.SchemaDeleted {
-						result = append(result, NewApiChange(
-							RequestBodyUnevaluatedItemsRemovedId,
-							config,
-							nil,
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-					}
-				}
-
-				if mediaTypeDiff.SchemaDiff.UnevaluatedPropertiesDiff != nil {
-					baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "unevaluatedProperties")
-					if mediaTypeDiff.SchemaDiff.UnevaluatedPropertiesDiff.SchemaAdded {
-						result = append(result, NewApiChange(
-							RequestBodyUnevaluatedPropertiesAddedId,
-							config,
-							nil,
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-					}
-					if mediaTypeDiff.SchemaDiff.UnevaluatedPropertiesDiff.SchemaDeleted {
-						result = append(result, NewApiChange(
-							RequestBodyUnevaluatedPropertiesRemovedId,
-							config,
-							nil,
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-					}
-				}
-
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						propName := propertyFullName(propertyPath, propertyName)
-
-						if propertyDiff.UnevaluatedItemsDiff != nil {
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "unevaluatedItems")
-							if propertyDiff.UnevaluatedItemsDiff.SchemaAdded {
-								result = append(result, NewApiChange(
-									RequestPropertyUnevaluatedItemsAddedId,
-									config,
-									[]any{propName},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(nil, propRevisionSource).WithDetails(mediaTypeDetails))
-							}
-							if propertyDiff.UnevaluatedItemsDiff.SchemaDeleted {
-								result = append(result, NewApiChange(
-									RequestPropertyUnevaluatedItemsRemovedId,
-									config,
-									[]any{propName},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(propBaseSource, nil).WithDetails(mediaTypeDetails))
-							}
-						}
-
-						if propertyDiff.UnevaluatedPropertiesDiff != nil {
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "unevaluatedProperties")
-							if propertyDiff.UnevaluatedPropertiesDiff.SchemaAdded {
-								result = append(result, NewApiChange(
-									RequestPropertyUnevaluatedPropertiesAddedId,
-									config,
-									[]any{propName},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(nil, propRevisionSource).WithDetails(mediaTypeDetails))
-							}
-							if propertyDiff.UnevaluatedPropertiesDiff.SchemaDeleted {
-								result = append(result, NewApiChange(
-									RequestPropertyUnevaluatedPropertiesRemovedId,
-									config,
-									[]any{propName},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(propBaseSource, nil).WithDetails(mediaTypeDetails))
-							}
-						}
-					})
+			if info.schemaDiff.UnevaluatedItemsDiff.SchemaDeleted {
+				result = append(result, info.newChange(RequestBodyUnevaluatedItemsRemovedId, nil, "").
+					WithSources(baseSource, nil))
 			}
 		}
-	}
+
+		if info.schemaDiff.UnevaluatedPropertiesDiff != nil {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "unevaluatedProperties")
+			if info.schemaDiff.UnevaluatedPropertiesDiff.SchemaAdded {
+				result = append(result, info.newChange(RequestBodyUnevaluatedPropertiesAddedId, nil, "").
+					WithSources(nil, revisionSource))
+			}
+			if info.schemaDiff.UnevaluatedPropertiesDiff.SchemaDeleted {
+				result = append(result, info.newChange(RequestBodyUnevaluatedPropertiesRemovedId, nil, "").
+					WithSources(baseSource, nil))
+			}
+		}
+
+		info.walkProperties(func(p propertyInfo) {
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+
+			if p.propertyDiff.UnevaluatedItemsDiff != nil {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "unevaluatedItems")
+				if p.propertyDiff.UnevaluatedItemsDiff.SchemaAdded {
+					result = append(result, p.newChange(RequestPropertyUnevaluatedItemsAddedId, []any{propName}, "").
+						WithSources(nil, propRevisionSource))
+				}
+				if p.propertyDiff.UnevaluatedItemsDiff.SchemaDeleted {
+					result = append(result, p.newChange(RequestPropertyUnevaluatedItemsRemovedId, []any{propName}, "").
+						WithSources(propBaseSource, nil))
+				}
+			}
+
+			if p.propertyDiff.UnevaluatedPropertiesDiff != nil {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "unevaluatedProperties")
+				if p.propertyDiff.UnevaluatedPropertiesDiff.SchemaAdded {
+					result = append(result, p.newChange(RequestPropertyUnevaluatedPropertiesAddedId, []any{propName}, "").
+						WithSources(nil, propRevisionSource))
+				}
+				if p.propertyDiff.UnevaluatedPropertiesDiff.SchemaDeleted {
+					result = append(result, p.newChange(RequestPropertyUnevaluatedPropertiesRemovedId, []any{propName}, "").
+						WithSources(propBaseSource, nil))
+				}
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_response_property_content_updated.go
+++ b/checker/check_response_property_content_updated.go
@@ -18,154 +18,64 @@ const (
 
 func ResponsePropertyContentUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil || operationItem.ResponsesDiff.Modified == nil {
-				continue
+
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if info.schemaDiff.ContentSchemaDiff != nil {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "contentSchema")
+			if info.schemaDiff.ContentSchemaDiff.SchemaAdded {
+				result = append(result, info.newChange(ResponseBodyContentSchemaAddedId, []any{info.responseStatus}, "").
+					WithSources(nil, revisionSource))
 			}
-
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff.ContentDiff == nil || responseDiff.ContentDiff.MediaTypeModified == nil {
-					continue
-				}
-
-				modifiedMediaTypes := responseDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					if mediaTypeDiff.SchemaDiff == nil {
-						continue
-					}
-
-					if mediaTypeDiff.SchemaDiff.ContentSchemaDiff != nil {
-						baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "contentSchema")
-						if mediaTypeDiff.SchemaDiff.ContentSchemaDiff.SchemaAdded {
-							result = append(result, NewApiChange(
-								ResponseBodyContentSchemaAddedId,
-								config,
-								[]any{responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-						}
-						if mediaTypeDiff.SchemaDiff.ContentSchemaDiff.SchemaDeleted {
-							result = append(result, NewApiChange(
-								ResponseBodyContentSchemaRemovedId,
-								config,
-								[]any{responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-						}
-					}
-
-					if mediaTypeDiff.SchemaDiff.ContentMediaTypeDiff != nil {
-						baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "contentMediaType")
-						d := mediaTypeDiff.SchemaDiff.ContentMediaTypeDiff
-						result = append(result, NewApiChange(
-							ResponseBodyContentMediaTypeChangedId,
-							config,
-							[]any{d.From, d.To, responseStatus},
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-					}
-
-					if mediaTypeDiff.SchemaDiff.ContentEncodingDiff != nil {
-						baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "contentEncoding")
-						d := mediaTypeDiff.SchemaDiff.ContentEncodingDiff
-						result = append(result, NewApiChange(
-							ResponseBodyContentEncodingChangedId,
-							config,
-							[]any{d.From, d.To, responseStatus},
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-					}
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							propName := propertyFullName(propertyPath, propertyName)
-
-							if propertyDiff.ContentSchemaDiff != nil {
-								propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "contentSchema")
-								if propertyDiff.ContentSchemaDiff.SchemaAdded {
-									result = append(result, NewApiChange(
-										ResponsePropertyContentSchemaAddedId,
-										config,
-										[]any{propName, responseStatus},
-										"",
-										operationsSources,
-										operationItem.Revision,
-										operation,
-										path,
-									).WithSources(nil, propRevisionSource).WithDetails(mediaTypeDetails))
-								}
-								if propertyDiff.ContentSchemaDiff.SchemaDeleted {
-									result = append(result, NewApiChange(
-										ResponsePropertyContentSchemaRemovedId,
-										config,
-										[]any{propName, responseStatus},
-										"",
-										operationsSources,
-										operationItem.Revision,
-										operation,
-										path,
-									).WithSources(propBaseSource, nil).WithDetails(mediaTypeDetails))
-								}
-							}
-
-							if propertyDiff.ContentMediaTypeDiff != nil {
-								propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "contentMediaType")
-								d := propertyDiff.ContentMediaTypeDiff
-								result = append(result, NewApiChange(
-									ResponsePropertyContentMediaTypeChangedId,
-									config,
-									[]any{propName, d.From, d.To, responseStatus},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-							}
-
-							if propertyDiff.ContentEncodingDiff != nil {
-								propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "contentEncoding")
-								d := propertyDiff.ContentEncodingDiff
-								result = append(result, NewApiChange(
-									ResponsePropertyContentEncodingChangedId,
-									config,
-									[]any{propName, d.From, d.To, responseStatus},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-							}
-						})
-				}
+			if info.schemaDiff.ContentSchemaDiff.SchemaDeleted {
+				result = append(result, info.newChange(ResponseBodyContentSchemaRemovedId, []any{info.responseStatus}, "").
+					WithSources(baseSource, nil))
 			}
 		}
-	}
+
+		if info.schemaDiff.ContentMediaTypeDiff != nil {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "contentMediaType")
+			d := info.schemaDiff.ContentMediaTypeDiff
+			result = append(result, info.newChange(ResponseBodyContentMediaTypeChangedId, []any{d.From, d.To, info.responseStatus}, "").
+				WithSources(baseSource, revisionSource))
+		}
+
+		if info.schemaDiff.ContentEncodingDiff != nil {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "contentEncoding")
+			d := info.schemaDiff.ContentEncodingDiff
+			result = append(result, info.newChange(ResponseBodyContentEncodingChangedId, []any{d.From, d.To, info.responseStatus}, "").
+				WithSources(baseSource, revisionSource))
+		}
+
+		info.walkProperties(func(p propertyInfo) {
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+
+			if p.propertyDiff.ContentSchemaDiff != nil {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "contentSchema")
+				if p.propertyDiff.ContentSchemaDiff.SchemaAdded {
+					result = append(result, p.newChange(ResponsePropertyContentSchemaAddedId, []any{propName, info.responseStatus}, "").
+						WithSources(nil, propRevisionSource))
+				}
+				if p.propertyDiff.ContentSchemaDiff.SchemaDeleted {
+					result = append(result, p.newChange(ResponsePropertyContentSchemaRemovedId, []any{propName, info.responseStatus}, "").
+						WithSources(propBaseSource, nil))
+				}
+			}
+
+			if p.propertyDiff.ContentMediaTypeDiff != nil {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "contentMediaType")
+				d := p.propertyDiff.ContentMediaTypeDiff
+				result = append(result, p.newChange(ResponsePropertyContentMediaTypeChangedId, []any{propName, d.From, d.To, info.responseStatus}, "").
+					WithSources(propBaseSource, propRevisionSource))
+			}
+
+			if p.propertyDiff.ContentEncodingDiff != nil {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "contentEncoding")
+				d := p.propertyDiff.ContentEncodingDiff
+				result = append(result, p.newChange(ResponsePropertyContentEncodingChangedId, []any{propName, d.From, d.To, info.responseStatus}, "").
+					WithSources(propBaseSource, propRevisionSource))
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_response_property_property_names_updated.go
+++ b/checker/check_response_property_property_names_updated.go
@@ -13,94 +13,36 @@ const (
 
 func ResponsePropertyPropertyNamesUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil || operationItem.ResponsesDiff.Modified == nil {
-				continue
+
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if info.schemaDiff.PropertyNamesDiff != nil {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "propertyNames")
+			if info.schemaDiff.PropertyNamesDiff.SchemaAdded {
+				result = append(result, info.newChange(ResponseBodyPropertyNamesAddedId, []any{info.responseStatus}, "").
+					WithSources(nil, revisionSource))
 			}
-
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff.ContentDiff == nil || responseDiff.ContentDiff.MediaTypeModified == nil {
-					continue
-				}
-
-				modifiedMediaTypes := responseDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					if mediaTypeDiff.SchemaDiff == nil {
-						continue
-					}
-
-					if mediaTypeDiff.SchemaDiff.PropertyNamesDiff != nil {
-						baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "propertyNames")
-						if mediaTypeDiff.SchemaDiff.PropertyNamesDiff.SchemaAdded {
-							result = append(result, NewApiChange(
-								ResponseBodyPropertyNamesAddedId,
-								config,
-								[]any{responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-						}
-						if mediaTypeDiff.SchemaDiff.PropertyNamesDiff.SchemaDeleted {
-							result = append(result, NewApiChange(
-								ResponseBodyPropertyNamesRemovedId,
-								config,
-								[]any{responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-						}
-					}
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							if propertyDiff.PropertyNamesDiff == nil {
-								return
-							}
-							propName := propertyFullName(propertyPath, propertyName)
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "propertyNames")
-							if propertyDiff.PropertyNamesDiff.SchemaAdded {
-								result = append(result, NewApiChange(
-									ResponsePropertyPropertyNamesAddedId,
-									config,
-									[]any{propName, responseStatus},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(nil, propRevisionSource).WithDetails(mediaTypeDetails))
-							}
-							if propertyDiff.PropertyNamesDiff.SchemaDeleted {
-								result = append(result, NewApiChange(
-									ResponsePropertyPropertyNamesRemovedId,
-									config,
-									[]any{propName, responseStatus},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(propBaseSource, nil).WithDetails(mediaTypeDetails))
-							}
-						})
-				}
+			if info.schemaDiff.PropertyNamesDiff.SchemaDeleted {
+				result = append(result, info.newChange(ResponseBodyPropertyNamesRemovedId, []any{info.responseStatus}, "").
+					WithSources(baseSource, nil))
 			}
 		}
-	}
+
+		info.walkProperties(func(p propertyInfo) {
+			if p.propertyDiff.PropertyNamesDiff == nil {
+				return
+			}
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "propertyNames")
+			if p.propertyDiff.PropertyNamesDiff.SchemaAdded {
+				result = append(result, p.newChange(ResponsePropertyPropertyNamesAddedId, []any{propName, info.responseStatus}, "").
+					WithSources(nil, propRevisionSource))
+			}
+			if p.propertyDiff.PropertyNamesDiff.SchemaDeleted {
+				result = append(result, p.newChange(ResponsePropertyPropertyNamesRemovedId, []any{propName, info.responseStatus}, "").
+					WithSources(propBaseSource, nil))
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_response_property_unevaluated_updated.go
+++ b/checker/check_response_property_unevaluated_updated.go
@@ -18,150 +18,60 @@ const (
 
 func ResponsePropertyUnevaluatedUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil || operationItem.ResponsesDiff.Modified == nil {
-				continue
+
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if info.schemaDiff.UnevaluatedItemsDiff != nil {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "unevaluatedItems")
+			if info.schemaDiff.UnevaluatedItemsDiff.SchemaAdded {
+				result = append(result, info.newChange(ResponseBodyUnevaluatedItemsAddedId, []any{info.responseStatus}, "").
+					WithSources(nil, revisionSource))
 			}
-
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff.ContentDiff == nil || responseDiff.ContentDiff.MediaTypeModified == nil {
-					continue
-				}
-
-				modifiedMediaTypes := responseDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					if mediaTypeDiff.SchemaDiff == nil {
-						continue
-					}
-
-					if mediaTypeDiff.SchemaDiff.UnevaluatedItemsDiff != nil {
-						baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "unevaluatedItems")
-						if mediaTypeDiff.SchemaDiff.UnevaluatedItemsDiff.SchemaAdded {
-							result = append(result, NewApiChange(
-								ResponseBodyUnevaluatedItemsAddedId,
-								config,
-								[]any{responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-						}
-						if mediaTypeDiff.SchemaDiff.UnevaluatedItemsDiff.SchemaDeleted {
-							result = append(result, NewApiChange(
-								ResponseBodyUnevaluatedItemsRemovedId,
-								config,
-								[]any{responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-						}
-					}
-
-					if mediaTypeDiff.SchemaDiff.UnevaluatedPropertiesDiff != nil {
-						baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "unevaluatedProperties")
-						if mediaTypeDiff.SchemaDiff.UnevaluatedPropertiesDiff.SchemaAdded {
-							result = append(result, NewApiChange(
-								ResponseBodyUnevaluatedPropertiesAddedId,
-								config,
-								[]any{responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-						}
-						if mediaTypeDiff.SchemaDiff.UnevaluatedPropertiesDiff.SchemaDeleted {
-							result = append(result, NewApiChange(
-								ResponseBodyUnevaluatedPropertiesRemovedId,
-								config,
-								[]any{responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-						}
-					}
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							propName := propertyFullName(propertyPath, propertyName)
-
-							if propertyDiff.UnevaluatedItemsDiff != nil {
-								propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "unevaluatedItems")
-								if propertyDiff.UnevaluatedItemsDiff.SchemaAdded {
-									result = append(result, NewApiChange(
-										ResponsePropertyUnevaluatedItemsAddedId,
-										config,
-										[]any{propName, responseStatus},
-										"",
-										operationsSources,
-										operationItem.Revision,
-										operation,
-										path,
-									).WithSources(nil, propRevisionSource).WithDetails(mediaTypeDetails))
-								}
-								if propertyDiff.UnevaluatedItemsDiff.SchemaDeleted {
-									result = append(result, NewApiChange(
-										ResponsePropertyUnevaluatedItemsRemovedId,
-										config,
-										[]any{propName, responseStatus},
-										"",
-										operationsSources,
-										operationItem.Revision,
-										operation,
-										path,
-									).WithSources(propBaseSource, nil).WithDetails(mediaTypeDetails))
-								}
-							}
-
-							if propertyDiff.UnevaluatedPropertiesDiff != nil {
-								propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "unevaluatedProperties")
-								if propertyDiff.UnevaluatedPropertiesDiff.SchemaAdded {
-									result = append(result, NewApiChange(
-										ResponsePropertyUnevaluatedPropertiesAddedId,
-										config,
-										[]any{propName, responseStatus},
-										"",
-										operationsSources,
-										operationItem.Revision,
-										operation,
-										path,
-									).WithSources(nil, propRevisionSource).WithDetails(mediaTypeDetails))
-								}
-								if propertyDiff.UnevaluatedPropertiesDiff.SchemaDeleted {
-									result = append(result, NewApiChange(
-										ResponsePropertyUnevaluatedPropertiesRemovedId,
-										config,
-										[]any{propName, responseStatus},
-										"",
-										operationsSources,
-										operationItem.Revision,
-										operation,
-										path,
-									).WithSources(propBaseSource, nil).WithDetails(mediaTypeDetails))
-								}
-							}
-						})
-				}
+			if info.schemaDiff.UnevaluatedItemsDiff.SchemaDeleted {
+				result = append(result, info.newChange(ResponseBodyUnevaluatedItemsRemovedId, []any{info.responseStatus}, "").
+					WithSources(baseSource, nil))
 			}
 		}
-	}
+
+		if info.schemaDiff.UnevaluatedPropertiesDiff != nil {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "unevaluatedProperties")
+			if info.schemaDiff.UnevaluatedPropertiesDiff.SchemaAdded {
+				result = append(result, info.newChange(ResponseBodyUnevaluatedPropertiesAddedId, []any{info.responseStatus}, "").
+					WithSources(nil, revisionSource))
+			}
+			if info.schemaDiff.UnevaluatedPropertiesDiff.SchemaDeleted {
+				result = append(result, info.newChange(ResponseBodyUnevaluatedPropertiesRemovedId, []any{info.responseStatus}, "").
+					WithSources(baseSource, nil))
+			}
+		}
+
+		info.walkProperties(func(p propertyInfo) {
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+
+			if p.propertyDiff.UnevaluatedItemsDiff != nil {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "unevaluatedItems")
+				if p.propertyDiff.UnevaluatedItemsDiff.SchemaAdded {
+					result = append(result, p.newChange(ResponsePropertyUnevaluatedItemsAddedId, []any{propName, info.responseStatus}, "").
+						WithSources(nil, propRevisionSource))
+				}
+				if p.propertyDiff.UnevaluatedItemsDiff.SchemaDeleted {
+					result = append(result, p.newChange(ResponsePropertyUnevaluatedItemsRemovedId, []any{propName, info.responseStatus}, "").
+						WithSources(propBaseSource, nil))
+				}
+			}
+
+			if p.propertyDiff.UnevaluatedPropertiesDiff != nil {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "unevaluatedProperties")
+				if p.propertyDiff.UnevaluatedPropertiesDiff.SchemaAdded {
+					result = append(result, p.newChange(ResponsePropertyUnevaluatedPropertiesAddedId, []any{propName, info.responseStatus}, "").
+						WithSources(nil, propRevisionSource))
+				}
+				if p.propertyDiff.UnevaluatedPropertiesDiff.SchemaDeleted {
+					result = append(result, p.newChange(ResponsePropertyUnevaluatedPropertiesRemovedId, []any{propName, info.responseStatus}, "").
+						WithSources(propBaseSource, nil))
+				}
+			}
+		})
+	})
+
 	return result
 }


### PR DESCRIPTION
## What

Eighth migration batch. Three matched request/response pairs.

| Pair | Files |
|---|---|
| property_names | `check_request_property_property_names_updated.go` + `check_response_property_property_names_updated.go` |
| content_*(schema/mediaType/encoding) | `check_request_property_content_updated.go` + `check_response_property_content_updated.go` |
| unevaluated_*(items/properties) | `check_request_property_unevaluated_updated.go` + `check_response_property_unevaluated_updated.go` |

## Per-pair notes

- **property_names**: single keyword `propertyNames`. Add/Remove emit via `SchemaAdded` / `SchemaDeleted` on the diff. Standard body + property shape.
- **content_updated**: three keywords — `contentSchema`, `contentMediaType`, `contentEncoding`. `contentSchema` uses `SchemaAdded` / `SchemaDeleted`; the other two are `ValueDiff` (`From` / `To`). All three emit at body and property levels.
- **unevaluated_updated**: two OpenAPI 3.1 keywords — `unevaluatedItems`, `unevaluatedProperties`. Both `SchemaAdded` / `SchemaDeleted` at body and property levels.

No asymmetries discovered in this batch; pure refactor. Existing tests pass without modification.

## Numbers

| | Before | After | Delta |
|---|---|---|---|
| property_names (request) | 102 | 48 | -54 |
| property_names (response) | 106 | 48 | -58 |
| content_updated (request) | 167 | 81 | -86 |
| content_updated (response) | 171 | 81 | -90 |
| unevaluated_updated (request) | 163 | 77 | -86 |
| unevaluated_updated (response) | 167 | 77 | -90 |

Net **-464 lines** across the six files (252 insertions, 716 deletions per `git diff --stat`).

## Tests

Full suite green; vet clean; fmt clean. No test assertions needed updating.

## Running total

After this PR, **44** checker files are on the walker. Roughly **31** remain.