### PR TITLE
checker: migrate discriminator, dependent_required, required pairs to walker (PR-9 of #936)

### DIFF
--- a/checker/check_request_discriminator_updated.go
+++ b/checker/check_request_discriminator_updated.go
@@ -21,73 +21,32 @@ const (
 
 func RequestDiscriminatorUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
 
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		bodyBaseSource, bodyRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "discriminator")
+		appendBodyResultItem := func(messageId string, a ...any) {
+			result = append(result, info.newChange(messageId, a, "").
+				WithSources(bodyBaseSource, bodyRevisionSource))
 		}
 
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
+		processDiscriminatorDiffForRequest(
+			info.schemaDiff.DiscriminatorDiff,
+			"",
+			appendBodyResultItem)
+
+		info.walkProperties(func(p propertyInfo) {
+			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "discriminator")
+			appendPropResultItem := func(messageId string, a ...any) {
+				result = append(result, p.newChange(messageId, a, "").
+					WithSources(propBaseSource, propRevisionSource))
 			}
+			processDiscriminatorDiffForRequest(
+				p.propertyDiff.DiscriminatorDiff,
+				propertyFullName(p.propertyPath, p.propertyName),
+				appendPropResultItem)
+		})
+	})
 
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				if mediaTypeDiff.SchemaDiff == nil {
-					continue
-				}
-
-				bodyBaseSource, bodyRevisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "discriminator")
-				appendBodyResultItem := func(messageId string, a ...any) {
-					result = append(result, NewApiChange(
-						messageId,
-						config,
-						a,
-						"",
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
-					).WithSources(bodyBaseSource, bodyRevisionSource).WithDetails(mediaTypeDetails))
-				}
-
-				processDiscriminatorDiffForRequest(
-					mediaTypeDiff.SchemaDiff.DiscriminatorDiff,
-					"",
-					appendBodyResultItem)
-
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "discriminator")
-						appendPropResultItem := func(messageId string, a ...any) {
-							result = append(result, NewApiChange(
-								messageId,
-								config,
-								a,
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						}
-						processDiscriminatorDiffForRequest(
-							propertyDiff.DiscriminatorDiff,
-							propertyFullName(propertyPath, propertyName),
-							appendPropResultItem)
-					})
-
-			}
-		}
-	}
 	return result
 }
 

--- a/checker/check_request_property_dependent_required_changed.go
+++ b/checker/check_request_property_dependent_required_changed.go
@@ -17,160 +17,64 @@ const (
 
 func RequestPropertyDependentRequiredChangedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
+
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if info.schemaDiff.DependentRequiredDiff != nil {
+			depReqDiff := info.schemaDiff.DependentRequiredDiff
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "dependentRequired")
+			for key, values := range depReqDiff.Added {
+				result = append(result, info.newChange(
+					RequestBodyDependentRequiredAddedId,
+					[]any{key, strings.Join(values, ", ")},
+					"",
+				).WithSources(nil, revisionSource))
 			}
-
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				if mediaTypeDiff.SchemaDiff != nil && mediaTypeDiff.SchemaDiff.DependentRequiredDiff != nil {
-					depReqDiff := mediaTypeDiff.SchemaDiff.DependentRequiredDiff
-					baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "dependentRequired")
-					result = append(result, requestBodyDependentRequiredChanges(
-						depReqDiff, config, operationsSources, operationItem, operation, path,
-						baseSource, revisionSource, mediaTypeDetails,
-					)...)
-				}
-
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						if propertyDiff == nil || propertyDiff.DependentRequiredDiff == nil {
-							return
-						}
-
-						depReqDiff := propertyDiff.DependentRequiredDiff
-						propName := propertyFullName(propertyPath, propertyName)
-						propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "dependentRequired")
-						result = append(result, requestPropertyDependentRequiredChanges(
-							depReqDiff, config, operationsSources, operationItem, operation, path,
-							propName, propBaseSource, propRevisionSource, mediaTypeDetails,
-						)...)
-					})
+			for key, values := range depReqDiff.Deleted {
+				result = append(result, info.newChange(
+					RequestBodyDependentRequiredRemovedId,
+					[]any{key, strings.Join(values, ", ")},
+					"",
+				).WithSources(baseSource, nil))
+			}
+			for key, stringsDiff := range depReqDiff.Modified {
+				result = append(result, info.newChange(
+					RequestBodyDependentRequiredChangedId,
+					[]any{key, formatDependentRequiredModification(stringsDiff)},
+					"",
+				).WithSources(baseSource, revisionSource))
 			}
 		}
