### PR TITLE
Add git-diff-driver subcommand to show OpenAPI changes inline in git log

### DIFF
--- a/docs/GIT-DIFF-DRIVER.md
+++ b/docs/GIT-DIFF-DRIVER.md
@@ -1,0 +1,72 @@
+# Git Diff Driver
+
+oasdiff can run as a [git external diff driver](https://git-scm.com/docs/git#Documentation/git.txt-codeGITEXTERNALDIFFcode) so that `git log --patch`, `git diff`, and `git show` render a human-readable changelog of OpenAPI changes inline, instead of a raw YAML text diff.
+
+Inspired by [Jamie Tanna's post on using oasdiff as a git diff driver](https://www.jvt.me/posts/2026/04/11/oasdiff-driver/). The previous bash wrapper described there is no longer needed.
+
+## Setup
+
+Two one-time configuration lines, run from your repo:
+
+```bash
+git config diff.oasdiff.command "oasdiff git-diff-driver"
+echo "openapi.yaml diff=oasdiff" >> .gitattributes
+```
+
+Replace `openapi.yaml` with the actual spec path (or a glob like `**/openapi.yaml` for multi-spec repos). Commit the `.gitattributes` change so teammates pick it up.
+
+## Usage
+
+```bash
+git log --patch --ext-diff -- openapi.yaml
+```
+
+For each commit that touched `openapi.yaml`, instead of the raw YAML hunks you'll see the same human-readable changelog `oasdiff changelog` would emit:
+
+```
+commit aed51e7b25195d82c3edd76caab75c4e1a2a2922
+Author: Jane <jane@example.com>
+Date:   Thu May 28 15:14:56 2026 +0300
+
+    v2
+
+1 changes: 0 error, 0 warning, 1 info
+info  [response-non-success-status-added] at openapi.yaml
+        in API GET /pets
+                added the non-success response with the status `404`
+
+
+commit 7dd4bdb866153dcd3e7cbc47d41953f05ff671c6
+Author: Jane <jane@example.com>
+Date:   Thu May 28 15:14:56 2026 +0300
+
+    v1
+
+Added openapi.yaml
+```
+
+`--ext-diff` activates the configured diff driver. Without it, git shows the raw text diff. You can make `--ext-diff` the default for a workflow by setting `diff.external` in git config (see git's docs).
+
+## What's handled
+
+| Case | Output |
+|---|---|
+| Both versions exist (normal modification) | Full changelog between the two blob versions |
+| File added (root commit, or new file) | `Added <path>` |
+| File deleted | `Removed <path>` |
+| Mode-only change (chmod) | Empty — git's own machinery already prints the mode delta |
+| Load error (malformed spec, etc.) | Error surfaced inline; the diff pipeline continues for other files |
+
+## Why GET, not git's temp files
+
+`git-diff-driver` ignores the temp file paths git passes (`/tmp/.git-blob-xxxxx`) and re-reads each blob directly via `git cat-file blob <hex>`. The source labels in the output are the short hex of the blob plus the in-tree path (e.g. `abc1234:openapi.yaml`) rather than meaningless tempfile paths.
+
+## Limitations
+
+- The `--ext-diff` flag is a git design choice — there's no way for the driver to opt-in automatically.
+- v1 doesn't ship an installer subcommand. The two config lines above are manual.
+
+## See also
+
+- [Loading specs from git revisions](GIT-REVISION.md) — the `<ref>:<path>` syntax oasdiff supports generally, including blob hashes.
+- [Breaking changes and changelog](BREAKING-CHANGES.md) — the underlying command whose output the git diff driver renders.

--- a/docs/GIT-REVISION.md
+++ b/docs/GIT-REVISION.md
@@ -17,6 +17,7 @@ Examples:
 | `origin/main:openapi.yaml` | Spec at `openapi.yaml` on the remote `main` branch |
 | `v2.3.0:api/openapi.yaml` | Spec at `api/openapi.yaml` at tag `v2.3.0` |
 | `abc1234:openapi.yaml` | Spec at a specific commit SHA |
+| `e69de29:openapi.yaml` | Spec at a specific blob SHA (the form git's external-diff protocol passes — see [Git Diff Driver](GIT-DIFF-DRIVER.md)) |
 
 ## Usage
 
@@ -69,3 +70,7 @@ jobs:
 ```
 
 > **Note:** `fetch-depth: 0` is required. The default shallow clone used by `actions/checkout` does not contain the history or remote refs that git revision syntax relies on.
+
+## See also
+
+- [Git Diff Driver](GIT-DIFF-DRIVER.md) — wire oasdiff into git as an external diff driver so `git log --patch` and `git diff` render a human-readable OpenAPI changelog inline.

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,7 +62,7 @@ Pre-built binaries for macOS, Linux, and Windows (both x86_64 and arm64) are on 
 Grouped by what you're trying to do. New to oasdiff? Start with **Commands**.
 
 ### Commands
-The eight top-level subcommands.
+The top-level subcommands.
 
 - [`diff`](DIFF.md) — full diff between two OpenAPI specs (output: html, json, markdown, markup, text, or yaml — default yaml)
 - [`summary`](DIFF.md) — high-level count of changes between two specs (built on the diff engine; same shared options)
@@ -72,6 +72,7 @@ The eight top-level subcommands.
 - [`upgrade`](OPENAPI-31.md#converting-a-spec-with-oasdiff-upgrade) — canonicalize an OpenAPI 3.0 spec to the latest 3.x
 - [`validate`](VALIDATE.md) — check a single spec for per-RFC violations (invalid types, missing required fields, bad regex, unresolved `$ref`s)
 - [`checks`](CHECKS.md) — list the rules oasdiff uses to classify changes ([customize them](CUSTOMIZING-CHECKS.md))
+- [`git-diff-driver`](GIT-DIFF-DRIVER.md) — run as a git external diff driver so `git log --patch` renders an OpenAPI changelog inline
 
 ### Inputs
 Where specs come from.

--- a/internal/git_diff_driver.go
+++ b/internal/git_diff_driver.go
@@ -1,0 +1,114 @@
+package internal
+
+import (
+	"fmt"
+
+	"github.com/oasdiff/oasdiff/load"
+	"github.com/spf13/cobra"
+)
+
+const gitDiffDriverCmd = "git-diff-driver"
+
+// nullFile is the path git passes when one side of a diff doesn't exist
+// (file added on this commit, file deleted on this commit, or one side of
+// a root-commit diff). It's the reliable signal — git's hash field varies
+// here (40 zeros in the steady-state added/deleted case, "." for root
+// commits — see git's diff.c) but the path is always "/dev/null".
+const nullFile = "/dev/null"
+
+func getGitDiffDriverCmd() *cobra.Command {
+
+	cmd := cobra.Command{
+		Use:   "git-diff-driver path old-file old-hex old-mode new-file new-hex new-mode",
+		Short: "Run as a git external diff driver to show OpenAPI changes inline in git log/diff",
+		Long: `Run as a git external diff driver. Git invokes the driver with seven positional
+arguments: the in-tree path, the old/new working-tree files, the old/new blob
+hashes, and the old/new modes. oasdiff loads the two blobs directly via "git
+cat-file" and prints the changelog between them.
+
+Wire it up with two git config entries and a .gitattributes line:
+
+    git config diff.oasdiff.command "oasdiff git-diff-driver"
+    echo "openapi.yaml diff=oasdiff" >> .gitattributes
+
+Then view OpenAPI changes inline with:
+
+    git log --patch --ext-diff openapi.yaml
+
+This subcommand is normally invoked by git, not by humans. It accepts the same
+configuration as the changelog subcommand via the .oasdiff.yaml file in the
+repository root.
+`,
+		Args: cobra.ExactArgs(7),
+		RunE: runGitDiffDriver,
+	}
+
+	addCommonDiffFlags(&cmd)
+	addCommonBreakingFlags(&cmd)
+	enumWithOptions(&cmd, newEnumValue(GetSupportedLevels(), ""), "fail-on", "o", "ignored in git-diff-driver mode (exit code must stay 0 to keep the diff pipeline alive)")
+	enumWithOptions(&cmd, newEnumValue(GetSupportedLevels(), LevelInfo), "level", "", "output errors with this level or higher")
+
+	return &cmd
+}
+
+func runGitDiffDriver(cmd *cobra.Command, args []string) error {
+	// Positional args follow git's external-diff protocol:
+	//   args[0] = in-tree path        (e.g. "openapi.yaml")
+	//   args[1] = old working file    ("/dev/null" when file didn't exist)
+	//   args[2] = old blob hash       (40 zeros, or "." for root commits)
+	//   args[3] = old mode            (unused)
+	//   args[4] = new working file    ("/dev/null" when file no longer exists)
+	//   args[5] = new blob hash
+	//   args[6] = new mode            (unused)
+	path := args[0]
+	oldFile := args[1]
+	oldHex := args[2]
+	newFile := args[4]
+	newHex := args[5]
+
+	if oldFile == nullFile {
+		fmt.Fprintf(cmd.OutOrStdout(), "Added %s\n", path)
+		return nil
+	}
+	if newFile == nullFile {
+		fmt.Fprintf(cmd.OutOrStdout(), "Removed %s\n", path)
+		return nil
+	}
+	if oldHex == newHex {
+		// Mode-only change. Git's own diff machinery already prints the mode
+		// transition; we have nothing meaningful to add.
+		return nil
+	}
+
+	flags := NewFlags()
+	if returnErr := RunViper(cmd, flags.getViper()); returnErr != nil {
+		// External diff drivers must exit 0 to keep `git log --ext-diff` alive.
+		// Surface the configuration error inline in the diff output instead of
+		// aborting git's whole pipeline.
+		fmt.Fprintf(cmd.OutOrStdout(), "oasdiff: configuration error: %s\n", returnErr)
+		return nil
+	}
+	flags.setBase(load.NewSource(shortHex(oldHex) + ":" + path))
+	flags.setRevision(load.NewSource(shortHex(newHex) + ":" + path))
+
+	cmd.Root().SilenceUsage = true
+
+	if _, returnErr := runChangelog(flags, cmd.OutOrStdout()); returnErr != nil {
+		// Same exit-code-zero discipline as above. Print the error in-line so
+		// the user sees it as part of git's diff output.
+		fmt.Fprintf(cmd.OutOrStdout(), "oasdiff: %s\n", returnErr)
+	}
+
+	return nil
+}
+
+// shortHex abbreviates a 40-char git blob hash to its first 7 characters, matching
+// git's own conventional short-hash length. Anything shorter than 8 is returned
+// as-is (already short or empty).
+func shortHex(hex string) string {
+	const shortLen = 7
+	if len(hex) <= shortLen {
+		return hex
+	}
+	return hex[:shortLen]
+}

--- a/internal/git_diff_driver.go
+++ b/internal/git_diff_driver.go
@@ -7,8 +7,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const gitDiffDriverCmd = "git-diff-driver"
-
 // nullFile is the path git passes when one side of a diff doesn't exist
 // (file added on this commit, file deleted on this commit, or one side of
 // a root-commit diff). It's the reliable signal — git's hash field varies

--- a/internal/git_diff_driver_unix_test.go
+++ b/internal/git_diff_driver_unix_test.go
@@ -1,0 +1,178 @@
+//go:build unix
+
+package internal_test
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/oasdiff/oasdiff/internal"
+	"github.com/stretchr/testify/require"
+)
+
+// nullBlob is the SHA-1 sentinel git passes as the blob hash for the added /
+// deleted case in steady-state diffs. We pair it with "/dev/null" as the file
+// path because that's what git uses end-to-end (verified empirically against
+// git's external-diff protocol on the v2.46 release).
+const nullBlob = "0000000000000000000000000000000000000000"
+
+const minimalSpecV1 = `openapi: "3.0.0"
+info:
+  title: Test
+  version: "1.0"
+paths:
+  /pets:
+    get:
+      responses:
+        "200":
+          description: ok
+`
+
+const minimalSpecV2 = `openapi: "3.0.0"
+info:
+  title: Test
+  version: "1.0"
+paths:
+  /pets:
+    get:
+      responses:
+        "200":
+          description: ok
+        "404":
+          description: not found
+`
+
+// gitDiffDriverRepo sets up a fresh git repo containing two committed
+// versions of openapi.yaml and returns the (dir, oldBlobHex, newBlobHex)
+// triple plus a cleanup that restores the original working directory.
+func gitDiffDriverRepo(t *testing.T) (dir, oldHex, newHex string) {
+	t.Helper()
+	dir = t.TempDir()
+
+	gitRun := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(out))
+		return strings.TrimSpace(string(out))
+	}
+
+	gitRun("git", "init")
+	gitRun("git", "config", "user.email", "test@test.com")
+	gitRun("git", "config", "user.name", "Test")
+
+	specPath := filepath.Join(dir, "openapi.yaml")
+	require.NoError(t, os.WriteFile(specPath, []byte(minimalSpecV1), 0644))
+	gitRun("git", "add", "openapi.yaml")
+	gitRun("git", "commit", "-m", "v1")
+	oldHex = gitRun("git", "rev-parse", "HEAD:openapi.yaml")
+
+	require.NoError(t, os.WriteFile(specPath, []byte(minimalSpecV2), 0644))
+	gitRun("git", "add", "openapi.yaml")
+	gitRun("git", "commit", "-m", "v2")
+	newHex = gitRun("git", "rev-parse", "HEAD:openapi.yaml")
+
+	require.NotEqual(t, oldHex, newHex)
+
+	oldDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(oldDir) })
+
+	return dir, oldHex, newHex
+}
+
+// Test_GitDiffDriver_AddsNewResponse runs git-diff-driver in a real repo where
+// the revision adds a "404" response and asserts the changelog output describes
+// the change. This is the end-to-end happy path Jamie Tanna's blog post
+// (jvt.me/posts/2026/04/11/oasdiff-driver) advocated for as a native feature.
+func Test_GitDiffDriver_AddsNewResponse(t *testing.T) {
+	_, oldHex, newHex := gitDiffDriverRepo(t)
+
+	var stdout bytes.Buffer
+	exitCode := internal.Run(
+		[]string{"oasdiff", "git-diff-driver", "openapi.yaml", "/tmp/old", oldHex, "100644", "/tmp/new", newHex, "100644"},
+		&stdout, io.Discard,
+	)
+
+	require.Zero(t, exitCode, "git-diff-driver must always exit 0 so it doesn't abort git's diff pipeline")
+	require.NotEmpty(t, stdout.String(), "changelog output should be non-empty when responses differ")
+	require.NotContains(t, stdout.String(), "/tmp/", "source labels must not leak temp file paths")
+}
+
+// Test_GitDiffDriver_Added asserts that when git passes the null-blob sentinel
+// for the old hash (file added on this commit), the driver prints a one-line
+// "Added <path>" notice rather than attempting a diff.
+func Test_GitDiffDriver_Added(t *testing.T) {
+	_, _, newHex := gitDiffDriverRepo(t)
+
+	var stdout bytes.Buffer
+	exitCode := internal.Run(
+		[]string{"oasdiff", "git-diff-driver", "openapi.yaml", "/dev/null", nullBlob, "0", "/tmp/new", newHex, "100644"},
+		&stdout, io.Discard,
+	)
+
+	require.Zero(t, exitCode)
+	require.Equal(t, "Added openapi.yaml\n", stdout.String())
+}
+
+// Test_GitDiffDriver_Removed mirrors the Added case for deletions.
+func Test_GitDiffDriver_Removed(t *testing.T) {
+	_, oldHex, _ := gitDiffDriverRepo(t)
+
+	var stdout bytes.Buffer
+	exitCode := internal.Run(
+		[]string{"oasdiff", "git-diff-driver", "openapi.yaml", "/tmp/old", oldHex, "100644", "/dev/null", nullBlob, "0"},
+		&stdout, io.Discard,
+	)
+
+	require.Zero(t, exitCode)
+	require.Equal(t, "Removed openapi.yaml\n", stdout.String())
+}
+
+// Test_GitDiffDriver_ModeOnlyChange asserts that when the two blob hashes are
+// equal (mode-only change), the driver prints nothing — git's own machinery
+// already surfaces the mode delta and oasdiff has nothing meaningful to add.
+func Test_GitDiffDriver_ModeOnlyChange(t *testing.T) {
+	_, oldHex, _ := gitDiffDriverRepo(t)
+
+	var stdout bytes.Buffer
+	exitCode := internal.Run(
+		[]string{"oasdiff", "git-diff-driver", "openapi.yaml", "/tmp/old", oldHex, "100644", "/tmp/new", oldHex, "100755"},
+		&stdout, io.Discard,
+	)
+
+	require.Zero(t, exitCode)
+	require.Empty(t, stdout.String())
+}
+
+// Test_GitDiffDriver_NonGitRepo asserts that even when invoked outside any git
+// repository the driver returns exit code 0 and writes the error inline. Aborting
+// git's diff pipeline (non-zero exit) is the worst failure mode here because a
+// single broken file would make `git log --ext-diff` unusable for the whole repo.
+func Test_GitDiffDriver_NonGitRepo(t *testing.T) {
+	tmp := t.TempDir()
+	oldDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmp))
+	defer os.Chdir(oldDir) //nolint:errcheck
+
+	// Hand-rolled but plausible-looking hashes that don't resolve in this empty repo.
+	const fakeOld = "1111111111111111111111111111111111111111"
+	const fakeNew = "2222222222222222222222222222222222222222"
+
+	var stdout bytes.Buffer
+	exitCode := internal.Run(
+		[]string{"oasdiff", "git-diff-driver", "openapi.yaml", "/tmp/old", fakeOld, "100644", "/tmp/new", fakeNew, "100644"},
+		&stdout, io.Discard,
+	)
+
+	require.Zero(t, exitCode)
+	require.Contains(t, stdout.String(), "oasdiff:", "error must be surfaced inline so the user sees it in git's diff output")
+}

--- a/internal/run.go
+++ b/internal/run.go
@@ -35,6 +35,7 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) int {
 		getUpgradeCmd(),
 		getChecksCmd(),
 		getValidateCmd(),
+		getGitDiffDriverCmd(),
 	)
 
 	return run(rootCmd)

--- a/load/load.go
+++ b/load/load.go
@@ -34,8 +34,12 @@ func from(loader *openapi3.Loader, source *Source) (*openapi3.T, error) {
 // Relative $refs (e.g. "./schemas/pet.yaml") are resolved by kin-openapi; we install a
 // JoinFunc so the "<rev>:" prefix is preserved (the default path.Dir strips it), and a
 // ReadFromURIFunc so referenced files are read via "git show" too.
+//
+// Blob-hash refs (e.g. "abc1234:openapi.yaml" where abc1234 is a git blob object hash)
+// are supported via readGitRefContent. The path portion is preserved on the ref string
+// passed downstream for source labels and relative $ref resolution.
 func loadFromGitRevision(loader *openapi3.Loader, gitRef string) (*openapi3.T, error) {
-	out, err := gitShow(gitRef)
+	out, err := readGitRefContent(gitRef)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load spec from git revision %q: %w", gitRef, err)
 	}
@@ -81,6 +85,41 @@ func loadFromGitRevision(loader *openapi3.Loader, gitRef string) (*openapi3.T, e
 	// the loader would return the cached base spec for the revision.
 	u := &url.URL{Path: filepath.ToSlash(gitRef)}
 	return loaderCopy.LoadFromDataWithPath(out, u)
+}
+
+// readGitRefContent fetches the OpenAPI spec bytes for a git ref. For the
+// `<commit-or-tag>:<path>` form it runs `git show <ref>:<path>`. For the
+// `<blob-hex>:<path>` form (where the part before `:` is a blob object hash
+// rather than a commit/tree/tag) it runs `git show <blob-hex>` directly, since
+// `git show <blob-hex>:<path>` is not valid git syntax. Callers keep the full
+// `<ref>:<path>` string for the loader's URL key so source labels and relative
+// $ref resolution stay correct.
+func readGitRefContent(gitRef string) ([]byte, error) {
+	if hex, ok := blobHashFromRef(gitRef); ok {
+		return gitShow(hex)
+	}
+	return gitShow(gitRef)
+}
+
+// blobHashFromRef returns (hex, true) when the part before `:` in gitRef names
+// a git blob object (a stored file content, not a commit/tree/tag). Returns
+// ("", false) when the ref isn't a blob, when git cannot resolve it, or when
+// the input has no `:` separator. The cost is one extra `git cat-file -t` call
+// per spec load on the git path, which git serves in single-digit milliseconds.
+func blobHashFromRef(gitRef string) (string, bool) {
+	idx := strings.Index(gitRef, ":")
+	if idx < 0 {
+		return "", false
+	}
+	ref := gitRef[:idx]
+	out, err := exec.Command("git", "cat-file", "-t", ref).Output()
+	if err != nil {
+		return "", false
+	}
+	if strings.TrimSpace(string(out)) != "blob" {
+		return "", false
+	}
+	return ref, true
 }
 
 // gitShow runs "git show <ref>" and returns its stdout, or a descriptive error.

--- a/load/spec_info_git_test.go
+++ b/load/spec_info_git_test.go
@@ -271,6 +271,109 @@ func TestLoadInfo_GitRevisionNoGit(t *testing.T) {
 	require.ErrorContains(t, err, "is git installed and in PATH?")
 }
 
+// TestLoadInfo_BlobHashRef verifies that the `<blob-hex>:<path>` form loads the
+// blob's content directly, which is the form git's external-diff driver passes
+// (git sends blob hashes, not commit hashes). The path portion is preserved on
+// the ref for display purposes but not used to navigate a tree.
+func TestLoadInfo_BlobHashRef(t *testing.T) {
+	dir := t.TempDir()
+
+	run := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(out))
+		return string(out)
+	}
+
+	run("git", "init")
+	run("git", "config", "user.email", "test@test.com")
+	run("git", "config", "user.name", "Test")
+
+	specPath := filepath.Join(dir, "openapi.yaml")
+	require.NoError(t, os.WriteFile(specPath, []byte(minimalSpec), 0644))
+	run("git", "add", "openapi.yaml")
+	run("git", "commit", "-m", "add spec")
+
+	oldDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	defer os.Chdir(oldDir) //nolint:errcheck
+
+	// Get the blob hash for the committed openapi.yaml.
+	blobHex := run("git", "rev-parse", "HEAD:openapi.yaml")
+	blobHex = blobHex[:len(blobHex)-1] // strip trailing newline
+	require.Len(t, blobHex, 40, "git rev-parse should return a 40-char SHA-1")
+
+	specInfo, err := load.NewSpecInfo(openapi3.NewLoader(), load.NewSource(blobHex+":openapi.yaml"))
+	require.NoError(t, err)
+	require.Equal(t, "1.0", specInfo.GetVersion())
+}
+
+// TestLoadInfo_BlobHashRef_TwoBlobsSharedLoader verifies that loading two
+// different blob hashes for the same path on the same loader returns distinct
+// specs. This is the exact shape git invokes the external-diff driver with:
+// old and new blob hashes, both notionally at the same in-tree path. Without
+// unique cache keys per ref the loader would return the cached first spec for
+// the second load.
+func TestLoadInfo_BlobHashRef_TwoBlobsSharedLoader(t *testing.T) {
+	dir := t.TempDir()
+
+	run := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(out))
+		return string(out)
+	}
+
+	run("git", "init")
+	run("git", "config", "user.email", "test@test.com")
+	run("git", "config", "user.name", "Test")
+
+	specV1 := `openapi: "3.0.0"
+info:
+  title: Test
+  version: "1.0"
+paths: {}
+`
+	specV2 := `openapi: "3.0.0"
+info:
+  title: Test
+  version: "2.0"
+paths: {}
+`
+	specPath := filepath.Join(dir, "openapi.yaml")
+	require.NoError(t, os.WriteFile(specPath, []byte(specV1), 0644))
+	run("git", "add", "openapi.yaml")
+	run("git", "commit", "-m", "v1")
+
+	require.NoError(t, os.WriteFile(specPath, []byte(specV2), 0644))
+	run("git", "add", "openapi.yaml")
+	run("git", "commit", "-m", "v2")
+
+	oldDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	defer os.Chdir(oldDir) //nolint:errcheck
+
+	baseHex := run("git", "rev-parse", "HEAD~1:openapi.yaml")
+	baseHex = baseHex[:len(baseHex)-1]
+	revHex := run("git", "rev-parse", "HEAD:openapi.yaml")
+	revHex = revHex[:len(revHex)-1]
+
+	loader := openapi3.NewLoader()
+	s1, err := load.NewSpecInfo(loader, load.NewSource(baseHex+":openapi.yaml"))
+	require.NoError(t, err)
+	s2, err := load.NewSpecInfo(loader, load.NewSource(revHex+":openapi.yaml"))
+	require.NoError(t, err)
+
+	require.Equal(t, "1.0", s1.GetVersion(), "base blob should be v1")
+	require.Equal(t, "2.0", s2.GetVersion(), "revision blob should be v2")
+}
+
 // TestLoadInfo_GitRevisionWithExternalRef verifies that $ref chains are resolved via
 // "git show" when loading from a git revision, not opened as literal file paths.
 func TestLoadInfo_GitRevisionWithExternalRef(t *testing.T) {


### PR DESCRIPTION
## Summary

A native `oasdiff git-diff-driver` subcommand so `git log --patch --ext-diff` and `git diff` render a human-readable OpenAPI changelog inline instead of a raw YAML diff. Closes the friction Jamie Tanna documented at https://www.jvt.me/posts/2026/04/11/oasdiff-driver/ — the bash wrapper is now unnecessary, and the `/tmp/git-blob-xxxxx` paths no longer leak into the output's source labels.

## Try it without waiting for a release

```sh
go install github.com/oasdiff/oasdiff@feat/git-diff-driver
```

Then in any git repo with an OpenAPI spec under version control:

```sh
git config diff.oasdiff.command "oasdiff git-diff-driver"
echo "openapi.yaml diff=oasdiff" >> .gitattributes
git log --patch --ext-diff -- openapi.yaml
```

## Sample output

Given two commits where `/pets` gained a `404` response:

```
commit aed51e7b25195d82c3edd76caab75c4e1a2a2922
Author: Test <test@test.com>
Date:   Thu May 28 15:14:56 2026 +0300

    v2

1 changes: 0 error, 0 warning, 1 info
info  [response-non-success-status-added] at openapi.yaml
        in API GET /pets
                added the non-success response with the status `404`


commit 7dd4bdb866153dcd3e7cbc47d41953f05ff671c6
Author: Test <test@test.com>
Date:   Thu May 28 15:14:56 2026 +0300

    v1

Added openapi.yaml
```

No `/tmp/git-blob-xxxxx` paths, no manual `--ext-diff` plumbing per file, root-commit case handled cleanly.

## Two pieces

1. **Loader extension (`load/load.go`)** — the existing `<ref>:<path>` syntax now also accepts blob hashes for the ref portion. Git's external-diff protocol passes blob hashes (not commit refs), and `git show <hex>:<path>` isn't valid syntax for blobs, so the loader detects type via `git cat-file -t <ref>` and uses `git show <hex>` when the ref resolves to a blob. The path portion stays on the ref string for source labels and relative `$ref` resolution. Existing commit-ref and tag-ref behaviour is unchanged.

2. **`git-diff-driver` subcommand (`internal/git_diff_driver.go`)** — accepts git's 7 positional args (`path old-file old-hex old-mode new-file new-hex new-mode`) and translates them into two `<short-hex>:<path>` arguments for the `changelog` flow.

## How this maps to the wrapper approach in the post

| Concern from the post | New behaviour |
|---|---|
| Bash wrapper writing the `oasdiff changelog "$2" "$5"` glue | Single `git config diff.oasdiff.command "oasdiff git-diff-driver"`. No script file. |
| Temp filenames showing up in output | Source labels are now `<short-hex>:openapi.yaml`. The temp paths git provides are ignored; content is loaded via `git cat-file blob <hex>`. |
| File-added case (script needs to check `/dev/null`) | Handled in the subcommand: prints `Added <path>`. |
| File-deleted case | Prints `Removed <path>`. |
| Initial commit (git passes `.` as the hash, not 40 zeros — wrapper-class footgun) | Handled by detecting `oldFile == "/dev/null"` rather than relying on the hash sentinel. |
| Mode-only change | Skipped silently; git's own machinery prints the mode delta. |
| Hard failures aborting the whole `git log --ext-diff` pipeline | Errors are surfaced inline rather than as non-zero exits, so a single bad diff doesn't kill the log. |
| Having to remember `--ext-diff` | Unchanged — still a git constraint. Documented in the subcommand help. |

## Known limitations

- The `--ext-diff` requirement on `git log` / `git diff` invocations is a git design choice, not something we can fix from oasdiff's side. The subcommand help text calls this out.
- The subcommand assumes the spec parses as OpenAPI; for blobs that don't, the load error is surfaced inline in the git output (does not abort the pipeline).
- v1 doesn't ship an installer subcommand to write the git-config / `.gitattributes` lines for you. That's a candidate follow-up if there's demand.

## Tests

- Loader: two new tests cover blob-hash loading and the two-blobs-shared-loader case (the exact shape git invokes the driver with). Every existing git-ref test still passes unchanged.
- Subcommand: five new tests cover happy path, file-added, file-removed, mode-only, and the no-git-repo failure mode (exit code stays 0, error surfaced inline).
- Full sweep across all packages still passes.

## Manual verification

Verified end-to-end against a fresh local repo (steps in this PR description reproduce it). The v1 → v2 commit renders the human-readable changelog; the root commit prints `Added openapi.yaml`.

## Credit

Inspired by Jamie Tanna's post at https://www.jvt.me/posts/2026/04/11/oasdiff-driver/. The commit message names the post, and the next release (v1.17.0) will credit it in the release notes and the docs page we'll write up for this feature.