### PR TITLE
checker: migrate five enum-themed pairs to the media-type walker (PR-10 of #936)

### DIFF
--- a/checker/check_request_property_became_enum.go
+++ b/checker/check_request_property_became_enum.go
@@ -10,49 +10,21 @@ const (
 
 func RequestPropertyBecameEnumCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
 
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		info.walkProperties(func(p propertyInfo) {
+			if enumDiff := p.propertyDiff.EnumDiff; enumDiff == nil || !enumDiff.EnumAdded {
+				return
 			}
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				if mediaTypeDiff.SchemaDiff == nil {
-					continue
-				}
 
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
+			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "enum")
+			result = append(result, p.newChange(
+				RequestPropertyBecameEnumId,
+				[]any{propertyFullName(p.propertyPath, p.propertyName)},
+				"",
+			).WithSources(propBaseSource, propRevisionSource))
+		})
+	})
 
-						if enumDiff := propertyDiff.EnumDiff; enumDiff == nil || !enumDiff.EnumAdded {
-							return
-						}
-
-						propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "enum")
-						result = append(result, NewApiChange(
-							RequestPropertyBecameEnumId,
-							config,
-							[]any{propertyFullName(propertyPath, propertyName)},
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-					})
-			}
-		}
-	}
 	return result
 }