-	}
-	return result
-}
 
-func requestBodyDependentRequiredChanges(
-	depReqDiff *diff.DependentRequiredDiff,
-	config *Config,
-	operationsSources *diff.OperationsSourcesMap,
-	operationItem *diff.MethodDiff,
-	operation string,
-	path string,
-	baseSource *Source,
-	revisionSource *Source,
-	mediaTypeDetails string,
-) Changes {
-	result := make(Changes, 0)
-
-	for key, values := range depReqDiff.Added {
-		result = append(result, NewApiChange(
-			RequestBodyDependentRequiredAddedId,
-			config,
-			[]any{key, strings.Join(values, ", ")},
-			"",
-			operationsSources,
-			operationItem.Revision,
-			operation,
-			path,
-		).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-	}
-
-	for key, values := range depReqDiff.Deleted {
-		result = append(result, NewApiChange(
-			RequestBodyDependentRequiredRemovedId,
-			config,
-			[]any{key, strings.Join(values, ", ")},
-			"",
-			operationsSources,
-			operationItem.Revision,
-			operation,
-			path,
-		).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-	}
-
-	for key, stringsDiff := range depReqDiff.Modified {
-		result = append(result, NewApiChange(
-			RequestBodyDependentRequiredChangedId,
-			config,
-			[]any{key, formatDependentRequiredModification(stringsDiff)},
-			"",
-			operationsSources,
-			operationItem.Revision,
-			operation,
-			path,
-		).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-	}
-
-	return result
-}
-
-func requestPropertyDependentRequiredChanges(
-	depReqDiff *diff.DependentRequiredDiff,
-	config *Config,
-	operationsSources *diff.OperationsSourcesMap,
-	operationItem *diff.MethodDiff,
-	operation string,
-	path string,
-	propName string,
-	baseSource *Source,
-	revisionSource *Source,
-	mediaTypeDetails string,
-) Changes {
-	result := make(Changes, 0)
-
-	for key, values := range depReqDiff.Added {
-		result = append(result, NewApiChange(
-			RequestPropertyDependentRequiredAddedId,
-			config,
-			[]any{propName, key, strings.Join(values, ", ")},
-			"",
-			operationsSources,
-			operationItem.Revision,
-			operation,
-			path,
-		).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-	}
-
-	for key, values := range depReqDiff.Deleted {
-		result = append(result, NewApiChange(
-			RequestPropertyDependentRequiredRemovedId,
-			config,
-			[]any{propName, key, strings.Join(values, ", ")},
-			"",
-			operationsSources,
-			operationItem.Revision,
-			operation,
-			path,
-		).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-	}
-
-	for key, stringsDiff := range depReqDiff.Modified {
-		result = append(result, NewApiChange(
-			RequestPropertyDependentRequiredChangedId,
-			config,
-			[]any{propName, key, formatDependentRequiredModification(stringsDiff)},
-			"",
-			operationsSources,
-			operationItem.Revision,
-			operation,
-			path,
-		).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-	}
+		info.walkProperties(func(p propertyInfo) {
+			if p.propertyDiff.DependentRequiredDiff == nil {
+				return
+			}
+			depReqDiff := p.propertyDiff.DependentRequiredDiff
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "dependentRequired")
+			for key, values := range depReqDiff.Added {
+				result = append(result, p.newChange(
+					RequestPropertyDependentRequiredAddedId,
+					[]any{propName, key, strings.Join(values, ", ")},
+					"",
+				).WithSources(nil, propRevisionSource))
+			}
+			for key, values := range depReqDiff.Deleted {
+				result = append(result, p.newChange(
+					RequestPropertyDependentRequiredRemovedId,
+					[]any{propName, key, strings.Join(values, ", ")},
+					"",
+				).WithSources(propBaseSource, nil))
+			}
+			for key, stringsDiff := range depReqDiff.Modified {
+				result = append(result, p.newChange(
+					RequestPropertyDependentRequiredChangedId,
+					[]any{propName, key, formatDependentRequiredModification(stringsDiff)},
+					"",
+				).WithSources(propBaseSource, propRevisionSource))
+			}
+		})
+	})
 
 	return result
 }

--- a/checker/check_request_property_required_updated.go
+++ b/checker/check_request_property_required_updated.go
@@ -12,90 +12,45 @@ const (
 
 func RequestPropertyRequiredUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
 
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		processRequiredDiff := func(schemaDiff *diff.SchemaDiff, propertyPath string, propertyName string) {
+			if schemaDiff.RequiredDiff == nil {
+				return
 			}
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				if mediaTypeDiff.SchemaDiff == nil {
+			for _, changedRequiredPropertyName := range schemaDiff.RequiredDiff.Added {
+				if !changedRequiredPropertyRelevant(schemaDiff, changedRequiredPropertyName) {
 					continue
 				}
-
-				processRequestPropertyRequiredDiff := func(schemaDiff *diff.SchemaDiff, propertyPath string, propertyName string) {
-					if schemaDiff.RequiredDiff != nil {
-						for _, changedRequiredPropertyName := range schemaDiff.RequiredDiff.Added {
-							if !changedRequiredPropertyRelevant(schemaDiff, changedRequiredPropertyName) {
-								continue
-							}
-
-							srcBase, srcRevision := SchemaAddedItemSources(operationsSources, operationItem, schemaDiff, "required", changedRequiredPropertyName)
-							if schemaDiff.Revision.Properties[changedRequiredPropertyName].Value.Default == nil {
-								result = append(result, NewApiChange(
-									RequestPropertyBecameRequiredId,
-									config,
-									[]any{propertyFullName(propertyPath, propertyFullName(propertyName, changedRequiredPropertyName))},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(srcBase, srcRevision).WithDetails(mediaTypeDetails))
-							} else {
-								// property has a default value, so making it required is not a breaking change
-								result = append(result, NewApiChange(
-									RequestPropertyBecameRequiredWithDefaultId,
-									config,
-									[]any{propertyFullName(propertyPath, propertyFullName(propertyName, changedRequiredPropertyName))},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(srcBase, srcRevision).WithDetails(mediaTypeDetails))
-							}
-						}
-						for _, changedRequiredPropertyName := range schemaDiff.RequiredDiff.Deleted {
-							if !changedRequiredPropertyRelevant(schemaDiff, changedRequiredPropertyName) {
-								continue
-							}
-
-							srcBase, srcRevision := SchemaDeletedItemSources(operationsSources, operationItem, schemaDiff, "required", changedRequiredPropertyName)
-							result = append(result, NewApiChange(
-								RequestPropertyBecameOptionalId,
-								config,
-								[]any{propertyFullName(propertyPath, propertyFullName(propertyName, changedRequiredPropertyName))},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(srcBase, srcRevision).WithDetails(mediaTypeDetails))
-						}
-					}
+				srcBase, srcRevision := SchemaAddedItemSources(operationsSources, info.operationItem, schemaDiff, "required", changedRequiredPropertyName)
+				args := []any{propertyFullName(propertyPath, propertyFullName(propertyName, changedRequiredPropertyName))}
+				if schemaDiff.Revision.Properties[changedRequiredPropertyName].Value.Default == nil {
+					result = append(result, info.newChange(RequestPropertyBecameRequiredId, args, "").
+						WithSources(srcBase, srcRevision))
+				} else {
+					// property has a default value, so making it required is not a breaking change
+					result = append(result, info.newChange(RequestPropertyBecameRequiredWithDefaultId, args, "").
+						WithSources(srcBase, srcRevision))
 				}
-
-				processRequestPropertyRequiredDiff(mediaTypeDiff.SchemaDiff, "", "")
-
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, _ *diff.SchemaDiff) {
-						processRequestPropertyRequiredDiff(propertyDiff, propertyPath, propertyName)
-					})
+			}
+			for _, changedRequiredPropertyName := range schemaDiff.RequiredDiff.Deleted {
+				if !changedRequiredPropertyRelevant(schemaDiff, changedRequiredPropertyName) {
+					continue
+				}
+				srcBase, srcRevision := SchemaDeletedItemSources(operationsSources, info.operationItem, schemaDiff, "required", changedRequiredPropertyName)
+				args := []any{propertyFullName(propertyPath, propertyFullName(propertyName, changedRequiredPropertyName))}
+				result = append(result, info.newChange(RequestPropertyBecameOptionalId, args, "").
+					WithSources(srcBase, srcRevision))
 			}
 		}
-	}
+
+		processRequiredDiff(info.schemaDiff, "", "")
+
+		info.walkProperties(func(p propertyInfo) {
+			processRequiredDiff(p.propertyDiff, p.propertyPath, p.propertyName)
+		})
+	})
+
 	return result
 }
 

--- a/checker/check_response_discriminator_updated.go
+++ b/checker/check_response_discriminator_updated.go
@@ -21,78 +21,34 @@ const (
 
 func ResponseDiscriminatorUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
 
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "discriminator")
+		appendResultItem := func(messageId string, a ...any) {
+			result = append(result, info.newChange(messageId, a, "").
+				WithSources(baseSource, revisionSource))
 		}
 
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil || operationItem.ResponsesDiff.Modified == nil {
-				continue
+		processDiscriminatorDiff(
+			info.schemaDiff.DiscriminatorDiff,
+			info.responseStatus,
+			"",
+			appendResultItem)
+
+		info.walkProperties(func(p propertyInfo) {
+			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "discriminator")
+			propAppendResultItem := func(messageId string, a ...any) {
+				result = append(result, p.newChange(messageId, a, "").
+					WithSources(propBaseSource, propRevisionSource))
 			}
+			processDiscriminatorDiff(
+				p.propertyDiff.DiscriminatorDiff,
+				info.responseStatus,
+				propertyFullName(p.propertyPath, p.propertyName),
+				propAppendResultItem)
+		})
+	})
 
-			for responseStatus, responsesDiff := range operationItem.ResponsesDiff.Modified {
-				if responsesDiff.ContentDiff == nil || responsesDiff.ContentDiff.MediaTypeModified == nil {
-					continue
-				}
-
-				modifiedMediaTypes := responsesDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					if mediaTypeDiff.SchemaDiff == nil {
-						continue
-					}
-
-					baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "discriminator")
-					appendResultItem := func(messageId string, a ...any) {
-						result = append(result, NewApiChange(
-							messageId,
-							config,
-							a,
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-					}
-
-					processDiscriminatorDiff(
-						mediaTypeDiff.SchemaDiff.DiscriminatorDiff,
-						responseStatus,
-						"",
-						appendResultItem)
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "discriminator")
-							propAppendResultItem := func(messageId string, a ...any) {
-								result = append(result, NewApiChange(
-									messageId,
-									config,
-									a,
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-							}
-							processDiscriminatorDiff(
-								propertyDiff.DiscriminatorDiff,
-								responseStatus,
-								propertyFullName(propertyPath, propertyName),
-								propAppendResultItem)
-						})
-				}
-			}
-		}
-	}
 	return result
 }
 

