### PR TITLE
checker: migrate property-updated pair to the media-type walker (PR-16 of #936)

### DIFF
--- a/checker/check_request_property_updated.go
+++ b/checker/check_request_property_updated.go
@@ -1,9 +1,10 @@
 package checker
 
 import (
+	"slices"
+
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
-	"slices"
 )
 
 const (
@@ -15,88 +16,57 @@ const (
 
 func RequestPropertyUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
-			if operationItem.RequestBodyDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff == nil ||
-				operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified == nil {
-				continue
-			}
-			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
-			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-				CheckDeletedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, parent *diff.SchemaDiff) {
-						if !propertyItem.ReadOnly {
-							baseSource := propertySource(operationsSources, operationItem.Base, propertyItem)
-							result = append(result, NewApiChange(
-								RequestPropertyRemovedId,
-								config,
-								[]any{propertyFullName(propertyPath, propertyName)},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-						}
-					})
-				CheckAddedPropertiesDiff(
-					mediaTypeDiff.SchemaDiff,
-					func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, parent *diff.SchemaDiff) {
-						if propertyItem.ReadOnly {
-							return
-						}
 
-						propName := propertyFullName(propertyPath, propertyName)
-						revisionSource := propertySource(operationsSources, operationItem.Revision, propertyItem)
+	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		// CheckDeletedPropertiesDiff / CheckAddedPropertiesDiff handle the
+		// added/removed property sides — different from info.walkProperties,
+		// which delegates to CheckModifiedPropertiesDiff. Used directly here.
+		CheckDeletedPropertiesDiff(
+			info.schemaDiff,
+			func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, parent *diff.SchemaDiff) {
+				if !propertyItem.ReadOnly {
+					baseSource := propertySource(operationsSources, info.operationItem.Base, propertyItem)
+					result = append(result, info.newChange(
+						RequestPropertyRemovedId,
+						[]any{propertyFullName(propertyPath, propertyName)},
+						"",
+					).WithSources(baseSource, nil))
+				}
+			})
 
-						if slices.Contains(parent.Revision.Required, propertyName) {
-							if propertyItem.Default == nil {
-								result = append(result, NewApiChange(
-									NewRequiredRequestPropertyId,
-									config,
-									[]any{propName},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-							} else {
-								result = append(result, NewApiChange(
-									NewRequiredRequestPropertyWithDefaultId,
-									config,
-									[]any{propName},
-									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
-								).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-							}
-						} else {
-							result = append(result, NewApiChange(
-								NewOptionalRequestPropertyId,
-								config,
-								[]any{propName},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-						}
-					})
-			}
-		}
-	}
+		CheckAddedPropertiesDiff(
+			info.schemaDiff,
+			func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, parent *diff.SchemaDiff) {
+				if propertyItem.ReadOnly {
+					return
+				}
+
+				propName := propertyFullName(propertyPath, propertyName)
+				revisionSource := propertySource(operationsSources, info.operationItem.Revision, propertyItem)
+
+				if slices.Contains(parent.Revision.Required, propertyName) {
+					if propertyItem.Default == nil {
+						result = append(result, info.newChange(
+							NewRequiredRequestPropertyId,
+							[]any{propName},
+							"",
+						).WithSources(nil, revisionSource))
+					} else {
+						result = append(result, info.newChange(
+							NewRequiredRequestPropertyWithDefaultId,
+							[]any{propName},
+							"",
+						).WithSources(nil, revisionSource))
+					}
+				} else {
+					result = append(result, info.newChange(
+						NewOptionalRequestPropertyId,
+						[]any{propName},
+						"",
+					).WithSources(nil, revisionSource))
+				}
+			})
+	})
+
 	return result
 }

