### PR TITLE
fix: honor --allow-external-refs on the git-revision load path

### DIFF
--- a/load/load.go
+++ b/load/load.go
@@ -68,13 +68,22 @@ func loadFromGitRevision(loader *openapi3.Loader, gitRef string) (*openapi3.T, e
 		return &result
 	}
 
-	// kin-openapi calls ReadFromURIFunc before checking IsExternalRefsAllowed, so the
-	// caller's --allow-external-refs setting is still enforced for non-git refs via
-	// DefaultReadFromURI.
+	// kin-openapi skips its own allowsExternalRefs policy check whenever a custom
+	// ReadFromURIFunc is installed (see openapi3.Loader.resolveComponent), so we
+	// must enforce IsExternalRefsAllowed here. Intra-git relative $refs keep their
+	// "<rev>:" prefix (via JoinFunc above) and are read with "git show". Any other
+	// $ref is genuinely external — an http(s) URL or a local file path outside the
+	// git tree — so honor IsExternalRefsAllowed: with --allow-external-refs=false a
+	// spec loaded from an (attacker-controlled) git blob must not be able to read
+	// local files or reach arbitrary URLs (SSRF). This matches the non-git load
+	// path, where kin-openapi enforces the same policy itself.
 	loaderCopy.ReadFromURIFunc = func(loader *openapi3.Loader, location *url.URL) ([]byte, error) {
 		p := filepath.FromSlash(location.Path)
 		if isGitRevision(p) {
 			return gitShow(p)
+		}
+		if !loader.IsExternalRefsAllowed {
+			return nil, fmt.Errorf("external $ref not allowed (enable --allow-external-refs to permit): %s", location.String())
 		}
 		return openapi3.DefaultReadFromURI(loader, location)
 	}

--- a/load/spec_info_git_test.go
+++ b/load/spec_info_git_test.go
@@ -444,3 +444,57 @@ properties:
 	schema := specInfo.Spec.Paths.Value("/pets").Get.Responses.Value("200").Value.Content["application/json"].Schema.Value
 	require.NotNil(t, schema.Properties["id"], "id property from $ref chain should be resolved")
 }
+
+// TestLoadInfo_GitRevisionExternalRefBlocked verifies that loading a spec from a
+// git revision honors IsExternalRefsAllowed=false: a genuinely external $ref (an
+// http(s) URL or a local path outside the git tree) must be refused, not fetched.
+// Without the guard, kin-openapi skips its own policy check whenever a custom
+// ReadFromURIFunc is installed, so the git path would read local files / reach
+// arbitrary URLs (SSRF) even with --allow-external-refs=false.
+func TestLoadInfo_GitRevisionExternalRefBlocked(t *testing.T) {
+	dir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(out))
+	}
+
+	run("git", "init")
+	run("git", "config", "user.email", "test@test.com")
+	run("git", "config", "user.name", "Test")
+
+	// A spec whose $ref points off-tree to an external URL.
+	topLevel := `openapi: "3.0.0"
+info:
+  title: Test
+  version: "1.0"
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "http://169.254.169.254/latest/meta-data/schema.yaml"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "openapi.yaml"), []byte(topLevel), 0644))
+	run("git", "add", ".")
+	run("git", "commit", "-m", "add spec with external ref")
+
+	oldDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	defer os.Chdir(oldDir) //nolint:errcheck
+
+	loader := openapi3.NewLoader()
+	loader.IsExternalRefsAllowed = false
+	_, err = load.NewSpecInfo(loader, load.NewSource("HEAD:openapi.yaml"))
+	require.Error(t, err, "external $ref must be refused on the git path when IsExternalRefsAllowed=false")
+	require.ErrorContains(t, err, "external $ref not allowed")
+}


### PR DESCRIPTION
## Summary

`loadFromGitRevision` installs a custom `ReadFromURIFunc` so relative `$refs` in a git-loaded spec are read via `git show`. kin-openapi **skips its own `allowsExternalRefs` policy check whenever a custom `ReadFromURIFunc` is installed**, and the custom func delegated every non-git `$ref` straight to `openapi3.DefaultReadFromURI` (HTTP fetch + local file read).

Net effect: `--allow-external-refs=false` was silently a **no-op on the git-revision path**.

## Impact

A spec loaded from a git blob — whose content is attacker-controlled in realistic flows: the `git-diff-driver` running over untrusted history, or a maintainer reviewing an untrusted branch with `oasdiff diff main:openapi.yaml HEAD:openapi.yaml` — could use an external `$ref` to:
- read local files: `$ref: "/etc/passwd"`
- reach arbitrary URLs / cloud-metadata: `$ref: "http://169.254.169.254/..."` (SSRF)

…even when the operator explicitly set `--allow-external-refs=false` to process untrusted specs safely. The non-git load path was never affected (kin-openapi enforces the policy itself there), so the git path was strictly weaker than the documented opt-out.

Found during the 2026-05-30 security audit. Note `--allow-external-refs` defaults to `true`, so this is about honoring the explicit opt-out; the fix restores parity with the non-git path.

## Fix

The custom `ReadFromURIFunc` now refuses non-git `$refs` when `loader.IsExternalRefsAllowed` is false, and behaves as before when true. Intra-git relative `$refs` keep their `<rev>:` prefix (via the existing `JoinFunc`) and continue to resolve via `git show`, so multi-file git specs are unaffected. The misleading comment that claimed the policy was already enforced is corrected.

## Test

`TestLoadInfo_GitRevisionExternalRefBlocked`: a committed spec with an external `$ref` loaded from `HEAD:` with `IsExternalRefsAllowed=false` must error with "external $ref not allowed". The existing intra-git multi-file tests (`TestLoadInfo_GitRevisionWithExternalRef`, `..._SlashedRef_...`) still pass. `go build ./...`, `go vet ./load/`, `go test ./load/` all green.