--- a/checker/check_request_property_enum_value_updated.go
+++ b/checker/check_request_property_enum_value_updated.go
@@ -14,69 +14,41 @@ const (
 
 func RequestPropertyEnumValueUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
+
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		info.walkProperties(func(p propertyInfo) {
+			enumDiff := p.propertyDiff.EnumDiff
+			if enumDiff == nil {
+				return
 			}
 
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						enumDiff := propertyDiff.EnumDiff
-						if enumDiff == nil {
-							return
-						}
+			propName := propertyFullName(p.propertyPath, p.propertyName)
 
-						propName := propertyFullName(propertyPath, propertyName)
+			for _, enumVal := range enumDiff.Deleted {
+				baseSource, revisionSource := SchemaDeletedItemSources(operationsSources, info.operationItem, p.propertyDiff, "enum", fmt.Sprintf("%v", enumVal))
 
-						for _, enumVal := range enumDiff.Deleted {
-							baseSource, revisionSource := SchemaDeletedItemSources(operationsSources, operationItem, propertyDiff, "enum", fmt.Sprintf("%v", enumVal))
+				id := RequestPropertyEnumValueRemovedId
+				if p.propertyDiff.Revision.ReadOnly {
+					id = RequestReadOnlyPropertyEnumValueRemovedId
+				}
 
-							id := RequestPropertyEnumValueRemovedId
-							if propertyDiff.Revision.ReadOnly {
-								id = RequestReadOnlyPropertyEnumValueRemovedId
-							}
-
-							result = append(result, NewApiChange(
-								id,
-								config,
-								[]any{enumVal, propName},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-						}
-
-						for _, enumVal := range enumDiff.Added {
-							baseSource, revisionSource := SchemaAddedItemSources(operationsSources, operationItem, propertyDiff, "enum", fmt.Sprintf("%v", enumVal))
-							result = append(result, NewApiChange(
-								RequestPropertyEnumValueAddedId,
-								config,
-								[]any{enumVal, propName},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-						}
-					})
+				result = append(result, p.newChange(
+					id,
+					[]any{enumVal, propName},
+					"",
+				).WithSources(baseSource, revisionSource))
 			}
-		}
-	}
+
+			for _, enumVal := range enumDiff.Added {
+				baseSource, revisionSource := SchemaAddedItemSources(operationsSources, info.operationItem, p.propertyDiff, "enum", fmt.Sprintf("%v", enumVal))
+				result = append(result, p.newChange(
+					RequestPropertyEnumValueAddedId,
+					[]any{enumVal, propName},
+					"",
+				).WithSources(baseSource, revisionSource))
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_request_property_x_extensible_enum_value_removed.go
+++ b/checker/check_request_property_x_extensible_enum_value_removed.go
@@ -1,8 +1,9 @@
 package checker
 
 import (
-	"github.com/oasdiff/oasdiff/diff"
 	"slices"
+
+	"github.com/oasdiff/oasdiff/diff"
 )
 
 const (
@@ -11,80 +12,57 @@ const (
 
 func RequestPropertyXExtensibleEnumValueRemovedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
+
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		info.walkProperties(func(p propertyInfo) {
+			if p.propertyDiff.ExtensionsDiff == nil {
+				return
+			}
+			if p.propertyDiff.ExtensionsDiff.Modified == nil {
+				return
+			}
+			if p.propertyDiff.ExtensionsDiff.Modified[diff.XExtensibleEnumExtension] == nil {
+				return
+			}
+			from, ok := p.propertyDiff.Base.Extensions[diff.XExtensibleEnumExtension].([]any)
+			if !ok {
+				return
+			}
+			to, ok := p.propertyDiff.Revision.Extensions[diff.XExtensibleEnumExtension].([]any)
+			if !ok {
+				return
 			}
 
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						if propertyDiff.ExtensionsDiff == nil {
-							return
-						}
-						if propertyDiff.ExtensionsDiff.Modified == nil {
-							return
-						}
-						if propertyDiff.ExtensionsDiff.Modified[diff.XExtensibleEnumExtension] == nil {
-							return
-						}
-						from, ok := propertyDiff.Base.Extensions[diff.XExtensibleEnumExtension].([]any)
-						if !ok {
-							return
-						}
-						to, ok := propertyDiff.Revision.Extensions[diff.XExtensibleEnumExtension].([]any)
-						if !ok {
-							return
-						}
-
-						fromSlice := make([]string, len(from))
-						for i, item := range from {
-							fromSlice[i] = item.(string)
-						}
-
-						toSlice := make([]string, len(to))
-						for i, item := range to {
-							toSlice[i] = item.(string)
-						}
-
-						deletedVals := make([]string, 0)
-						for _, fromVal := range fromSlice {
-							if !slices.Contains(toSlice, fromVal) {
-								deletedVals = append(deletedVals, fromVal)
-							}
-						}
-
-						if propertyDiff.Revision.ReadOnly {
-							return
-						}
-						propBaseSource, propRevisionSource := SchemaSources(operationsSources, operationItem, propertyDiff)
-						for _, enumVal := range deletedVals {
-							result = append(result, NewApiChange(
-								RequestPropertyXExtensibleEnumValueRemovedId,
-								config,
-								[]any{enumVal, propertyFullName(propertyPath, propertyName)},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						}
-					})
+			fromSlice := make([]string, len(from))
+			for i, item := range from {
+				fromSlice[i] = item.(string)
 			}
-		}
-	}
+
+			toSlice := make([]string, len(to))
+			for i, item := range to {
+				toSlice[i] = item.(string)
+			}
+
+			deletedVals := make([]string, 0)
+			for _, fromVal := range fromSlice {
+				if !slices.Contains(toSlice, fromVal) {
+					deletedVals = append(deletedVals, fromVal)
+				}
+			}
+
+			if p.propertyDiff.Revision.ReadOnly {
+				return
+			}
+			propBaseSource, propRevisionSource := SchemaSources(operationsSources, info.operationItem, p.propertyDiff)
+			for _, enumVal := range deletedVals {
+				result = append(result, p.newChange(
+					RequestPropertyXExtensibleEnumValueRemovedId,
+					[]any{enumVal, propertyFullName(p.propertyPath, p.propertyName)},
+					"",
+				).WithSources(propBaseSource, propRevisionSource))
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_response_property_enum_value_added.go
+++ b/checker/check_response_property_enum_value_added.go
@@ -13,62 +13,33 @@ const (
 
 func ResponsePropertyEnumValueAddedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil || operationItem.ResponsesDiff.Modified == nil {
-				continue
-			}
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff == nil ||
-					responseDiff.ContentDiff == nil ||
-					responseDiff.ContentDiff.MediaTypeModified == nil {
-					continue
-				}
-				modifiedMediaTypes := responseDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							enumDiff := propertyDiff.EnumDiff
-							if enumDiff == nil || enumDiff.Added == nil {
-								return
-							}
 
-							id := ResponsePropertyEnumValueAddedId
-							comment := commentId(ResponsePropertyEnumValueAddedId)
-
-							if propertyDiff.Revision.WriteOnly {
-								// Document write-only enum update
-								id = ResponseWriteOnlyPropertyEnumValueAddedId
-								comment = ""
-							}
-
-							for _, enumVal := range enumDiff.Added {
-								baseSource, revisionSource := SchemaAddedItemSources(operationsSources, operationItem, propertyDiff, "enum", fmt.Sprintf("%v", enumVal))
-								result = append(result, NewApiChange(
-									id,
-									config,
-									[]any{enumVal, propertyFullName(propertyPath, propertyName), responseStatus},
-									comment,
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-							}
-						})
-				}
-
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		info.walkProperties(func(p propertyInfo) {
+			enumDiff := p.propertyDiff.EnumDiff
+			if enumDiff == nil || enumDiff.Added == nil {
+				return
 			}
 
-		}
-	}
+			id := ResponsePropertyEnumValueAddedId
+			comment := commentId(ResponsePropertyEnumValueAddedId)
+
+			if p.propertyDiff.Revision.WriteOnly {
+				// Document write-only enum update
+				id = ResponseWriteOnlyPropertyEnumValueAddedId
+				comment = ""
+			}
+
+			for _, enumVal := range enumDiff.Added {
+				baseSource, revisionSource := SchemaAddedItemSources(operationsSources, info.operationItem, p.propertyDiff, "enum", fmt.Sprintf("%v", enumVal))
+				result = append(result, p.newChange(
+					id,
+					[]any{enumVal, propertyFullName(p.propertyPath, p.propertyName), info.responseStatus},
+					comment,
+				).WithSources(baseSource, revisionSource))
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_response_property_enum_value_removed.go
+++ b/checker/check_response_property_enum_value_removed.go
@@ -12,52 +12,24 @@ const (
 
 func ResponseParameterEnumValueRemovedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil || operationItem.ResponsesDiff.Modified == nil {
-				continue
+
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		info.walkProperties(func(p propertyInfo) {
+			enumDiff := p.propertyDiff.EnumDiff
+			if enumDiff == nil || enumDiff.Deleted == nil {
+				return
 			}
 
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff == nil ||
-					responseDiff.ContentDiff == nil ||
-					responseDiff.ContentDiff.MediaTypeModified == nil {
-					continue
-				}
-				modifiedMediaTypes := responseDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							enumDiff := propertyDiff.EnumDiff
-							if enumDiff == nil || enumDiff.Deleted == nil {
-								return
-							}
-
-							for _, enumVal := range enumDiff.Deleted {
-								baseSource, revisionSource := SchemaDeletedItemSources(operationsSources, operationItem, propertyDiff, "enum", fmt.Sprintf("%v", enumVal))
-								result = append(result, NewApiChange(
-									ResponsePropertyEnumValueRemovedId,
-									config,
-									[]any{enumVal, propertyFullName(propertyPath, propertyName), responseStatus},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-							}
-						})
-				}
+			for _, enumVal := range enumDiff.Deleted {
+				baseSource, revisionSource := SchemaDeletedItemSources(operationsSources, info.operationItem, p.propertyDiff, "enum", fmt.Sprintf("%v", enumVal))
+				result = append(result, p.newChange(
+					ResponsePropertyEnumValueRemovedId,
+					[]any{enumVal, propertyFullName(p.propertyPath, p.propertyName), info.responseStatus},
+					"",
+				).WithSources(baseSource, revisionSource))
 			}
-		}
-	}
+		})
+	})
+
 	return result
 }


### PR DESCRIPTION
Same migration shape as the prior walker batches (#941–#952): the per-checker path / operation / requestBody|response / content / mediaType / schema boilerplate disappears in favor of `walkModifiedRequestBodySchemas` or `walkModifiedResponseSchemas` plus `info.walkProperties`. The body of each checker becomes just the predicate and result emission.

## Files in this batch

| File | Before | After |
|---|---|---|
| `check_request_property_became_enum.go` | 58 lines | 30 lines |
| `check_request_property_enum_value_updated.go` | 82 lines | 56 lines |
| `check_request_property_x_extensible_enum_value_removed.go` | 90 lines | 68 lines |
| `check_response_property_enum_value_added.go` | 74 lines | 45 lines |
| `check_response_property_enum_value_removed.go` | 63 lines | 36 lines |

All five share the enum-related theme so they sit naturally together for a comparison-shape review.

## Verification

- `go test ./checker/` — pass
- `go test ./...` — pass across `diff`, `flatten/*`, `formatters`, `internal`, `load`

No behavior change: the walker handles the same traversal the per-checker bodies did, and the checker predicates / emissions are reproduced unchanged.
