### PR TITLE
checker: migrate write-only / read-only triplet to the media-type walker (PR-14 of #936)

### DIFF
--- a/checker/check_request_property_write_only_read_only.go
+++ b/checker/check_request_property_write_only_read_only.go
@@ -1,8 +1,9 @@
 package checker
 
 import (
-	"github.com/oasdiff/oasdiff/diff"
 	"slices"
+
+	"github.com/oasdiff/oasdiff/diff"
 )
 
 const (
@@ -18,127 +19,59 @@ const (
 
 func RequestPropertyWriteOnlyReadOnlyCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
 
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		info.walkProperties(func(p propertyInfo) {
+			if p.parent.Revision.Properties[p.propertyName] == nil {
+				// removed properties processed by the RequestOptionalPropertyUpdatedCheck check
+				return
 			}
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				if mediaTypeDiff.SchemaDiff == nil {
-					continue
+			required := slices.Contains(p.parent.Base.Required, p.propertyName)
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+
+			if writeOnlyDiff := p.propertyDiff.WriteOnlyDiff; writeOnlyDiff != nil {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "writeOnly")
+				var id string
+				if required {
+					id = RequestRequiredPropertyBecameNonWriteOnlyCheckId
+					if writeOnlyDiff.To == true {
+						id = RequestRequiredPropertyBecameWriteOnlyCheckId
+					}
+				} else {
+					id = RequestOptionalPropertyBecameNonWriteOnlyCheckId
+					if writeOnlyDiff.To == true {
+						id = RequestOptionalPropertyBecameWriteOnlyCheckId
+					}
 				}
-
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						writeOnlyDiff := propertyDiff.WriteOnlyDiff
-						if writeOnlyDiff == nil {
-							return
-						}
-						if parent.Revision.Properties[propertyName] == nil {
-							// removed properties processed by the RequestOptionalPropertyUpdatedCheck check
-							return
-						}
-
-						propName := propertyFullName(propertyPath, propertyName)
-						propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "writeOnly")
-
-						if slices.Contains(parent.Base.Required, propertyName) {
-							id := RequestRequiredPropertyBecameNonWriteOnlyCheckId
-							if writeOnlyDiff.To == true {
-								id = RequestRequiredPropertyBecameWriteOnlyCheckId
-							}
-
-							result = append(result, NewApiChange(
-								id,
-								config,
-								[]any{propName},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-							return
-						}
-
-						id := RequestOptionalPropertyBecameNonWriteOnlyCheckId
-						if writeOnlyDiff.To == true {
-							id = RequestOptionalPropertyBecameWriteOnlyCheckId
-						}
-						result = append(result, NewApiChange(
-							id,
-							config,
-							[]any{propName},
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-					})
-
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						readOnlyDiff := propertyDiff.ReadOnlyDiff
-						if readOnlyDiff == nil {
-							return
-						}
-						if parent.Revision.Properties[propertyName] == nil {
-							// removed properties processed by the RequestOptionalPropertyUpdatedCheck check
-							return
-						}
-
-						propName := propertyFullName(propertyPath, propertyName)
-						propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "readOnly")
-
-						if slices.Contains(parent.Base.Required, propertyName) {
-							id := RequestRequiredPropertyBecameNonReadOnlyCheckId
-							if readOnlyDiff.To == true {
-								id = RequestRequiredPropertyBecameReadOnlyCheckId
-							}
-							result = append(result, NewApiChange(
-								id,
-								config,
-								[]any{propName},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-							return
-						}
-
-						id := RequestOptionalPropertyBecameNonReadOnlyCheckId
-						if readOnlyDiff.To == true {
-							id = RequestOptionalPropertyBecameReadOnlyCheckId
-						}
-						result = append(result, NewApiChange(
-							id,
-							config,
-							[]any{propName},
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-					})
+				result = append(result, p.newChange(
+					id,
+					[]any{propName},
+					"",
+				).WithSources(propBaseSource, propRevisionSource))
 			}
-		}
-	}
+
+			if readOnlyDiff := p.propertyDiff.ReadOnlyDiff; readOnlyDiff != nil {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "readOnly")
+				var id string
+				if required {
+					id = RequestRequiredPropertyBecameNonReadOnlyCheckId
+					if readOnlyDiff.To == true {
+						id = RequestRequiredPropertyBecameReadOnlyCheckId
+					}
+				} else {
+					id = RequestOptionalPropertyBecameNonReadOnlyCheckId
+					if readOnlyDiff.To == true {
+						id = RequestOptionalPropertyBecameReadOnlyCheckId
+					}
+				}
+				result = append(result, p.newChange(
+					id,
+					[]any{propName},
+					"",
+				).WithSources(propBaseSource, propRevisionSource))
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_response_optional_property_write_only_read_only.go
+++ b/checker/check_response_optional_property_write_only_read_only.go
@@ -1,8 +1,9 @@
 package checker
 
 import (
-	"github.com/oasdiff/oasdiff/diff"
 	"slices"
+
+	"github.com/oasdiff/oasdiff/diff"
 )
 
 const (
@@ -14,106 +15,47 @@ const (
 
 func ResponseOptionalPropertyWriteOnlyReadOnlyCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
 
-			if operationItem.ResponsesDiff == nil {
-				continue
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		info.walkProperties(func(p propertyInfo) {
+			if p.parent.Revision.Properties[p.propertyName] == nil {
+				// removed properties processed by the ResponseOptionalPropertyUpdatedCheck check
+				return
+			}
+			if slices.Contains(p.parent.Base.Required, p.propertyName) {
+				// skip required properties — checked at ResponseRequiredPropertyWriteOnlyReadOnlyCheck
+				return
 			}
 
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff.ContentDiff == nil ||
-					responseDiff.ContentDiff.MediaTypeModified == nil {
-					continue
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+
+			if writeOnlyDiff := p.propertyDiff.WriteOnlyDiff; writeOnlyDiff != nil {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "writeOnly")
+				id := ResponseOptionalPropertyBecameNonWriteOnlyId
+				if writeOnlyDiff.To == true {
+					id = ResponseOptionalPropertyBecameWriteOnlyId
 				}
-
-				modifiedMediaTypes := responseDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					if mediaTypeDiff.SchemaDiff == nil {
-						continue
-					}
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							writeOnlyDiff := propertyDiff.WriteOnlyDiff
-							if writeOnlyDiff == nil {
-								return
-							}
-							if parent.Revision.Properties[propertyName] == nil {
-								// removed properties processed by the ResponseOptionalPropertyUpdatedCheck check
-								return
-							}
-							if slices.Contains(parent.Base.Required, propertyName) {
-								// skip required properties - checked at ResponseRequiredPropertyWriteOnlyReadOnlyCheck
-								return
-							}
-
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "writeOnly")
-
-							id := ResponseOptionalPropertyBecameNonWriteOnlyId
-
-							if writeOnlyDiff.To == true {
-								id = ResponseOptionalPropertyBecameWriteOnlyId
-							}
-
-							result = append(result, NewApiChange(
-								id,
-								config,
-								[]any{propertyFullName(propertyPath, propertyName), responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						})
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							readOnlyDiff := propertyDiff.ReadOnlyDiff
-							if readOnlyDiff == nil {
-								return
-							}
-							if parent.Revision.Properties[propertyName] == nil {
-								// removed properties processed by the ResponseOptionalPropertyUpdatedCheck check
-								return
-							}
-							if slices.Contains(parent.Base.Required, propertyName) {
-								// skip non-optional properties
-								return
-							}
-
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "readOnly")
-
-							id := ResponseOptionalPropertyBecameNonReadOnlyId
-
-							if readOnlyDiff.To == true {
-								id = ResponseOptionalPropertyBecameReadOnlyId
-							}
-
-							result = append(result, NewApiChange(
-								id,
-								config,
-								[]any{propertyFullName(propertyPath, propertyName), responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						})
-				}
+				result = append(result, p.newChange(
+					id,
+					[]any{propName, info.responseStatus},
+					"",
+				).WithSources(propBaseSource, propRevisionSource))
 			}
-		}
-	}
+
+			if readOnlyDiff := p.propertyDiff.ReadOnlyDiff; readOnlyDiff != nil {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "readOnly")
+				id := ResponseOptionalPropertyBecameNonReadOnlyId
+				if readOnlyDiff.To == true {
+					id = ResponseOptionalPropertyBecameReadOnlyId
+				}
+				result = append(result, p.newChange(
+					id,
+					[]any{propName, info.responseStatus},
+					"",
+				).WithSources(propBaseSource, propRevisionSource))
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_response_required_property_write_only_read_only.go
+++ b/checker/check_response_required_property_write_only_read_only.go
@@ -1,8 +1,9 @@
 package checker
 
 import (
-	"github.com/oasdiff/oasdiff/diff"
 	"slices"
+
+	"github.com/oasdiff/oasdiff/diff"
 )
 
 const (
@@ -14,109 +15,49 @@ const (
 
 func ResponseRequiredPropertyWriteOnlyReadOnlyCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
 
-			if operationItem.ResponsesDiff == nil {
-				continue
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		info.walkProperties(func(p propertyInfo) {
+			if p.parent.Revision.Properties[p.propertyName] == nil {
+				// removed properties processed by the ResponseRequiredPropertyUpdatedCheck check
+				return
+			}
+			if !slices.Contains(p.parent.Base.Required, p.propertyName) {
+				// skip non-required properties
+				return
 			}
 
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff.ContentDiff == nil ||
-					responseDiff.ContentDiff.MediaTypeModified == nil {
-					continue
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+
+			if writeOnlyDiff := p.propertyDiff.WriteOnlyDiff; writeOnlyDiff != nil {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "writeOnly")
+				id := ResponseRequiredPropertyBecameNonWriteOnlyId
+				comment := commentId(ResponseRequiredPropertyBecameNonWriteOnlyId)
+				if writeOnlyDiff.To == true {
+					id = ResponseRequiredPropertyBecameWriteOnlyId
+					comment = ""
 				}
-
-				modifiedMediaTypes := responseDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					if mediaTypeDiff.SchemaDiff == nil {
-						continue
-					}
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							writeOnlyDiff := propertyDiff.WriteOnlyDiff
-							if writeOnlyDiff == nil {
-								return
-							}
-							if parent.Revision.Properties[propertyName] == nil {
-								// removed properties processed by the ResponseRequiredPropertyUpdatedCheck check
-								return
-							}
-							if !slices.Contains(parent.Base.Required, propertyName) {
-								// skip non-required properties
-								return
-							}
-
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "writeOnly")
-
-							id := ResponseRequiredPropertyBecameNonWriteOnlyId
-							comment := commentId(ResponseRequiredPropertyBecameNonWriteOnlyId)
-
-							if writeOnlyDiff.To == true {
-								id = ResponseRequiredPropertyBecameWriteOnlyId
-								comment = ""
-							}
-
-							result = append(result, NewApiChange(
-								id,
-								config,
-								[]any{propertyFullName(propertyPath, propertyName), responseStatus},
-								comment,
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						})
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							readOnlyDiff := propertyDiff.ReadOnlyDiff
-							if readOnlyDiff == nil {
-								return
-							}
-							if parent.Revision.Properties[propertyName] == nil {
-								// removed properties processed by the ResponseRequiredPropertyUpdatedCheck check
-								return
-							}
-							if !slices.Contains(parent.Base.Required, propertyName) {
-								// skip non-required properties
-								return
-							}
-
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "readOnly")
-
-							id := ResponseRequiredPropertyBecameNonReadOnlyId
-
-							if readOnlyDiff.To == true {
-								id = ResponseRequiredPropertyBecameReadOnlyId
-							}
-
-							result = append(result, NewApiChange(
-								id,
-								config,
-								[]any{propertyFullName(propertyPath, propertyName), responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-						})
-				}
+				result = append(result, p.newChange(
+					id,
+					[]any{propName, info.responseStatus},
+					comment,
+				).WithSources(propBaseSource, propRevisionSource))
 			}
-		}
-	}
+
+			if readOnlyDiff := p.propertyDiff.ReadOnlyDiff; readOnlyDiff != nil {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "readOnly")
+				id := ResponseRequiredPropertyBecameNonReadOnlyId
+				if readOnlyDiff.To == true {
+					id = ResponseRequiredPropertyBecameReadOnlyId
+				}
+				result = append(result, p.newChange(
+					id,
+					[]any{propName, info.responseStatus},
+					"",
+				).WithSources(propBaseSource, propRevisionSource))
+			}
+		})
+	})
 
 	return result
 }


### PR DESCRIPTION
Same migration shape as the prior walker batches (#940–#963): the per-checker `path / operation / requestBody|response / content / mediaType / schema` boilerplate disappears in favor of `walkModifiedRequestBodySchemas` / `walkModifiedResponseSchemas` plus `info.walkProperties`.

## Bonus cleanup

Each file called `CheckModifiedPropertiesDiff` twice in sequence (once for `WriteOnlyDiff`, once for `ReadOnlyDiff`) over the same property set. The walker version uses a single `info.walkProperties` pass and emits one ApiChange per applicable diff. Same behavior, one traversal.

## Required vs optional gating

All three checks classify each property by `parent.Base.Required` before selecting the change ID. `propertyInfo` exposes the parent diff via `p.parent`, so the gating preserves 1:1 with the original.

## Files

| File | Before | After |
|---|---|---|
| `check_request_property_write_only_read_only.go` | 144 lines | 79 lines |
| `check_response_optional_property_write_only_read_only.go` | 119 lines | 61 lines |
| `check_response_required_property_write_only_read_only.go` | 122 lines | 65 lines |

Net: -180 lines.

## Verification

- `go test ./checker/` pass (`WriteOnly` / `ReadOnly` tests + full suite).
- `go test ./...` pass across `diff`, `flatten/*`, `formatters`, `internal`, `load`.

No behavior change.