--- a/checker/check_response_optional_property_updated.go
+++ b/checker/check_response_optional_property_updated.go
@@ -1,9 +1,10 @@
 package checker
 
 import (
+	"slices"
+
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
-	"slices"
 )
 
 const (
@@ -15,80 +16,50 @@ const (
 
 func ResponseOptionalPropertyUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.OperationsSourcesMap, config *Config) Changes {
 	result := make(Changes, 0)
-	if diffReport.PathsDiff == nil {
-		return result
-	}
-	for path, pathItem := range diffReport.PathsDiff.Modified {
-		if pathItem.OperationsDiff == nil {
-			continue
-		}
-		for operation, operationItem := range pathItem.OperationsDiff.Modified {
 
-			if operationItem.ResponsesDiff == nil {
-				continue
-			}
-
-			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
-				if responseDiff.ContentDiff == nil ||
-					responseDiff.ContentDiff.MediaTypeModified == nil {
-					continue
+	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
+		// CheckDeletedPropertiesDiff / CheckAddedPropertiesDiff handle the
+		// added/removed property sides; info.walkProperties only delegates
+		// to CheckModifiedPropertiesDiff so the primitives are called
+		// directly inside the walker callback.
+		CheckDeletedPropertiesDiff(
+			info.schemaDiff,
+			func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, parent *diff.SchemaDiff) {
+				if slices.Contains(parent.Base.Required, propertyName) {
+					// covered by response-required-property-removed
+					return
 				}
-
-				modifiedMediaTypes := responseDiff.ContentDiff.MediaTypeModified
-				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					mediaTypeDetails := formatMediaTypeDetails(mediaType, len(modifiedMediaTypes))
-					CheckDeletedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, parent *diff.SchemaDiff) {
-							id := ResponseOptionalPropertyRemovedId
-							if propertyItem.WriteOnly {
-								id = ResponseOptionalWriteOnlyPropertyRemovedId
-							}
-							if slices.Contains(parent.Base.Required, propertyName) {
-								// covered by response-required-property-removed
-								return
-							}
-
-							baseSource := propertySource(operationsSources, operationItem.Base, propertyItem)
-							result = append(result, NewApiChange(
-								id,
-								config,
-								[]any{propertyFullName(propertyPath, propertyName), responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(baseSource, nil).WithDetails(mediaTypeDetails))
-						})
-					CheckAddedPropertiesDiff(
-						mediaTypeDiff.SchemaDiff,
-						func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, parent *diff.SchemaDiff) {
-							id := ResponseOptionalPropertyAddedId
-							if propertyItem.WriteOnly {
-								id = ResponseOptionalWriteOnlyPropertyAddedId
-							}
-
-							if slices.Contains(parent.Revision.Required, propertyName) {
-								// covered by response-required-property-added
-								return
-							}
-
-							revisionSource := propertySource(operationsSources, operationItem.Revision, propertyItem)
-							result = append(result, NewApiChange(
-								id,
-								config,
-								[]any{propertyFullName(propertyPath, propertyName), responseStatus},
-								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
-							).WithSources(nil, revisionSource).WithDetails(mediaTypeDetails))
-						})
+				id := ResponseOptionalPropertyRemovedId
+				if propertyItem.WriteOnly {
+					id = ResponseOptionalWriteOnlyPropertyRemovedId
 				}
-			}
-		}
-	}
+				baseSource := propertySource(operationsSources, info.operationItem.Base, propertyItem)
+				result = append(result, info.newChange(
+					id,
+					[]any{propertyFullName(propertyPath, propertyName), info.responseStatus},
+					"",
+				).WithSources(baseSource, nil))
+			})
+
+		CheckAddedPropertiesDiff(
+			info.schemaDiff,
+			func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, parent *diff.SchemaDiff) {
+				if slices.Contains(parent.Revision.Required, propertyName) {
+					// covered by response-required-property-added
+					return
+				}
+				id := ResponseOptionalPropertyAddedId
+				if propertyItem.WriteOnly {
+					id = ResponseOptionalWriteOnlyPropertyAddedId
+				}
+				revisionSource := propertySource(operationsSources, info.operationItem.Revision, propertyItem)
+				result = append(result, info.newChange(
+					id,
+					[]any{propertyFullName(propertyPath, propertyName), info.responseStatus},
+					"",
+				).WithSources(nil, revisionSource))
+			})
+	})
+
 	return result
 }


### PR DESCRIPTION
**Final batch in the media-type walker migration series.** With #970, #971, and this PR merged, every checker that operates over request body or response body schemas runs through the walker. The remaining unmigrated checkers all operate on parameters / headers and would need a separate parameter walker; out of scope for #936.

## Files

| File | Before | After |
|---|---|---|
| `check_request_property_updated.go` | 102 lines | 70 lines |
| `check_response_optional_property_updated.go` | 94 lines | 60 lines |

Both checks use `CheckDeletedPropertiesDiff` / `CheckAddedPropertiesDiff` for their per-property iteration (`info.walkProperties` only delegates to `CheckModifiedPropertiesDiff`). The walker handles the outer `path / operation / requestBody|response / content / mediaType` traversal; the added / deleted primitives stay inside the callback unchanged. This is the same pattern PR #952 (`response-required-property-updated`) established and is preserved here.

## Migration summary across the series

- **Foundation:** #940 introduced the walker + `mediaTypeInfo` / `propertyInfo` types.
- **Pilots and early batches:** #941 #942 #943 #944 #945 #946 #947 #948 #949 #951 #952 (over April / early May).
- **Today's run:** #960 (enum pairs), #961 (numeric constraints), #962 (became_required / became_optional), #963 (deprecation), #970 (write-only / read-only triplet), #971 (contains pair), #972 (this PR).

Roughly 1300 net lines removed across the series. Per-check function shape is now uniform; new checks added in the future drop into the same shape.

## Verification

- `go test ./checker/` pass.
- `go test ./...` pass across `diff`, `flatten/*`, `formatters`, `internal`, `load`.

No behavior change.