### PR TITLE
load: typed ExternalRefError + dedicated exit code 123

### DIFF
--- a/internal/errors.go
+++ b/internal/errors.go
@@ -27,38 +27,22 @@ func getErrFailedToLoadSpec(what string, source *load.Source, err error) *Return
 	if flatErr := asFlattenError(err); flatErr != nil {
 		return getErrFailedToFlatten(flatErr)
 	}
-	return getError(
-		fmt.Errorf("failed to load %s spec from %s: %w", what, source.Out(), err),
-		102,
-	)
+	wrapped := fmt.Errorf("failed to load %s spec from %s: %w", what, source.Out(), err)
+	if isExternalRefError(err) {
+		return getErrDisallowedExternalRef(wrapped)
+	}
+	return getError(wrapped, 102)
 }
 
 func getErrFailedToLoadSpecs(what string, path string, err error) *ReturnError {
 	if flatErr := asFlattenError(err); flatErr != nil {
 		return getErrFailedToFlatten(flatErr)
 	}
-	return getError(
-		fmt.Errorf("failed to load %s specs from glob %q: %w", what, path, err),
-		103,
-	)
-}
-
-// asFlattenError returns the *load.FlattenError in err's chain, or nil
-// if err is a genuine load failure. Centralised so every spec-loading
-// site stays a single line at the call site.
-func asFlattenError(err error) *load.FlattenError {
-	var flatErr *load.FlattenError
-	if errors.As(err, &flatErr) {
-		return flatErr
+	wrapped := fmt.Errorf("failed to load %s specs from glob %q: %w", what, path, err)
+	if isExternalRefError(err) {
+		return getErrDisallowedExternalRef(wrapped)
 	}
-	return nil
-}
-
-// getErrFailedToFlatten returns the FlattenError unwrapped — its Error()
-// already reports the offending file and the merge failure. The outer
-// "failed to load spec" wrap is misleading because loading succeeded.
-func getErrFailedToFlatten(err *load.FlattenError) *ReturnError {
-	return getError(err, 122)
+	return getError(wrapped, 103)
 }
 
 func getErrDiffFailed(err error) *ReturnError {
@@ -118,11 +102,44 @@ func getErrCantProcessIgnoreFile(what string, err error) *ReturnError {
 	)
 }
 
+// getErrFailedToFlatten returns the FlattenError unwrapped — its Error()
+// already reports the offending file and the merge failure. The outer
+// "failed to load spec" wrap is misleading because loading succeeded.
+func getErrFailedToFlatten(err *load.FlattenError) *ReturnError {
+	return getError(err, 122)
+}
+
+// getErrDisallowedExternalRef returns the dedicated exit code (123) for a spec
+// that resolved an external $ref while --allow-external-refs=false. Callers
+// (e.g. the GitHub Action) key off this code to surface a precise
+// "set allow-external-refs" remedy without matching error text. 123 is kept
+// under 125 to stay clear of the shell's reserved 126/127/128+ range.
+func getErrDisallowedExternalRef(err error) *ReturnError {
+	return getError(err, 123)
+}
+
 func getErrUploadAndOpenFailed(err error) *ReturnError {
 	return getError(
 		fmt.Errorf("--open failed: %w", err),
 		130,
 	)
+}
+
+// asFlattenError returns the *load.FlattenError in err's chain, or nil if err is
+// a genuine load failure. Centralised so every spec-loading site stays a single
+// line at the call site.
+func asFlattenError(err error) *load.FlattenError {
+	var flatErr *load.FlattenError
+	if errors.As(err, &flatErr) {
+		return flatErr
+	}
+	return nil
+}
+
+// isExternalRefError reports whether err's chain contains a *load.ExternalRefError.
+func isExternalRefError(err error) bool {
+	var extErr *load.ExternalRefError
+	return errors.As(err, &extErr)
 }
 
 func getError(err error, code int) *ReturnError {

--- a/load/errors.go
+++ b/load/errors.go
@@ -16,3 +16,16 @@ func (e *FlattenError) Error() string {
 }
 
 func (e *FlattenError) Unwrap() error { return e.Err }
+
+// ExternalRefError reports that a spec resolved an external $ref (an http(s)
+// URL or a local file outside the git tree) while external refs were disallowed
+// (IsExternalRefsAllowed=false, i.e. --allow-external-refs=false). Returned as a
+// distinct type so callers can use errors.As to map it to a dedicated exit code,
+// rather than matching the message text.
+type ExternalRefError struct {
+	Ref string
+}
+
+func (e *ExternalRefError) Error() string {
+	return fmt.Sprintf("external $ref not allowed (enable --allow-external-refs to permit): %s", e.Ref)
+}

--- a/load/load.go
+++ b/load/load.go
@@ -77,13 +77,20 @@ func loadFromGitRevision(loader *openapi3.Loader, gitRef string) (*openapi3.T, e
 	// spec loaded from an (attacker-controlled) git blob must not be able to read
 	// local files or reach arbitrary URLs (SSRF). This matches the non-git load
 	// path, where kin-openapi enforces the same policy itself.
+	// blockedRef records the first external $ref we refuse, so loadFromGitRevision
+	// can return a typed *ExternalRefError regardless of how kin-openapi wraps the
+	// error from ReadFromURIFunc — callers map the type to a dedicated exit code.
+	var blockedRef string
 	loaderCopy.ReadFromURIFunc = func(loader *openapi3.Loader, location *url.URL) ([]byte, error) {
 		p := filepath.FromSlash(location.Path)
 		if isGitRevision(p) {
 			return gitShow(p)
 		}
 		if !loader.IsExternalRefsAllowed {
-			return nil, fmt.Errorf("external $ref not allowed (enable --allow-external-refs to permit): %s", location.String())
+			if blockedRef == "" {
+				blockedRef = location.String()
+			}
+			return nil, &ExternalRefError{Ref: location.String()}
 		}
 		return openapi3.DefaultReadFromURI(loader, location)
 	}
@@ -93,7 +100,13 @@ func loadFromGitRevision(loader *openapi3.Loader, gitRef string) (*openapi3.T, e
 	// Using only the file portion would cause both refs to share the key "openapi.yaml" and
 	// the loader would return the cached base spec for the revision.
 	u := &url.URL{Path: filepath.ToSlash(gitRef)}
-	return loaderCopy.LoadFromDataWithPath(out, u)
+	t, err := loaderCopy.LoadFromDataWithPath(out, u)
+	if err != nil && blockedRef != "" {
+		// Return the typed error even if kin-openapi wrapped ours in plain text,
+		// so callers can errors.As it to a dedicated exit code.
+		return nil, &ExternalRefError{Ref: blockedRef}
+	}
+	return t, err
 }
 
 // readGitRefContent fetches the OpenAPI spec bytes for a git ref. For the

--- a/load/spec_info_git_test.go
+++ b/load/spec_info_git_test.go
@@ -497,4 +497,8 @@ paths:
 	_, err = load.NewSpecInfo(loader, load.NewSource("HEAD:openapi.yaml"))
 	require.Error(t, err, "external $ref must be refused on the git path when IsExternalRefsAllowed=false")
 	require.ErrorContains(t, err, "external $ref not allowed")
+	// Callers map the typed error to a dedicated exit code, so it must survive
+	// kin-openapi's error wrapping and be reachable via errors.As.
+	var extErr *load.ExternalRefError
+	require.ErrorAs(t, err, &extErr)
 }


### PR DESCRIPTION
Follow-up to #974. Lets downstream consumers detect a disallowed external `$ref` by **exit code**, not by matching error text.

## What

- New typed `load.ExternalRefError`, returned by the git-revision loader when it refuses an external `$ref` under `--allow-external-refs=false`. Captured via a closure flag so the type survives kin-openapi's error wrapping.
- `getErrFailedToLoadSpec` / `getErrFailedToLoadSpecs` map it (via `errors.As`) to a dedicated exit code **123**, distinct from the generic load-failure code 102.

## Why

The oasdiff-action wants to surface a precise "set `allow-external-refs: true`" remedy when this specific failure occurs. Matching the message text is brittle — kin-openapi owns the wording on the file-path load path, and messages can change. An exit code is a stable contract.

## Scope

Only the **git-revision load path** (which runs through our loader) carries the typed error → 123. The file-path load path's "disallowed external reference" comes straight from kin-openapi (untyped) and stays 102; consumers fall back to surfacing the raw error there. 123 is kept under 125 to avoid the shell's reserved 126/127/128+ range.

## Test

`TestLoadInfo_GitRevisionExternalRefBlocked` now also asserts `errors.As(err, *load.ExternalRefError)`. Verified end-to-end: git-path external ref under `false` exits **123**; a missing-file load failure exits **102**.