### PR TITLE
checker: migrate four numeric-constraint pairs to the media-type walker (PR-11 of #936)

### DIFF
--- a/checker/check_request_property_max_length_updated.go
+++ b/checker/check_request_property_max_length_updated.go
@@ -14,106 +14,62 @@ const (
 
 func RequestPropertyMaxLengthUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
-			}
 
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				if mediaTypeDiff.SchemaDiff == nil {
-					continue
-				}
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "maxLength")
-				if mediaTypeDiff.SchemaDiff.MaxLengthDiff != nil {
-					maxLengthDiff := mediaTypeDiff.SchemaDiff.MaxLengthDiff
-					if maxLengthDiff.From != nil &&
-						maxLengthDiff.To != nil {
-						if IsDecreasedValue(maxLengthDiff) {
-							result = append(result, NewApiChange(
-								RequestBodyMaxLengthDecreasedId,
-								config,
-								[]any{maxLengthDiff.To},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-						} else {
-							result = append(result, NewApiChange(
-								RequestBodyMaxLengthIncreasedId,
-								config,
-								[]any{maxLengthDiff.From, maxLengthDiff.To},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-						}
-					}
-				}
-
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						maxLengthDiff := propertyDiff.MaxLengthDiff
-						if maxLengthDiff == nil {
-							return
-						}
-						if maxLengthDiff.From == nil ||
-							maxLengthDiff.To == nil {
-							return
-						}
-
-						propName := propertyFullName(propertyPath, propertyName)
-						propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "maxLength")
-
-						if IsDecreasedValue(maxLengthDiff) {
-
-							id := RequestPropertyMaxLengthDecreasedId
-
-							if propertyDiff.Revision.ReadOnly {
-								id = RequestReadOnlyPropertyMaxLengthDecreasedId
-							}
-
-							result = append(result, NewApiChange(
-								id,
-								config,
-								[]any{propName, maxLengthDiff.To},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						} else {
-							result = append(result, NewApiChange(
-								RequestPropertyMaxLengthIncreasedId,
-								config,
-								[]any{propName, maxLengthDiff.From, maxLengthDiff.To},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						}
-
-					})
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "maxLength")
+		if maxLengthDiff := info.schemaDiff.MaxLengthDiff; maxLengthDiff != nil &&
+			maxLengthDiff.From != nil &&
+			maxLengthDiff.To != nil {
+			if IsDecreasedValue(maxLengthDiff) {
+				result = append(result, info.newChange(
+					RequestBodyMaxLengthDecreasedId,
+					[]any{maxLengthDiff.To},
+					"",
+				).WithSources(baseSource, revisionSource))
+			} else {
+				result = append(result, info.newChange(
+					RequestBodyMaxLengthIncreasedId,
+					[]any{maxLengthDiff.From, maxLengthDiff.To},
+					"",
+				).WithSources(baseSource, revisionSource))
 			}
 		}
-	}
+
+		info.walkProperties(func(p propertyInfo) {
+			maxLengthDiff := p.propertyDiff.MaxLengthDiff
+			if maxLengthDiff == nil {
+				return
+			}
+			if maxLengthDiff.From == nil ||
+				maxLengthDiff.To == nil {
+				return
+			}
+
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "maxLength")
+
+			if IsDecreasedValue(maxLengthDiff) {
+
+				id := RequestPropertyMaxLengthDecreasedId
+
+				if p.propertyDiff.Revision.ReadOnly {
+					id = RequestReadOnlyPropertyMaxLengthDecreasedId
+				}
+
+				result = append(result, p.newChange(
+					id,
+					[]any{propName, maxLengthDiff.To},
+					"",
+				).WithSources(propBaseSource, propRevisionSource))
+			} else {
+				result = append(result, p.newChange(
+					RequestPropertyMaxLengthIncreasedId,
+					[]any{propName, maxLengthDiff.From, maxLengthDiff.To},
+					"",
+				).WithSources(propBaseSource, propRevisionSource))
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_request_property_max_set.go
+++ b/checker/check_request_property_max_set.go
@@ -13,118 +13,58 @@ const (
 
 func RequestPropertyMaxSetCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		_, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "maximum")
+		if maxDiff := info.schemaDiff.MaxDiff; maxDiff != nil &&
+			maxDiff.From == nil &&
+			maxDiff.To != nil {
+			result = append(result, info.newChange(
+				RequestBodyMaxSetId,
+				[]any{maxDiff.To},
+				commentId(RequestBodyMaxSetId),
+			).WithSources(nil, revisionSource))
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
+		if exMaxDiff := info.schemaDiff.ExclusiveMaxDiff; exMaxDiff != nil &&
+			exMaxDiff.From == nil &&
+			exMaxDiff.To != nil {
+			_, exRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "exclusiveMaximum")
+			result = append(result, info.newChange(
+				RequestBodyExclusiveMaxSetId,
+				[]any{exMaxDiff.To},
+				commentId(RequestBodyExclusiveMaxSetId),
+			).WithSources(nil, exRevisionSource))
+		}
+
+		info.walkProperties(func(p propertyInfo) {
+			if p.propertyDiff.Revision.ReadOnly {
+				return
+			}
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+
+			if maxDiff := p.propertyDiff.MaxDiff; maxDiff != nil &&
+				maxDiff.From == nil &&
+				maxDiff.To != nil {
+				_, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "maximum")
+				result = append(result, p.newChange(
+					RequestPropertyMaxSetId,
+					[]any{propName, maxDiff.To},
+					commentId(RequestPropertyMaxSetId),
+				).WithSources(nil, propRevisionSource))
 			}
 
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				if mediaTypeDiff.SchemaDiff == nil {
-					continue
-				}
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				_, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "maximum")
-				if mediaTypeDiff.SchemaDiff.MaxDiff != nil {
-					maxDiff := mediaTypeDiff.SchemaDiff.MaxDiff
-					if maxDiff.From == nil &&
-						maxDiff.To != nil {
-						result = append(result, NewApiChange(
-							RequestBodyMaxSetId,
-							config,
-							[]any{maxDiff.To},
-							commentId(RequestBodyMaxSetId),
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-					}
-				}
-				if mediaTypeDiff.SchemaDiff.ExclusiveMaxDiff != nil {
-					exMaxDiff := mediaTypeDiff.SchemaDiff.ExclusiveMaxDiff
-					if exMaxDiff.From == nil &&
-						exMaxDiff.To != nil {
-						_, exRevisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "exclusiveMaximum")
-						result = append(result, NewApiChange(
-							RequestBodyExclusiveMaxSetId,
-							config,
-							[]any{exMaxDiff.To},
-							commentId(RequestBodyExclusiveMaxSetId),
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(nil, exRevisionSource).WithDetails(mediaTypeDetails))
-					}
-				}
-
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						maxDiff := propertyDiff.MaxDiff
-						if maxDiff == nil {
-							return
-						}
-						if maxDiff.From != nil ||
-							maxDiff.To == nil {
-							return
-						}
-						if propertyDiff.Revision.ReadOnly {
-							return
-						}
-
-						_, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "maximum")
-						result = append(result, NewApiChange(
-							RequestPropertyMaxSetId,
-							config,
-							[]any{propertyFullName(propertyPath, propertyName), maxDiff.To},
-							commentId(RequestPropertyMaxSetId),
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(nil, propRevisionSource).WithDetails(mediaTypeDetails))
-					})
-
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						exMaxDiff := propertyDiff.ExclusiveMaxDiff
-						if exMaxDiff == nil {
-							return
-						}
-						if exMaxDiff.From != nil ||
-							exMaxDiff.To == nil {
-							return
-						}
-						if propertyDiff.Revision.ReadOnly {
-							return
-						}
-
-						_, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "exclusiveMaximum")
-						result = append(result, NewApiChange(
-							RequestPropertyExclusiveMaxSetId,
-							config,
-							[]any{propertyFullName(propertyPath, propertyName), exMaxDiff.To},
-							commentId(RequestPropertyExclusiveMaxSetId),
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(nil, propRevisionSource).WithDetails(mediaTypeDetails))
-					})
+			if exMaxDiff := p.propertyDiff.ExclusiveMaxDiff; exMaxDiff != nil &&
+				exMaxDiff.From == nil &&
+				exMaxDiff.To != nil {
+				_, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "exclusiveMaximum")
+				result = append(result, p.newChange(
+					RequestPropertyExclusiveMaxSetId,
+					[]any{propName, exMaxDiff.To},
+					commentId(RequestPropertyExclusiveMaxSetId),
+				).WithSources(nil, propRevisionSource))
 			}
-		}
-	}
+		})
+	})
+
 	return result
 }