--- a/checker/check_response_property_dependent_required_changed.go
+++ b/checker/check_response_property_dependent_required_changed.go
@@ -17,172 +17,64 @@ const (
 
 func ResponsePropertyDependentRequiredChangedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil || operationItem.ResponsesDiff.Modified == nil {
-				continue
+
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if info.schemaDiff.DependentRequiredDiff != nil {
+			depReqDiff := info.schemaDiff.DependentRequiredDiff
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "dependentRequired")
+			for key, values := range depReqDiff.Added {
+				result = append(result, info.newChange(
+					ResponseBodyDependentRequiredAddedId,
+					[]any{info.responseStatus, key, strings.Join(values, ", ")},
+					"",
+				).WithSources(nil, revisionSource))
 			}
-
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff.ContentDiff == nil || responseDiff.ContentDiff.MediaTypeModified == nil {
-					continue
-				}
-
-				modifiedMediaTypes := responseDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					if mediaTypeDiff.SchemaDiff != nil && mediaTypeDiff.SchemaDiff.DependentRequiredDiff != nil {
-						depReqDiff := mediaTypeDiff.SchemaDiff.DependentRequiredDiff
-						baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "dependentRequired")
-						result = append(result, responseBodyDependentRequiredChanges(
-							depReqDiff, config, operationsSources, operationItem, operation, path,
-							responseStatus, baseSource, revisionSource, mediaTypeDetails,
-						)...)
-					}
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							if propertyDiff == nil || propertyDiff.DependentRequiredDiff == nil {
-								return
-							}
-
-							depReqDiff := propertyDiff.DependentRequiredDiff
-							propName := propertyFullName(propertyPath, propertyName)
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "dependentRequired")
-							result = append(result, responsePropertyDependentRequiredChanges(
-								depReqDiff, config, operationsSources, operationItem, operation, path,
-								responseStatus, propName, propBaseSource, propRevisionSource, mediaTypeDetails,
-							)...)
-						})
-				}
+			for key, values := range depReqDiff.Deleted {
+				result = append(result, info.newChange(
+					ResponseBodyDependentRequiredRemovedId,
+					[]any{info.responseStatus, key, strings.Join(values, ", ")},
+					"",
+				).WithSources(baseSource, nil))
+			}
+			for key, stringsDiff := range depReqDiff.Modified {
+				result = append(result, info.newChange(
+					ResponseBodyDependentRequiredChangedId,
+					[]any{key, info.responseStatus, formatDependentRequiredModification(stringsDiff)},
+					"",
+				).WithSources(baseSource, revisionSource))
 			}
 		}
