### PR TITLE
checker: migrate contains pair to the media-type walker (PR-15 of #936)

### DIFF
--- a/checker/check_request_property_contains_updated.go
+++ b/checker/check_request_property_contains_updated.go
@@ -21,208 +21,84 @@ const (
 
 func RequestPropertyContainsUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
 
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if containsDiff := info.schemaDiff.ContainsDiff; containsDiff != nil {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "contains")
+			if containsDiff.SchemaAdded {
+				result = append(result, info.newChange(RequestBodyContainsAddedId, nil, "").
+					WithSources(nil, revisionSource))
 			}
-
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				if mediaTypeDiff.SchemaDiff == nil {
-					continue
-				}
-
-				if mediaTypeDiff.SchemaDiff.ContainsDiff != nil {
-					baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "contains")
-					if mediaTypeDiff.SchemaDiff.ContainsDiff.SchemaAdded {
-						result = append(result, NewApiChange(
-							RequestBodyContainsAddedId,
-							config,
-							nil,
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-					}
-					if mediaTypeDiff.SchemaDiff.ContainsDiff.SchemaDeleted {
-						result = append(result, NewApiChange(
-							RequestBodyContainsRemovedId,
-							config,
-							nil,
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-					}
-				}
-
-				if mediaTypeDiff.SchemaDiff.MinContainsDiff != nil {
-					baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "minContains")
-					d := mediaTypeDiff.SchemaDiff.MinContainsDiff
-					if IsIncreasedValue(d) {
-						result = append(result, NewApiChange(
-							RequestBodyMinContainsIncreasedId,
-							config,
-							[]any{d.From, d.To},
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-					}
-					if IsDecreasedValue(d) {
-						result = append(result, NewApiChange(
-							RequestBodyMinContainsDecreasedId,
-							config,
-							[]any{d.From, d.To},
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-					}
-				}
-
-				if mediaTypeDiff.SchemaDiff.MaxContainsDiff != nil {
-					baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "maxContains")
-					d := mediaTypeDiff.SchemaDiff.MaxContainsDiff
-					if IsIncreasedValue(d) {
-						result = append(result, NewApiChange(
-							RequestBodyMaxContainsIncreasedId,
-							config,
-							[]any{d.From, d.To},
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-					}
-					if IsDecreasedValue(d) {
-						result = append(result, NewApiChange(
-							RequestBodyMaxContainsDecreasedId,
-							config,
-							[]any{d.From, d.To},
-							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
-						).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-					}
-				}
-
-				CheckModifiedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-						propName := propertyFullName(propertyPath, propertyName)
-
-						if propertyDiff.ContainsDiff != nil {
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "contains")
-							if propertyDiff.ContainsDiff.SchemaAdded {
-								result = append(result, NewApiChange(
-									RequestPropertyContainsAddedId,
-									config,
-									[]any{propName},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(nil, propRevisionSource).WithDetails(mediaTypeDetails))
-							}
-							if propertyDiff.ContainsDiff.SchemaDeleted {
-								result = append(result, NewApiChange(
-									RequestPropertyContainsRemovedId,
-									config,
-									[]any{propName},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(propBaseSource, nil).WithDetails(mediaTypeDetails))
-							}
-						}
-
-						if propertyDiff.MinContainsDiff != nil {
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "minContains")
-							d := propertyDiff.MinContainsDiff
-							if IsIncreasedValue(d) {
-								result = append(result, NewApiChange(
-									RequestPropertyMinContainsIncreasedId,
-									config,
-									[]any{propName, d.From, d.To},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-							}
-							if IsDecreasedValue(d) {
-								result = append(result, NewApiChange(
-									RequestPropertyMinContainsDecreasedId,
-									config,
-									[]any{propName, d.From, d.To},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-							}
-						}
-
-						if propertyDiff.MaxContainsDiff != nil {
-							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "maxContains")
-							d := propertyDiff.MaxContainsDiff
-							if IsIncreasedValue(d) {
-								result = append(result, NewApiChange(
-									RequestPropertyMaxContainsIncreasedId,
-									config,
-									[]any{propName, d.From, d.To},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-							}
-							if IsDecreasedValue(d) {
-								result = append(result, NewApiChange(
-									RequestPropertyMaxContainsDecreasedId,
-									config,
-									[]any{propName, d.From, d.To},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-							}
-						}
-					})
+			if containsDiff.SchemaDeleted {
+				result = append(result, info.newChange(RequestBodyContainsRemovedId, nil, "").
+					WithSources(baseSource, nil))
 			}
 		}
-	}
+
+		if d := info.schemaDiff.MinContainsDiff; d != nil {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "minContains")
+			if IsIncreasedValue(d) {
+				result = append(result, info.newChange(RequestBodyMinContainsIncreasedId, []any{d.From, d.To}, "").
+					WithSources(baseSource, revisionSource))
+			}
+			if IsDecreasedValue(d) {
+				result = append(result, info.newChange(RequestBodyMinContainsDecreasedId, []any{d.From, d.To}, "").
+					WithSources(baseSource, revisionSource))
+			}
+		}
+
+		if d := info.schemaDiff.MaxContainsDiff; d != nil {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "maxContains")
+			if IsIncreasedValue(d) {
+				result = append(result, info.newChange(RequestBodyMaxContainsIncreasedId, []any{d.From, d.To}, "").
+					WithSources(baseSource, revisionSource))
+			}
+			if IsDecreasedValue(d) {
+				result = append(result, info.newChange(RequestBodyMaxContainsDecreasedId, []any{d.From, d.To}, "").
+					WithSources(baseSource, revisionSource))
+			}
+		}
+
+		info.walkProperties(func(p propertyInfo) {
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+
+			if containsDiff := p.propertyDiff.ContainsDiff; containsDiff != nil {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "contains")
+				if containsDiff.SchemaAdded {
+					result = append(result, p.newChange(RequestPropertyContainsAddedId, []any{propName}, "").
+						WithSources(nil, propRevisionSource))
+				}
+				if containsDiff.SchemaDeleted {
+					result = append(result, p.newChange(RequestPropertyContainsRemovedId, []any{propName}, "").
+						WithSources(propBaseSource, nil))
+				}
+			}
+
+			if d := p.propertyDiff.MinContainsDiff; d != nil {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "minContains")
+				if IsIncreasedValue(d) {
+					result = append(result, p.newChange(RequestPropertyMinContainsIncreasedId, []any{propName, d.From, d.To}, "").
+						WithSources(propBaseSource, propRevisionSource))
+				}
+				if IsDecreasedValue(d) {
+					result = append(result, p.newChange(RequestPropertyMinContainsDecreasedId, []any{propName, d.From, d.To}, "").
+						WithSources(propBaseSource, propRevisionSource))
+				}
+			}
+
+			if d := p.propertyDiff.MaxContainsDiff; d != nil {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "maxContains")
+				if IsIncreasedValue(d) {
+					result = append(result, p.newChange(RequestPropertyMaxContainsIncreasedId, []any{propName, d.From, d.To}, "").
+						WithSources(propBaseSource, propRevisionSource))
+				}
+				if IsDecreasedValue(d) {
+					result = append(result, p.newChange(RequestPropertyMaxContainsDecreasedId, []any{propName, d.From, d.To}, "").
+						WithSources(propBaseSource, propRevisionSource))
+				}
+			}
+		})
+	})
+
 	return result
 }

--- a/checker/check_response_property_contains_updated.go
+++ b/checker/check_response_property_contains_updated.go
@@ -21,212 +21,84 @@ const (
 
 func ResponsePropertyContainsUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
 
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.ResponsesDiff == nil || operationItem.ResponsesDiff.Modified == nil {
-				continue
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		if containsDiff := info.schemaDiff.ContainsDiff; containsDiff != nil {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "contains")
+			if containsDiff.SchemaAdded {
+				result = append(result, info.newChange(ResponseBodyContainsAddedId, []any{info.responseStatus}, "").
+					WithSources(nil, revisionSource))
 			}
-
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff.ContentDiff == nil || responseDiff.ContentDiff.MediaTypeModified == nil {
-					continue
-				}
-
-				modifiedMediaTypes := responseDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					if mediaTypeDiff.SchemaDiff == nil {
-						continue
-					}
-
-					if mediaTypeDiff.SchemaDiff.ContainsDiff != nil {
-						baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "contains")
-						if mediaTypeDiff.SchemaDiff.ContainsDiff.SchemaAdded {
-							result = append(result, NewApiChange(
-								ResponseBodyContainsAddedId,
-								config,
-								[]any{responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-						}
-						if mediaTypeDiff.SchemaDiff.ContainsDiff.SchemaDeleted {
-							result = append(result, NewApiChange(
-								ResponseBodyContainsRemovedId,
-								config,
-								[]any{responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-						}
-					}
-
-					if mediaTypeDiff.SchemaDiff.MinContainsDiff != nil {
-						baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "minContains")
-						d := mediaTypeDiff.SchemaDiff.MinContainsDiff
-						if IsIncreasedValue(d) {
-							result = append(result, NewApiChange(
-								ResponseBodyMinContainsIncreasedId,
-								config,
-								[]any{d.From, d.To, responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-						}
-						if IsDecreasedValue(d) {
-							result = append(result, NewApiChange(
-								ResponseBodyMinContainsDecreasedId,
-								config,
-								[]any{d.From, d.To, responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-						}
-					}
-
-					if mediaTypeDiff.SchemaDiff.MaxContainsDiff != nil {
-						baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, mediaTypeDiff.SchemaDiff, "maxContains")
-						d := mediaTypeDiff.SchemaDiff.MaxContainsDiff
-						if IsIncreasedValue(d) {
-							result = append(result, NewApiChange(
-								ResponseBodyMaxContainsIncreasedId,
-								config,
-								[]any{d.From, d.To, responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-						}
-						if IsDecreasedValue(d) {
-							result = append(result, NewApiChange(
-								ResponseBodyMaxContainsDecreasedId,
-								config,
-								[]any{d.From, d.To, responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
-						}
-					}
-
-					CheckModifiedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
-							propName := propertyFullName(propertyPath, propertyName)
-
-							if propertyDiff.ContainsDiff != nil {
-								propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "contains")
-								if propertyDiff.ContainsDiff.SchemaAdded {
-									result = append(result, NewApiChange(
-										ResponsePropertyContainsAddedId,
-										config,
-										[]any{propName, responseStatus},
-										"",
-										operationsSources,
-										operationItem.Revision,
-										operation,
-										path,
-									).WithSources(nil, propRevisionSource).WithDetails(mediaTypeDetails))
-								}
-								if propertyDiff.ContainsDiff.SchemaDeleted {
-									result = append(result, NewApiChange(
-										ResponsePropertyContainsRemovedId,
-										config,
-										[]any{propName, responseStatus},
-										"",
-										operationsSources,
-										operationItem.Revision,
-										operation,
-										path,
-									).WithSources(propBaseSource, nil).WithDetails(mediaTypeDetails))
-								}
-							}
-
-							if propertyDiff.MinContainsDiff != nil {
-								propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "minContains")
-								d := propertyDiff.MinContainsDiff
-								if IsIncreasedValue(d) {
-									result = append(result, NewApiChange(
-										ResponsePropertyMinContainsIncreasedId,
-										config,
-										[]any{propName, d.From, d.To, responseStatus},
-										"",
-										operationsSources,
-										operationItem.Revision,
-										operation,
-										path,
-									).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-								}
-								if IsDecreasedValue(d) {
-									result = append(result, NewApiChange(
-										ResponsePropertyMinContainsDecreasedId,
-										config,
-										[]any{propName, d.From, d.To, responseStatus},
-										"",
-										operationsSources,
-										operationItem.Revision,
-										operation,
-										path,
-									).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-								}
-							}
-
-							if propertyDiff.MaxContainsDiff != nil {
-								propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "maxContains")
-								d := propertyDiff.MaxContainsDiff
-								if IsIncreasedValue(d) {
-									result = append(result, NewApiChange(
-										ResponsePropertyMaxContainsIncreasedId,
-										config,
-										[]any{propName, d.From, d.To, responseStatus},
-										"",
-										operationsSources,
-										operationItem.Revision,
-										operation,
-										path,
-									).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-								}
-								if IsDecreasedValue(d) {
-									result = append(result, NewApiChange(
-										ResponsePropertyMaxContainsDecreasedId,
-										config,
-										[]any{propName, d.From, d.To, responseStatus},
-										"",
-										operationsSources,
-										operationItem.Revision,
-										operation,
-										path,
-									).WithSources(propBaseSource, propRevisionSource).WithDetails(mediaTypeDetails))
-								}
-							}
-						})
-				}
+			if containsDiff.SchemaDeleted {
+				result = append(result, info.newChange(ResponseBodyContainsRemovedId, []any{info.responseStatus}, "").
+					WithSources(baseSource, nil))
 			}
 		}
-	}
+
+		if d := info.schemaDiff.MinContainsDiff; d != nil {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "minContains")
+			if IsIncreasedValue(d) {
+				result = append(result, info.newChange(ResponseBodyMinContainsIncreasedId, []any{d.From, d.To, info.responseStatus}, "").
+					WithSources(baseSource, revisionSource))
+			}
+			if IsDecreasedValue(d) {
+				result = append(result, info.newChange(ResponseBodyMinContainsDecreasedId, []any{d.From, d.To, info.responseStatus}, "").
+					WithSources(baseSource, revisionSource))
+			}
+		}
+
+		if d := info.schemaDiff.MaxContainsDiff; d != nil {
+			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "maxContains")
+			if IsIncreasedValue(d) {
+				result = append(result, info.newChange(ResponseBodyMaxContainsIncreasedId, []any{d.From, d.To, info.responseStatus}, "").
+					WithSources(baseSource, revisionSource))
+			}
+			if IsDecreasedValue(d) {
+				result = append(result, info.newChange(ResponseBodyMaxContainsDecreasedId, []any{d.From, d.To, info.responseStatus}, "").
+					WithSources(baseSource, revisionSource))
+			}
+		}
+
+		info.walkProperties(func(p propertyInfo) {
+			propName := propertyFullName(p.propertyPath, p.propertyName)
+
+			if containsDiff := p.propertyDiff.ContainsDiff; containsDiff != nil {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "contains")
+				if containsDiff.SchemaAdded {
+					result = append(result, p.newChange(ResponsePropertyContainsAddedId, []any{propName, info.responseStatus}, "").
+						WithSources(nil, propRevisionSource))
+				}
+				if containsDiff.SchemaDeleted {
+					result = append(result, p.newChange(ResponsePropertyContainsRemovedId, []any{propName, info.responseStatus}, "").
+						WithSources(propBaseSource, nil))
+				}
+			}
+
+			if d := p.propertyDiff.MinContainsDiff; d != nil {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "minContains")
+				if IsIncreasedValue(d) {
+					result = append(result, p.newChange(ResponsePropertyMinContainsIncreasedId, []any{propName, d.From, d.To, info.responseStatus}, "").
+						WithSources(propBaseSource, propRevisionSource))
+				}
+				if IsDecreasedValue(d) {
+					result = append(result, p.newChange(ResponsePropertyMinContainsDecreasedId, []any{propName, d.From, d.To, info.responseStatus}, "").
+						WithSources(propBaseSource, propRevisionSource))
+				}
+			}
+
+			if d := p.propertyDiff.MaxContainsDiff; d != nil {
+				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "maxContains")
+				if IsIncreasedValue(d) {
+					result = append(result, p.newChange(ResponsePropertyMaxContainsIncreasedId, []any{propName, d.From, d.To, info.responseStatus}, "").
+						WithSources(propBaseSource, propRevisionSource))
+				}
+				if IsDecreasedValue(d) {
+					result = append(result, p.newChange(ResponsePropertyMaxContainsDecreasedId, []any{propName, d.From, d.To, info.responseStatus}, "").
+						WithSources(propBaseSource, propRevisionSource))
+				}
+			}
+		})
+	})
+
 	return result
 }


### PR DESCRIPTION
Same migration shape as the prior walker batches (#940–#970): the per-checker `path / operation / requestBody|response / content / mediaType / schema` boilerplate disappears in favor of `walkModifiedRequestBodySchemas` / `walkModifiedResponseSchemas` plus `info.walkProperties`.

Each file handles three orthogonal schema fields (`ContainsDiff`, `MinContainsDiff`, `MaxContainsDiff`) at both body level and per-property level. Pre-migration this required hand-threading `path / operation / operationItem / mediaType / mediaTypeDiff / responseStatus` through every emission site. Post-migration the walker carries all of it on `mediaTypeInfo` / `propertyInfo` and the per-field logic stays unchanged.

## Files

| File | Before | After |
|---|---|---|
| `check_request_property_contains_updated.go` | 228 lines | 102 lines |
| `check_response_property_contains_updated.go` | 232 lines | 102 lines |

Largest single-batch line reduction in the migration so far.

## Verification

- `go test ./checker/ -run Contains` pass.
- `go test ./...` pass across `diff`, `flatten/*`, `formatters`, `internal`, `load`.

No behavior change at the message level.