### PR TITLE
docs: bump oasdiff-action references to v0.0.50

### DIFF
--- a/docs/CONTRIB.md
+++ b/docs/CONTRIB.md
@@ -16,7 +16,7 @@ The simplest contribution is to use oasdiff in your projects and tell others abo
 If your team uses GitHub, install the [oasdiff GitHub Action](https://github.com/oasdiff/oasdiff-action) to automatically detect breaking changes on every pull request:
 
 ```yaml
-- uses: oasdiff/oasdiff-action/changelog@v0.0.49
+- uses: oasdiff/oasdiff-action/changelog@v0.0.50
   with:
     base: 'origin/${{ github.base_ref }}:openapi.yaml'
     revision: 'HEAD:openapi.yaml'

--- a/docs/GIT-REVISION.md
+++ b/docs/GIT-REVISION.md
@@ -63,7 +63,7 @@ jobs:
         with:
           fetch-depth: 0          # full history needed for git refs
 
-      - uses: oasdiff/oasdiff-action/breaking@v0.0.49
+      - uses: oasdiff/oasdiff-action/breaking@v0.0.50
         with:
           base: 'origin/${{ github.base_ref }}:openapi.yaml'
           revision: 'HEAD:openapi.yaml'


### PR DESCRIPTION
Trailing bump from the v1.18.0 release wave. `docs/GIT-REVISION.md` and `docs/CONTRIB.md` each pinned a `uses: oasdiff/oasdiff-action/<job>@v0.0.49` line in workflow examples; both now point at v0.0.50.

- oasdiff-action v0.0.50: https://github.com/oasdiff/oasdiff-action/releases/tag/v0.0.50