### PR TITLE
--open: pass mode (breaking|changelog) so the rendered page filters severity

### DIFF
--- a/internal/changelog.go
+++ b/internal/changelog.go
@@ -82,7 +82,7 @@ func getChangelog(flags *Flags, stdout io.Writer, level checker.Level, isBreakin
 	}
 
 	if flags.getOpen() {
-		if err := uploadAndOpen(flags, stdout); err != nil {
+		if err := uploadAndOpen(flags, stdout, isBreaking); err != nil {
 			return false, getErrUploadAndOpenFailed(err)
 		}
 	}

--- a/internal/open_review.go
+++ b/internal/open_review.go
@@ -37,9 +37,16 @@ func oasdiffSiteURL() string {
 // terminal changelog/breaking output has already been printed by the caller;
 // --open is purely additive.
 //
+// isBreaking is the visitor's subcommand intent: true when invoked via
+// `oasdiff breaking`, false via `oasdiff changelog`. We forward this as the
+// upload's `mode` field so the rendered /review/local page filters its
+// severity view to match what the visitor saw in their terminal — the same
+// reasoning that semantic comparison flags (flatten-params etc.) are
+// forwarded but filtering / presentation flags are not.
+//
 // Sign-in: if no access token is stored locally, the CLI runs the first-run
 // browser handshake. See enterprise/docs/cli-local-review.md for the design.
-func uploadAndOpen(flags *Flags, stdout io.Writer) error {
+func uploadAndOpen(flags *Flags, stdout io.Writer, isBreaking bool) error {
 	baseBytes, baseName, err := readSpecSource(flags.getBase())
 	if err != nil {
 		return fmt.Errorf("read base spec: %w", err)
@@ -56,7 +63,11 @@ func uploadAndOpen(flags *Flags, stdout io.Writer) error {
 		return err
 	}
 
-	reviewURL, expiresAt, err := postPreviewReview(accessToken, baseName, baseBytes, revName, revBytes, options)
+	mode := "changelog"
+	if isBreaking {
+		mode = "breaking"
+	}
+	reviewURL, expiresAt, err := postPreviewReview(accessToken, baseName, baseBytes, revName, revBytes, options, mode)
 	if err != nil {
 		return err
 	}
@@ -172,8 +183,10 @@ func buildSemanticOptionsJSON(flags *Flags) string {
 }
 
 // postPreviewReview uploads the two spec files to oasdiff.com and returns
-// the rendered review URL plus its TTL expiry timestamp.
-func postPreviewReview(accessToken, baseName string, baseBytes []byte, revName string, revBytes []byte, options string) (string, time.Time, error) {
+// the rendered review URL plus its TTL expiry timestamp. mode is "breaking"
+// or "changelog"; the server uses it to default the rendered /review/local
+// page's severity filter.
+func postPreviewReview(accessToken, baseName string, baseBytes []byte, revName string, revBytes []byte, options, mode string) (string, time.Time, error) {
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 
@@ -186,6 +199,11 @@ func postPreviewReview(accessToken, baseName string, baseBytes []byte, revName s
 	if options != "" {
 		if err := writer.WriteField("options", options); err != nil {
 			return "", time.Time{}, fmt.Errorf("write options field: %w", err)
+		}
+	}
+	if mode != "" {
+		if err := writer.WriteField("mode", mode); err != nil {
+			return "", time.Time{}, fmt.Errorf("write mode field: %w", err)
 		}
 	}
 	if err := writer.Close(); err != nil {

--- a/internal/open_review_unix_test.go
+++ b/internal/open_review_unix_test.go
@@ -147,6 +147,7 @@ func TestUploadAndOpen_PostsToServer(t *testing.T) {
 		revFilename  string
 		username     string
 		options      string
+		mode         string
 	}{}
 
 	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -165,6 +166,7 @@ func TestUploadAndOpen_PostsToServer(t *testing.T) {
 		captured.revFilename = revHdr.Filename
 		captured.username = r.PostFormValue("github_username")
 		captured.options = r.PostFormValue("options")
+		captured.mode = r.PostFormValue("mode")
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"review_id":"abc-123","expires_at":1700000000}`))
 	}))
@@ -192,7 +194,7 @@ func TestUploadAndOpen_PostsToServer(t *testing.T) {
 	flags.getViper().Set("flatten-params", true)
 
 	var out bytes.Buffer
-	require.NoError(t, uploadAndOpen(flags, &out))
+	require.NoError(t, uploadAndOpen(flags, &out, false))
 
 	require.Equal(t, "Bearer 11111111-1111-1111-1111-111111111111", captured.auth,
 		"the stored access token must be sent as Bearer auth, not in a form field")
@@ -202,11 +204,48 @@ func TestUploadAndOpen_PostsToServer(t *testing.T) {
 	require.Equal(t, "openapi.yaml", captured.revFilename)
 	require.JSONEq(t, `{"flatten-params":true}`, captured.options,
 		"semantic flags must round-trip into the options field; filtering and presentation flags must not appear here")
+	require.Equal(t, "changelog", captured.mode,
+		"isBreaking=false maps to mode=changelog so the rendered page shows every change")
 	// The CLI builds the URL from the stub's base, not hard-coded, so we
 	// just check it appears in stdout for the user to follow.
 	require.Contains(t, out.String(), "/review/local/abc-123")
 	_ = revPath // silence unused (kept for symmetry with the earlier path)
 	_ = viper.New()
+}
+
+func TestUploadAndOpen_BreakingSendsModeBreaking(t *testing.T) {
+	// When the visitor ran `oasdiff breaking --open`, the upload must carry
+	// mode=breaking so the rendered /review/local page defaults its severity
+	// filter to breaking-only and matches the terminal output.
+	var capturedMode string
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseMultipartForm(8<<20))
+		capturedMode = r.PostFormValue("mode")
+		_, _ = w.Write([]byte(`{"review_id":"r1","expires_at":0}`))
+	}))
+	defer stub.Close()
+
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("HOME", dir)
+	t.Setenv("OASDIFF_URL", stub.URL)
+	require.NoError(t, writeStoredAccessToken("11111111-1111-1111-1111-111111111111"))
+
+	tmpdir := t.TempDir()
+	basePath := filepath.Join(tmpdir, "openapi.yaml")
+	require.NoError(t, os.WriteFile(basePath, []byte("openapi: 3.0.0\n"), 0644))
+	revFileDir := t.TempDir()
+	revPath := filepath.Join(revFileDir, "openapi.yaml")
+	require.NoError(t, os.WriteFile(revPath, []byte("openapi: 3.0.0\n"), 0644))
+
+	flags := NewFlags()
+	flags.setBase(load.NewSource(basePath))
+	flags.setRevision(load.NewSource(revPath))
+
+	var out bytes.Buffer
+	require.NoError(t, uploadAndOpen(flags, &out, true))
+	require.Equal(t, "breaking", capturedMode,
+		"isBreaking=true must propagate as mode=breaking on the upload")
 }
 
 func TestUploadAndOpen_401ClearsCredentials(t *testing.T) {
@@ -233,7 +272,7 @@ func TestUploadAndOpen_401ClearsCredentials(t *testing.T) {
 	flags.setRevision(load.NewSource(revPath))
 
 	var out bytes.Buffer
-	err := uploadAndOpen(flags, &out)
+	err := uploadAndOpen(flags, &out, false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "credentials")
 
@@ -303,7 +342,7 @@ func TestPostPreviewReviewSendsMultipart(t *testing.T) {
 	defer stub.Close()
 	t.Setenv("OASDIFF_URL", stub.URL)
 
-	url, _, err := postPreviewReview("tok", "base.yaml", []byte("openapi: 3.0.0\nbase\n"), "rev.yaml", []byte("openapi: 3.0.0\nrev\n"), `{"flatten-params":true}`)
+	url, _, err := postPreviewReview("tok", "base.yaml", []byte("openapi: 3.0.0\nbase\n"), "rev.yaml", []byte("openapi: 3.0.0\nrev\n"), `{"flatten-params":true}`, "changelog")
 	require.NoError(t, err)
 	require.Contains(t, url, "/review/local/x")
 	require.True(t, strings.HasPrefix(received.contentType, "multipart/form-data"),


### PR DESCRIPTION
When the visitor runs `oasdiff breaking --open`, the resulting /review/local page should default its severity filter to breaking-only so the web view matches the visitor's terminal output. Today it shows every change including info-level, which is confusing.

The original design decision to ignore filtering flags (`--fail-on`, `--level`, `--include-checks`) stands — those are interactive concerns of the web UI. But the **subcommand itself** is a stronger signal of intent than a flag, and propagating it matches what users expect.

## What changes

- `uploadAndOpen` now takes the `isBreaking` flag (already threaded through `getChangelog` from `runChangelog` and `runBreakingChanges`).
- It forwards `"breaking"` or `"changelog"` as a new `mode` form field on the upload.
- New test `TestUploadAndOpen_BreakingSendsModeBreaking` locks the contract.

## Coordinated PRs

- oasdiff-service #205 — adds the `mode` column to `preview_reviews` (additive, defaults to `changelog` for backward compat).
- w3 follow-up — reads `mode` from the service response and filters changes at render time when `mode === "breaking"`.

Both companion PRs need to land for the end-to-end behavior to take effect, but each is independently safe.

## Backward compat

Older oasdiff versions that don't send the field continue to work: the service defaults to `changelog` (the pre-mode behavior of showing every change). Newer oasdiff against an older service: the field is silently accepted but stored as `changelog` (older code path ignores it).