-	}
-	return result
-}
 
-func responseBodyDependentRequiredChanges(
-	depReqDiff *diff.DependentRequiredDiff,
-	config *Config,
-	operationsSources *diff.OperationsSourcesMap,
-	operationItem *diff.MethodDiff,
-	operation string,
-	path string,
-	responseStatus string,
-	baseSource *Source,
-	revisionSource *Source,
-	mediaTypeDetails string,
-) Changes {
-	result := make(Changes, 0)
-
-	// message: "the response body dependentRequired was added for the status %s: when '%s' is present, '%s' are required"
-	for key, values := range depReqDiff.Added {
-		result = append(result, NewApiChange(
-			ResponseBodyDependentRequiredAddedId,
-			config,
-			[]any{responseStatus, key, strings.Join(values, ", ")},
-			"",
-			operationsSources,
-			operationItem.Revision,
-			operation,
-			path,
-		).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-	}
-
-	// message: "the response body dependentRequired was removed for the status %s: when '%s' was present, '%s' were required"
-	for key, values := range depReqDiff.Deleted {
-		result = append(result, NewApiChange(
-			ResponseBodyDependentRequiredRemovedId,
-			config,
-			[]any{responseStatus, key, strings.Join(values, ", ")},
-			"",
-			operationsSources,
-			operationItem.Revision,
-			operation,
-			path,
-		).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-	}
-
-	// message: "the response body dependentRequired for '%s' was updated for the status %s: %s"
-	for key, stringsDiff := range depReqDiff.Modified {
-		result = append(result, NewApiChange(
-			ResponseBodyDependentRequiredChangedId,
-			config,
-			[]any{key, responseStatus, formatDependentRequiredModification(stringsDiff)},
-			"",
-			operationsSources,
-			operationItem.Revision,
-			operation,
-			path,
-		).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-	}
-
-	return result
-}
-
-func responsePropertyDependentRequiredChanges(
-	depReqDiff *diff.DependentRequiredDiff,
-	config *Config,
-	operationsSources *diff.OperationsSourcesMap,
-	operationItem *diff.MethodDiff,
-	operation string,
-	path string,
-	responseStatus string,
-	propName string,
-	baseSource *Source,
-	revisionSource *Source,
-	mediaTypeDetails string,
-) Changes {
-	result := make(Changes, 0)
-
-	// message: "the %s response property dependentRequired was added for the status %s: when '%s' is present, '%s' are required"
-	for key, values := range depReqDiff.Added {
-		result = append(result, NewApiChange(
-			ResponsePropertyDependentRequiredAddedId,
-			config,
-			[]any{propName, responseStatus, key, strings.Join(values, ", ")},
-			"",
-			operationsSources,
-			operationItem.Revision,
-			operation,
-			path,
-		).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-	}
-
-	// message: "the %s response property dependentRequired was removed for the status %s: when '%s' was present, '%s' were required"
-	for key, values := range depReqDiff.Deleted {
-		result = append(result, NewApiChange(
-			ResponsePropertyDependentRequiredRemovedId,
-			config,
-			[]any{propName, responseStatus, key, strings.Join(values, ", ")},
-			"",
-			operationsSources,
-			operationItem.Revision,
-			operation,
-			path,
-		).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-	}
-
-	// message: "the %s response property dependentRequired for '%s' was updated for the status %s: %s"
-	for key, stringsDiff := range depReqDiff.Modified {
-		result = append(result, NewApiChange(
-			ResponsePropertyDependentRequiredChangedId,
-			config,
-			[]any{propName, key, responseStatus, formatDependentRequiredModification(stringsDiff)},
-			"",
-			operationsSources,
-			operationItem.Revision,
-			operation,
-			path,
-		).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-	}
+		info.walkProperties(func(p propertyInfo) {
+			if p.propertyDiff.DependentRequiredDiff == nil {
+				return
+			}
+			depReqDiff := p.propertyDiff.DependentRequiredDiff
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "dependentRequired")
+			for key, values := range depReqDiff.Added {
+				result = append(result, p.newChange(
+					ResponsePropertyDependentRequiredAddedId,
+					[]any{propName, info.responseStatus, key, strings.Join(values, ", ")},
+					"",
+				).WithSources(nil, propRevisionSource))
+			}
+			for key, values := range depReqDiff.Deleted {
+				result = append(result, p.newChange(
+					ResponsePropertyDependentRequiredRemovedId,
+					[]any{propName, info.responseStatus, key, strings.Join(values, ", ")},
+					"",
+				).WithSources(propBaseSource, nil))
+			}
+			for key, stringsDiff := range depReqDiff.Modified {
+				result = append(result, p.newChange(
+					ResponsePropertyDependentRequiredChangedId,
+					[]any{propName, key, info.responseStatus, formatDependentRequiredModification(stringsDiff)},
+					"",
+				).WithSources(propBaseSource, propRevisionSource))
+			}
+		})
+	})
 
 	return result
 }

--- a/checker/check_response_required_property_updated.go
+++ b/checker/check_response_required_property_updated.go
@@ -1,9 +1,10 @@
 package checker
 
 import (
+	"slices"
+
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
-	"slices"
 )
 
 const (
@@ -15,79 +16,51 @@ const (
 
 func ResponseRequiredPropertyUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
 
-			if operationItem.ResponsesDiff == nil {
-				continue
-			}
-
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff.ContentDiff == nil ||
-					responseDiff.ContentDiff.MediaTypeModified == nil {
-					continue
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		// CheckDeletedPropertiesDiff / CheckAddedPropertiesDiff walk
+		// properties that were dropped or introduced entirely, not just
+		// modified ones — different from info.walkProperties, which
+		// delegates to CheckModifiedPropertiesDiff. Used directly here.
+		CheckDeletedPropertiesDiff(
+			info.schemaDiff,
+			func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, parent *diff.SchemaDiff) {
+				id := ResponseRequiredPropertyRemovedId
+				if propertyItem.WriteOnly {
+					id = ResponseRequiredWriteOnlyPropertyRemovedId
+				}
+				if !slices.Contains(parent.Base.Required, propertyName) {
+					// Covered by response-optional-property-removed
+					return
 				}
 
-				modifiedMediaTypes := responseDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					CheckDeletedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, parent *diff.SchemaDiff) {
-							id := ResponseRequiredPropertyRemovedId
-							if propertyItem.WriteOnly {
-								id = ResponseRequiredWriteOnlyPropertyRemovedId
-							}
-							if !slices.Contains(parent.Base.Required, propertyName) {
-								// Covered by response-optional-property-removed
-								return
-							}
-
-							baseSource := propertySource(operationsSources, operationItem.Base, propertyItem)
-							result = append(result, NewApiChange(
-								id,
-								config,
-								[]any{propertyFullName(propertyPath, propertyName), responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-						})
-					CheckAddedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, parent *diff.SchemaDiff) {
-							id := ResponseRequiredPropertyAddedId
-							if propertyItem.WriteOnly {
-								id = ResponseRequiredWriteOnlyPropertyAddedId
-							}
-							if !slices.Contains(parent.Revision.Required, propertyName) {
-								// Covered by response-optional-property-added
-								return
-							}
-
-							revisionSource := propertySource(operationsSources, operationItem.Revision, propertyItem)
-							result = append(result, NewApiChange(
-								id,
-								config,
-								[]any{propertyFullName(propertyPath, propertyName), responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-						})
+				baseSource := propertySource(operationsSources, info.operationItem.Base, propertyItem)
+				result = append(result, info.newChange(
+					id,
+					[]any{propertyFullName(propertyPath, propertyName), info.responseStatus},
+					"",
+				).WithSources(baseSource, nil))
+			})
+		CheckAddedPropertiesDiff(
+			info.schemaDiff,
+			func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, parent *diff.SchemaDiff) {
+				id := ResponseRequiredPropertyAddedId
+				if propertyItem.WriteOnly {
+					id = ResponseRequiredWriteOnlyPropertyAddedId
 				}
-			}
-		}
-	}
+				if !slices.Contains(parent.Revision.Required, propertyName) {
+					// Covered by response-optional-property-added
+					return
+				}
+
+				revisionSource := propertySource(operationsSources, info.operationItem.Revision, propertyItem)
+				result = append(result, info.newChange(
+					id,
+					[]any{propertyFullName(propertyPath, propertyName), info.responseStatus},
+					"",
+				).WithSources(nil, revisionSource))
+			})
+	})
+
 	return result
 }