--- a/checker/check_request_property_min_set.go
+++ b/checker/check_request_property_min_set.go
@@ -13,118 +13,58 @@ const (
 
 func RequestPropertyMinSetCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		_, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "minimum")
+		if minDiff := info.schemaDiff.MinDiff; minDiff != nil &&
+			minDiff.From == nil &&
+			minDiff.To != nil {
+			result = append(result, info.newChange(
+				RequestBodyMinSetId,
+				[]any{minDiff.To},
+				commentId(RequestBodyMinSetId),
+			).WithSources(nil, revisionSource))
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
+		if exMinDiff := info.schemaDiff.ExclusiveMinDiff; exMinDiff != nil &&
+			exMinDiff.From == nil &&
+			exMinDiff.To != nil {
+			_, exRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "exclusiveMinimum")
+			result = append(result, info.newChange(
+				RequestBodyExclusiveMinSetId,
+				[]any{exMinDiff.To},
+				commentId(RequestBodyExclusiveMinSetId),
+			).WithSources(nil, exRevisionSource))
+		}
+
+		info.walkProperties(func(p propertyInfo) {
+			if p.propertyDiff.Revision.ReadOnly {
+				return
+			}
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+
+			if minDiff := p.propertyDiff.MinDiff; minDiff != nil &&
+				minDiff.From == nil &&
+				minDiff.To != nil {
+				_, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "minimum")
+				result = append(result, p.newChange(
+					RequestPropertyMinSetId,
+					[]any{propName, minDiff.To},
+					commentId(RequestPropertyMinSetId),
+				).WithSources(nil, propRevisionSource))
 			}
 
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				if mediaTypeDiff.SchemaDiff == nil {
-					continue
-				}
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				_, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "minimum")
-				if mediaTypeDiff.SchemaDiff.MinDiff != nil {
-					minDiff := mediaTypeDiff.SchemaDiff.MinDiff
-					if minDiff.From == nil &&
-						minDiff.To != nil {
-						result = append(result, NewApiChange(
-							RequestBodyMinSetId,
-							config,
-							[]any{minDiff.To},
-							commentId(RequestBodyMinSetId),
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-					}
-				}
-				if mediaTypeDiff.SchemaDiff.ExclusiveMinDiff != nil {
-					exMinDiff := mediaTypeDiff.SchemaDiff.ExclusiveMinDiff
-					if exMinDiff.From == nil &&
-						exMinDiff.To != nil {
-						_, exRevisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "exclusiveMinimum")
-						result = append(result, NewApiChange(
-							RequestBodyExclusiveMinSetId,
-							config,
-							[]any{exMinDiff.To},
-							commentId(RequestBodyExclusiveMinSetId),
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(nil, exRevisionSource).WithDetails(mediaTypeDetails))
-					}
-				}
-
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						minDiff := propertyDiff.MinDiff
-						if minDiff == nil {
-							return
-						}
-						if minDiff.From != nil ||
-							minDiff.To == nil {
-							return
-						}
-						if propertyDiff.Revision.ReadOnly {
-							return
-						}
-
-						_, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "minimum")
-						result = append(result, NewApiChange(
-							RequestPropertyMinSetId,
-							config,
-							[]any{propertyFullName(propertyPath, propertyName), minDiff.To},
-							commentId(RequestPropertyMinSetId),
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(nil, propRevisionSource).WithDetails(mediaTypeDetails))
-					})
-
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						exMinDiff := propertyDiff.ExclusiveMinDiff
-						if exMinDiff == nil {
-							return
-						}
-						if exMinDiff.From != nil ||
-							exMinDiff.To == nil {
-							return
-						}
-						if propertyDiff.Revision.ReadOnly {
-							return
-						}
-
-						_, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "exclusiveMinimum")
-						result = append(result, NewApiChange(
-							RequestPropertyExclusiveMinSetId,
-							config,
-							[]any{propertyFullName(propertyPath, propertyName), exMinDiff.To},
-							commentId(RequestPropertyExclusiveMinSetId),
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(nil, propRevisionSource).WithDetails(mediaTypeDetails))
-					})
+			if exMinDiff := p.propertyDiff.ExclusiveMinDiff; exMinDiff != nil &&
+				exMinDiff.From == nil &&
+				exMinDiff.To != nil {
+				_, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "exclusiveMinimum")
+				result = append(result, p.newChange(
+					RequestPropertyExclusiveMinSetId,
+					[]any{propName, exMinDiff.To},
+					commentId(RequestPropertyExclusiveMinSetId),
+				).WithSources(nil, propRevisionSource))
 			}
