### PR TITLE
fix: cli-login handoff is now a GET, listener reads token from query string

### DIFF
--- a/internal/open_review.go
+++ b/internal/open_review.go
@@ -329,8 +329,8 @@ func deleteStoredAccessToken() error {
 // readOrMintAccessToken returns the stored access token, or runs the
 // first-run browser sign-in if none is stored. The sign-in flow opens a
 // random-port HTTP listener on 127.0.0.1, opens the visitor's browser at
-// /cli-login?port=N, waits for the POST callback, captures the token from
-// the form body, and writes it to credentialsPath() before returning.
+// /cli-login?port=N, waits for the GET callback with the token in the
+// query string, and writes it to credentialsPath() before returning.
 func readOrMintAccessToken(stdout io.Writer) (string, error) {
 	token, err := readStoredAccessToken()
 	if err != nil {
@@ -354,8 +354,14 @@ func readOrMintAccessToken(stdout io.Writer) (string, error) {
 
 // signInViaBrowser runs the localhost-handoff dance. Binds to 127.0.0.1 on a
 // random high port; opens the visitor's browser at /cli-login?port=N; waits
-// up to 5 minutes for a POST whose body contains the access_token form field;
+// up to 5 minutes for a GET callback whose query string carries access_token;
 // returns the token.
+//
+// The handoff is a GET (top-level navigation) rather than a POST because
+// browsers warn on HTTPS → HTTP form submissions even when the destination
+// is loopback. Top-level navigations to HTTP are silently allowed. The
+// listener's response page uses history.replaceState to scrub the token
+// from the address bar.
 //
 // Edge cases (SSH / WSL / Codespaces where the browser and CLI run on
 // different hosts) are not handled in v1; the listener times out and the
@@ -374,22 +380,21 @@ func signInViaBrowser(stdout io.Writer) (string, error) {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
+		if r.Method != http.MethodGet {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
-		if err := r.ParseForm(); err != nil {
-			http.Error(w, "bad request", http.StatusBadRequest)
-			errCh <- fmt.Errorf("parse callback form: %w", err)
-			return
-		}
-		token := strings.TrimSpace(r.PostFormValue("access_token"))
+		token := strings.TrimSpace(r.URL.Query().Get("access_token"))
 		if token == "" {
 			http.Error(w, "missing access_token", http.StatusBadRequest)
 			errCh <- errors.New("callback missing access_token")
 			return
 		}
-		fmt.Fprintln(w, "<!doctype html><html><body style=\"font-family:sans-serif;text-align:center;padding:4rem\"><h2>oasdiff CLI is signed in</h2><p>You can close this tab and return to your terminal.</p></body></html>")
+		// Scrub the token from the address bar before the visitor can read
+		// or share it. history.replaceState replaces the loopback URL
+		// (which carried the token in its query string) with a clean path
+		// on the same loopback origin.
+		fmt.Fprintln(w, `<!doctype html><html><head><script>history.replaceState(null,'','/');</script></head><body style="font-family:sans-serif;text-align:center;padding:4rem"><h2>oasdiff CLI is signed in</h2><p>You can close this tab and return to your terminal.</p></body></html>`)
 		tokenCh <- token
 	})
 

--- a/internal/open_review_unix_test.go
+++ b/internal/open_review_unix_test.go
@@ -244,20 +244,21 @@ func TestUploadAndOpen_401ClearsCredentials(t *testing.T) {
 
 func TestSignInViaBrowser_CapturesCallback(t *testing.T) {
 	// We can't easily fake the browser opening, but we can short-circuit
-	// the wait by having a goroutine POST to the listener right after the
+	// the wait by having a goroutine GET the listener right after the
 	// CLI starts it. To find the port, monkey-patch openBrowser via the
 	// environment: OASDIFF_URL is a stub server that, when /cli-login is
-	// hit, immediately POSTs back to the local listener.
+	// hit, immediately GETs back to the local listener.
 	const issuedToken = "deadbeef-dead-beef-dead-beefdeadbeef"
 
 	// httptest stub that imitates the /cli-login page: when the CLI calls
-	// openBrowser, we instead end up here, parse the port, and POST back.
+	// openBrowser, we instead end up here, parse the port, and call back.
+	// The production page uses a meta-refresh + JS navigation to the
+	// loopback URL; the test approximates that with an http.Get.
 	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		port := r.URL.Query().Get("port")
 		require.NotEmpty(t, port)
 		go func() {
-			form := "access_token=" + issuedToken
-			_, err := http.Post("http://127.0.0.1:"+port+"/callback", "application/x-www-form-urlencoded", bytes.NewBufferString(form))
+			_, err := http.Get("http://127.0.0.1:" + port + "/callback?access_token=" + issuedToken)
 			require.NoError(t, err)
 		}()
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Browsers (Chrome, Edge, Firefox) show a 'This is a non-secure form' warning when an HTTPS page submits a form to http://, **even when the destination is loopback**. The user has to click 'Yes, send it' before the handoff completes — terrible UX for what should be a one-second sign-in.

The matching w3 fix (oasdiff/w3#248) switches the /cli-login page from a form POST to a top-level navigation (meta refresh + JS `location.replace()`). Top-level navigations to HTTP are silently allowed by browsers — the user navigating to an HTTP URL is treated as their own choice, no warning.

This PR is the CLI half. The listener now accepts GET on /callback with the access token in the query string instead of POST with the token in the form body.

## Token-in-URL concern

The token appears in the URL the browser navigates to (`http://127.0.0.1:NNNN/callback?access_token=...`). Mitigations:

- The URL is loopback-only — never crosses the network, never appears in any server access log outside the user's own machine.
- The listener's response page runs `history.replaceState(null, '', '/')` immediately on render, scrubbing the token from the address bar before the visitor can share or screenshot it.
- The token is upload-only and revocable by deleting `~/.config/oasdiff/credentials` (and Phase 2 will add a server-side revoke flow).

Acceptable for v1. The alternative is the deferred copy-paste fallback for the SSH/WSL/Codespaces cohort, which has the same property (token visible on the page before pasting).

## Test plan

- [ ] Build the CLI from this branch.
- [ ] Delete `~/.config/oasdiff/credentials`.
- [ ] Run `oasdiff changelog HEAD~1:openapi.yaml HEAD:openapi.yaml --open` (against a deploy with oasdiff/w3#248).
- [ ] Browser opens `/cli-login`, navigates to the loopback URL **without a non-secure-form warning**, CLI captures token and proceeds to upload.
- [ ] Second run: skips sign-in.

## Depends on

oasdiff/w3#248 — both have to deploy for the end-to-end handoff to work. Order doesn't matter for merging; the test isn't end-to-end until both are deployed.
