### PR TITLE
checker: migrate became_required/became_optional response pair to walker (PR-12 of #936)

### DIFF
--- a/checker/check_response_property_became_optional.go
+++ b/checker/check_response_property_became_optional.go
@@ -11,98 +11,59 @@ const (
 
 func ResponsePropertyBecameOptionalCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
 
-			if operationItem.ResponsesDiff == nil {
-				continue
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if requiredDiff := info.schemaDiff.RequiredDiff; requiredDiff != nil {
+			for _, changedRequiredPropertyName := range requiredDiff.Deleted {
+				id := ResponsePropertyBecameOptionalId
+				if info.schemaDiff.Revision.Properties[changedRequiredPropertyName] == nil {
+					// removed properties processed by the ResponseRequiredPropertyUpdatedCheck check
+					continue
+				}
+				if info.schemaDiff.Revision.Properties[changedRequiredPropertyName].Value.WriteOnly {
+					id = ResponseWriteOnlyPropertyBecameOptionalId
+				}
+
+				baseSource, revisionSource := SchemaDeletedItemSources(operationsSources, info.operationItem, info.schemaDiff, "required", changedRequiredPropertyName)
+				result = append(result, info.newChange(
+					id,
+					[]any{changedRequiredPropertyName, info.responseStatus},
+					"",
+				).WithSources(baseSource, revisionSource))
 			}
+		}
 
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff.ContentDiff == nil ||
-					responseDiff.ContentDiff.MediaTypeModified == nil {
+		info.walkProperties(func(p propertyInfo) {
+			requiredDiff := p.propertyDiff.RequiredDiff
+			if requiredDiff == nil {
+				return
+			}
+			for _, changedRequiredPropertyName := range requiredDiff.Deleted {
+
+				if p.propertyDiff.Base.Properties[changedRequiredPropertyName] == nil {
 					continue
 				}
 
-				modifiedMediaTypes := responseDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					if mediaTypeDiff.SchemaDiff == nil {
-						continue
-					}
-
-					if mediaTypeDiff.SchemaDiff.RequiredDiff != nil {
-						for _, changedRequiredPropertyName := range mediaTypeDiff.SchemaDiff.RequiredDiff.Deleted {
-							id := ResponsePropertyBecameOptionalId
-							if mediaTypeDiff.SchemaDiff.Revision.Properties[changedRequiredPropertyName] == nil {
-								// removed properties processed by the ResponseRequiredPropertyUpdatedCheck check
-								continue
-							}
-							if mediaTypeDiff.SchemaDiff.Revision.Properties[changedRequiredPropertyName].Value.WriteOnly {
-								id = ResponseWriteOnlyPropertyBecameOptionalId
-							}
-
-							baseSource, revisionSource := SchemaDeletedItemSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "required", changedRequiredPropertyName)
-							result = append(result, NewApiChange(
-								id,
-								config,
-								[]any{changedRequiredPropertyName, responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-						}
-					}
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							requiredDiff := propertyDiff.RequiredDiff
-							if requiredDiff == nil {
-								return
-							}
-							for _, changedRequiredPropertyName := range requiredDiff.Deleted {
-
-								if propertyDiff.Base.Properties[changedRequiredPropertyName] == nil {
-									continue
-								}
-
-								if propertyDiff.Revision.Properties[changedRequiredPropertyName] == nil {
-									// removed properties processed by the ResponseRequiredPropertyUpdatedCheck check
-									continue
-								}
-
-								id := ResponsePropertyBecameOptionalId
-
-								if propertyDiff.Base.Properties[changedRequiredPropertyName].Value.WriteOnly {
-									id = ResponseWriteOnlyPropertyBecameOptionalId
-								}
-
-								propBaseSource, propRevisionSource := SchemaDeletedItemSources(operationsSources, operationItem, propertyDiff, "required", changedRequiredPropertyName)
-								result = append(result, NewApiChange(
-									id,
-									config,
-									[]any{propertyFullName(propertyPath, propertyFullName(propertyName, changedRequiredPropertyName)), responseStatus},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-							}
-						})
+				if p.propertyDiff.Revision.Properties[changedRequiredPropertyName] == nil {
+					// removed properties processed by the ResponseRequiredPropertyUpdatedCheck check
+					continue
 				}
+
+				id := ResponsePropertyBecameOptionalId
+
+				if p.propertyDiff.Base.Properties[changedRequiredPropertyName].Value.WriteOnly {
+					id = ResponseWriteOnlyPropertyBecameOptionalId
+				}
+
+				propBaseSource, propRevisionSource := SchemaDeletedItemSources(operationsSources, info.operationItem, p.propertyDiff, "required", changedRequiredPropertyName)
+				result = append(result, p.newChange(
+					id,
+					[]any{propertyFullName(p.propertyPath, propertyFullName(p.propertyName, changedRequiredPropertyName)), info.responseStatus},
+					"",
+				).WithSources(propBaseSource, propRevisionSource))
 			}
-		}
-	}
+		})
+	})
 
 	return result
 }

--- a/checker/check_response_property_became_required.go
+++ b/checker/check_response_property_became_required.go
@@ -11,99 +11,60 @@ const (
 
 func ResponsePropertyBecameRequiredCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
 
-			if operationItem.ResponsesDiff == nil {
-				continue
-			}
-
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff.ContentDiff == nil ||
-					responseDiff.ContentDiff.MediaTypeModified == nil {
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if requiredDiff := info.schemaDiff.RequiredDiff; requiredDiff != nil {
+			for _, changedRequiredPropertyName := range requiredDiff.Added {
+				if info.schemaDiff.Base.Properties[changedRequiredPropertyName] == nil {
+					// added properties are processed by ResponseRequiredPropertyUpdatedCheck check
 					continue
 				}
-
-				modifiedMediaTypes := responseDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					if mediaTypeDiff.SchemaDiff == nil {
-						continue
-					}
-
-					if mediaTypeDiff.SchemaDiff.RequiredDiff != nil {
-						for _, changedRequiredPropertyName := range mediaTypeDiff.SchemaDiff.RequiredDiff.Added {
-							if mediaTypeDiff.SchemaDiff.Base.Properties[changedRequiredPropertyName] == nil {
-								// added properties are processed by ResponseRequiredPropertyUpdatedCheck check
-								continue
-							}
-							if mediaTypeDiff.SchemaDiff.Revision.Properties[changedRequiredPropertyName] == nil {
-								// removed properties processed by the ResponseRequiredPropertyUpdatedCheck check
-								continue
-							}
-							id := ResponsePropertyBecameRequiredId
-							if mediaTypeDiff.SchemaDiff.Revision.Properties[changedRequiredPropertyName].Value.WriteOnly {
-								id = ResponseWriteOnlyPropertyBecameRequiredId
-							}
-
-							baseSource, revisionSource := SchemaAddedItemSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "required", changedRequiredPropertyName)
-							result = append(result, NewApiChange(
-								id,
-								config,
-								[]any{propertyFullName("", changedRequiredPropertyName), responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-						}
-					}
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							requiredDiff := propertyDiff.RequiredDiff
-							if requiredDiff == nil {
-								return
-							}
-							for _, changedRequiredPropertyName := range requiredDiff.Added {
-								if propertyDiff.Base.Properties[changedRequiredPropertyName] == nil {
-									// added properties are processed by ResponseRequiredPropertyUpdatedCheck check
-									continue
-								}
-								if propertyDiff.Revision.Properties[changedRequiredPropertyName] == nil {
-									// removed properties processed by the ResponseRequiredPropertyUpdatedCheck check
-									continue
-								}
-								id := ResponsePropertyBecameRequiredId
-								if propertyDiff.Base.Properties[changedRequiredPropertyName].Value.WriteOnly {
-									id = ResponseWriteOnlyPropertyBecameRequiredId
-								}
-
-								propBaseSource, propRevisionSource := SchemaAddedItemSources(operationsSources, operationItem, propertyDiff, "required", changedRequiredPropertyName)
-								result = append(result, NewApiChange(
-									id,
-									config,
-									[]any{propertyFullName(propertyPath, propertyFullName(propertyName, changedRequiredPropertyName)), responseStatus},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-							}
-						})
+				if info.schemaDiff.Revision.Properties[changedRequiredPropertyName] == nil {
+					// removed properties processed by the ResponseRequiredPropertyUpdatedCheck check
+					continue
+				}
+				id := ResponsePropertyBecameRequiredId
+				if info.schemaDiff.Revision.Properties[changedRequiredPropertyName].Value.WriteOnly {
+					id = ResponseWriteOnlyPropertyBecameRequiredId
 				}
 
+				baseSource, revisionSource := SchemaAddedItemSources(operationsSources, info.operationItem, info.schemaDiff, "required", changedRequiredPropertyName)
+				result = append(result, info.newChange(
+					id,
+					[]any{propertyFullName("", changedRequiredPropertyName), info.responseStatus},
+					"",
+				).WithSources(baseSource, revisionSource))
 			}
 		}
-	}
+
+		info.walkProperties(func(p propertyInfo) {
+			requiredDiff := p.propertyDiff.RequiredDiff
+			if requiredDiff == nil {
+				return
+			}
+			for _, changedRequiredPropertyName := range requiredDiff.Added {
+				if p.propertyDiff.Base.Properties[changedRequiredPropertyName] == nil {
+					// added properties are processed by ResponseRequiredPropertyUpdatedCheck check
+					continue
+				}
+				if p.propertyDiff.Revision.Properties[changedRequiredPropertyName] == nil {
+					// removed properties processed by the ResponseRequiredPropertyUpdatedCheck check
+					continue
+				}
+				id := ResponsePropertyBecameRequiredId
+				if p.propertyDiff.Base.Properties[changedRequiredPropertyName].Value.WriteOnly {
+					id = ResponseWriteOnlyPropertyBecameRequiredId
+				}
+
+				propBaseSource, propRevisionSource := SchemaAddedItemSources(operationsSources, info.operationItem, p.propertyDiff, "required", changedRequiredPropertyName)
+				result = append(result, p.newChange(
+					id,
+					[]any{propertyFullName(p.propertyPath, propertyFullName(p.propertyName, changedRequiredPropertyName)), info.responseStatus},
+					"",
+				).WithSources(propBaseSource, propRevisionSource))
+			}
+		})
+	})
+
 	return result
 }


### PR DESCRIPTION
Same migration shape as the prior walker batches (#940–#961): the per-checker `path / operation / response / content / mediaType / schema` boilerplate disappears in favor of `walkModifiedResponseSchemas` plus `info.walkProperties`. Body-level emissions (on `info.schemaDiff.RequiredDiff`) and the per-property walk live inside one outer walker invocation.

## Files

| File | Before | After |
|---|---|---|
| `check_response_property_became_required.go` | 109 lines | 71 lines |
| `check_response_property_became_optional.go` | 108 lines | 70 lines |

The two are inverse-of-each-other checks (one fires on `requiredDiff.Added`, the other on `requiredDiff.Deleted`); migrating them together makes the shape comparison reviewable side-by-side.

## Verification

- `go test ./checker/` pass
- `go test ./...` pass across `diff`, `flatten/*`, `formatters`, `internal`, `load`

No behavior change.