-		}
-	}
+		})
+	})
+
 	return result
 }

--- a/checker/check_response_property_max_length_increased.go
+++ b/checker/check_response_property_max_length_increased.go
@@ -11,80 +11,45 @@ const (
 
 func ResponsePropertyMaxLengthIncreasedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
+
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if maxLengthDiff := info.schemaDiff.MaxLengthDiff; maxLengthDiff != nil &&
+			maxLengthDiff.From != nil &&
+			maxLengthDiff.To != nil &&
+			IsIncreasedValue(maxLengthDiff) {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "maxLength")
+			result = append(result, info.newChange(
+				ResponseBodyMaxLengthIncreasedId,
+				[]any{maxLengthDiff.From, maxLengthDiff.To},
+				"",
+			).WithSources(baseSource, revisionSource))
 		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil || operationItem.ResponsesDiff.Modified == nil {
-				continue
+
+		info.walkProperties(func(p propertyInfo) {
+			maxLengthDiff := p.propertyDiff.MaxLengthDiff
+			if maxLengthDiff == nil {
+				return
 			}
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff == nil ||
-					responseDiff.ContentDiff == nil ||
-					responseDiff.ContentDiff.MediaTypeModified == nil {
-					continue
-				}
-				modifiedMediaTypes := responseDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					if mediaTypeDiff.SchemaDiff != nil && mediaTypeDiff.SchemaDiff.MaxLengthDiff != nil {
-						maxLengthDiff := mediaTypeDiff.SchemaDiff.MaxLengthDiff
-						if maxLengthDiff.From != nil &&
-							maxLengthDiff.To != nil {
-							if IsIncreasedValue(maxLengthDiff) {
-								baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "maxLength")
-								result = append(result, NewApiChange(
-									ResponseBodyMaxLengthIncreasedId,
-									config,
-									[]any{maxLengthDiff.From, maxLengthDiff.To},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-							}
-						}
-					}
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							maxLengthDiff := propertyDiff.MaxLengthDiff
-							if maxLengthDiff == nil {
-								return
-							}
-							if maxLengthDiff.To == nil ||
-								maxLengthDiff.From == nil {
-								return
-							}
-							if !IsIncreasedValue(maxLengthDiff) {
-								return
-							}
-
-							if propertyDiff.Revision.WriteOnly {
-								return
-							}
-
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "maxLength")
-							result = append(result, NewApiChange(
-								ResponsePropertyMaxLengthIncreasedId,
-								config,
-								[]any{propertyFullName(propertyPath, propertyName), maxLengthDiff.From, maxLengthDiff.To, responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						})
-				}
+			if maxLengthDiff.To == nil ||
+				maxLengthDiff.From == nil {
+				return
 			}
-		}
-	}
+			if !IsIncreasedValue(maxLengthDiff) {
+				return
+			}
+
+			if p.propertyDiff.Revision.WriteOnly {
+				return
+			}
+
+			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "maxLength")
+			result = append(result, p.newChange(
+				ResponsePropertyMaxLengthIncreasedId,
+				[]any{propertyFullName(p.propertyPath, p.propertyName), maxLengthDiff.From, maxLengthDiff.To, info.responseStatus},
+				"",
+			).WithSources(propBaseSource, propRevisionSource))
+		})
+	})
+
 	return result
 }