### PR DESCRIPTION
## What

Ninth migration batch. Three matched request/response pairs.

| Pair | Files |
|---|---|
| discriminator | `check_request_discriminator_updated.go` + `check_response_discriminator_updated.go` |
| dependent_required | `check_request_property_dependent_required_changed.go` + `check_response_property_dependent_required_changed.go` |
| required | `check_request_property_required_updated.go` + `check_response_required_property_updated.go` |

## Per-pair notes

- **discriminator** delegates to `processDiscriminatorDiffForRequest` / `processDiscriminatorDiff` (existing helpers, untouched). The walker callback wraps `info.newChange` / `p.newChange` in a small `appendResultItem` closure that the helper invokes for each emit.
- **dependent_required** previously had four helper funcs (body/property × request/response). The walker form inlines all four into the callbacks since the migration drops most of the helpers' parameters (config, operationsSources, operationItem, operation, path, details all flow from `info`). Net result is about half the original lines.
- **required (request)** uses a closure that handles both body and property levels — preserved. **required (response)** is an oddball: it uses `CheckDeletedPropertiesDiff` / `CheckAddedPropertiesDiff` (not `CheckModifiedPropertiesDiff`), which walk added / dropped properties, not modified ones. The walker's `info.walkProperties` only covers modified. The migration replaces the outer media-type loops with the walker but leaves the Deleted/Added property primitives in place inside the callback. Worth a follow-up: add sibling helpers `walkAddedProperties` / `walkDeletedProperties` to the walker if more checkers turn out to need them.

No asymmetries discovered in this batch; pure refactor. Existing tests pass without modification.

## Numbers

| | Before | After | Delta |
|---|---|---|---|
| discriminator (request) | 177 | 136 | -41 |
| discriminator (response) | 191 | 147 | -44 |
| dependent_required (request) | 176 | 80 | -96 |
| dependent_required (response) | 188 | 80 | -108 |
| required (request) | 117 | 72 | -45 |
| required (response) | 93 | 66 | -27 |

Net **-361 lines** across the six files (227 insertions, 588 deletions per `git diff --stat`).

## Tests

Full suite green; vet clean; fmt clean. No test assertions needed updating.

## Running total

After this PR, **50** checker files are on the walker. Roughly **25** remain — two-thirds done.