### PR DESCRIPTION
Same shape as PR-10 (#960): the per-checker path / operation / requestBody|response / content / mediaType / schema boilerplate disappears in favor of `walkModifiedRequestBodySchemas` / `walkModifiedResponseSchemas` plus `info.walkProperties`. Both body-level emissions (on `info.schemaDiff.MaxDiff` etc.) and the per-property walk live inside the same outer walker invocation.

## Bonus cleanup on the max/min set checkers

The originals called `CheckModifiedPropertiesDiff` twice in sequence (once for `MaxDiff`, once for `ExclusiveMaxDiff`) over the same property set. The walker version uses a single `info.walkProperties` pass and emits both ApiChanges per property where applicable. Same behavior, one traversal.

## Files in this batch

| File | Before | After |
|---|---|---|
| `check_request_property_max_length_updated.go` | 119 lines | 76 lines |
| `check_response_property_max_length_increased.go` | 90 lines | 55 lines |
| `check_request_property_max_set.go` | 130 lines | 72 lines |
| `check_request_property_min_set.go` | 130 lines | 72 lines |

Total: 379 lines removed, 180 added (-199 net).

## Verification

- `go test ./checker/` pass
- `go test ./...` pass across `diff`, `flatten/*`, `formatters`, `internal`, `load`

No behavior change.
