### PR TITLE
refactor: consolidate raw spec read into load.Source; make semanticOptionsJSON a Flags method

### DIFF
--- a/internal/flags.go
+++ b/internal/flags.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"encoding/json"
+
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/oasdiff/oasdiff/load"
 	"github.com/spf13/viper"
@@ -30,10 +32,43 @@ func (flags *Flags) toConfig() *diff.Config {
 	config.PathPrefixRevision = flags.v.GetString("prefix-revision")
 	config.PathStripPrefixBase = flags.v.GetString("strip-prefix-base")
 	config.PathStripPrefixRevision = flags.v.GetString("strip-prefix-revision")
-	config.IncludePathParams = flags.v.GetBool("include-path-params")
-	config.MatchInlineRefs = flags.v.GetBool("match-inline-refs")
+	config.IncludePathParams = flags.getIncludePathParams()
+	config.MatchInlineRefs = flags.getMatchInlineRefs()
 
 	return config
+}
+
+// semanticOptionsJSON returns a JSON object of the semantic comparison flags
+// the visitor passed (flatten-allof, flatten-params, etc.), for callers that
+// forward comparison settings to another renderer (the --open web review
+// upload). Filtering and presentation flags are deliberately excluded: the web
+// UI owns those interactively. Returns "" when no semantic flags are set, so
+// the upload omits the field rather than sending an empty object.
+func (flags *Flags) semanticOptionsJSON() string {
+	opts := map[string]any{}
+	if flags.getFlattenAllOf() {
+		opts["flatten-allof"] = true
+	}
+	if flags.getFlattenParams() {
+		opts["flatten-params"] = true
+	}
+	if flags.getCaseInsensitiveHeaders() {
+		opts["case-insensitive-headers"] = true
+	}
+	if flags.getAutoUpgrade() {
+		opts["auto-upgrade"] = true
+	}
+	if flags.getMatchInlineRefs() {
+		opts["match-inline-refs"] = true
+	}
+	if flags.getIncludePathParams() {
+		opts["include-path-params"] = true
+	}
+	if len(opts) == 0 {
+		return ""
+	}
+	b, _ := json.Marshal(opts)
+	return string(b)
 }
 
 func (flags *Flags) getViper() *viper.Viper {
@@ -74,6 +109,14 @@ func (flags *Flags) getAllowExternalRefs() bool {
 
 func (flags *Flags) getAutoUpgrade() bool {
 	return flags.v.GetBool("auto-upgrade")
+}
+
+func (flags *Flags) getIncludePathParams() bool {
+	return flags.v.GetBool("include-path-params")
+}
+
+func (flags *Flags) getMatchInlineRefs() bool {
+	return flags.v.GetBool("match-inline-refs")
 }
 
 func (flags *Flags) getOpen() bool {

--- a/internal/open_review.go
+++ b/internal/open_review.go
@@ -56,7 +56,7 @@ func uploadAndOpen(flags *Flags, stdout io.Writer, isBreaking bool) error {
 		return fmt.Errorf("read revision spec: %w", err)
 	}
 
-	options := buildSemanticOptionsJSON(flags)
+	options := flags.semanticOptionsJSON()
 
 	accessToken, err := readOrMintAccessToken(stdout)
 	if err != nil {
@@ -80,106 +80,27 @@ func uploadAndOpen(flags *Flags, stdout io.Writer, isBreaking bool) error {
 }
 
 // readSpecSource returns the raw bytes of a spec source and a display
-// filename. For files: ReadFile + basename. For git refs: `git show` and
-// the filename portion. URL and stdin sources are not supported by --open
-// in v1 — the upload requires bytes the CLI can attribute to a filename.
+// filename for the upload. --open supports file and git-ref sources (the
+// git-ref read, including blob-hash handling, lives in the load package);
+// stdin and URL sources are rejected here because the upload requires bytes
+// the CLI can attribute to a filename.
 func readSpecSource(source *load.Source) ([]byte, string, error) {
 	if source == nil {
 		return nil, "", errors.New("spec source is required")
 	}
-	switch {
-	case source.IsStdin():
+	if source.IsStdin() {
 		return nil, "", errors.New("--open does not support stdin (use a file path or git ref)")
-	case source.IsGitRevision():
-		raw := source.Path
-		// "<ref>:<path>". For blob hashes, `git show <hex>:<path>` is invalid
-		// — the path is for display only. NewSpecInfo handles this distinction
-		// internally; here we just call git show <full-ref> and let it speak.
-		cmd := exec.Command("git", "show", raw)
-		out, err := cmd.Output()
-		if err != nil {
-			var exitErr *exec.ExitError
-			if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
-				return nil, "", fmt.Errorf("git show %s: %s", raw, strings.TrimSpace(string(exitErr.Stderr)))
-			}
-			// Blob-hash refs require the explicit blob-only call.
-			if hex, _, ok := splitRefPath(raw); ok && looksLikeHex(hex) {
-				out2, err2 := exec.Command("git", "show", hex).Output()
-				if err2 == nil {
-					return out2, displayNameFromRef(raw), nil
-				}
-			}
-			return nil, "", fmt.Errorf("git show %s: %w", raw, err)
-		}
-		return out, displayNameFromRef(raw), nil
-	case source.IsFile():
-		body, err := os.ReadFile(source.Path)
-		if err != nil {
-			return nil, "", fmt.Errorf("read %s: %w", source.Path, err)
-		}
-		return body, filepath.Base(source.Path), nil
-	default:
+	}
+	if !source.IsFile() && !source.IsGitRevision() {
 		return nil, "", fmt.Errorf("--open does not support source type for %q", source.Path)
 	}
-}
-
-func splitRefPath(s string) (string, string, bool) {
-	idx := strings.Index(s, ":")
-	if idx < 0 {
-		return "", "", false
+	body, err := source.ReadRaw()
+	if err != nil {
+		return nil, "", err
 	}
-	return s[:idx], s[idx+1:], true
-}
-
-func looksLikeHex(s string) bool {
-	if len(s) < 4 || len(s) > 40 {
-		return false
-	}
-	for _, r := range s {
-		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')) {
-			return false
-		}
-	}
-	return true
-}
-
-func displayNameFromRef(ref string) string {
-	if _, path, ok := splitRefPath(ref); ok && path != "" {
-		return filepath.Base(path)
-	}
-	return ref
-}
-
-// buildSemanticOptionsJSON returns a JSON blob of the semantic comparison
-// flags the visitor passed (flatten-allof, flatten-params, etc.). Filtering
-// and presentation flags are deliberately not included — the web UI handles
-// those interactively. See enterprise/docs/cli-local-review.md.
-func buildSemanticOptionsJSON(flags *Flags) string {
-	opts := map[string]any{}
-	if flags.getFlattenAllOf() {
-		opts["flatten-allof"] = true
-	}
-	if flags.getFlattenParams() {
-		opts["flatten-params"] = true
-	}
-	if flags.getCaseInsensitiveHeaders() {
-		opts["case-insensitive-headers"] = true
-	}
-	if flags.getAutoUpgrade() {
-		opts["auto-upgrade"] = true
-	}
-	v := flags.getViper()
-	if v.GetBool("match-inline-refs") {
-		opts["match-inline-refs"] = true
-	}
-	if v.GetBool("include-path-params") {
-		opts["include-path-params"] = true
-	}
-	if len(opts) == 0 {
-		return ""
-	}
-	b, _ := json.Marshal(opts)
-	return string(b)
+	// DisplayPath strips the "<ref>:" prefix for git sources; Base trims any
+	// directory so the upload's filename is just "openapi.yaml".
+	return body, filepath.Base(source.DisplayPath()), nil
 }
 
 // postPreviewReview uploads the two spec files to oasdiff.com and returns

--- a/internal/open_review_unix_test.go
+++ b/internal/open_review_unix_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestBuildSemanticOptionsJSON_OmitsEmpty(t *testing.T) {
 	flags := NewFlags()
-	require.Equal(t, "", buildSemanticOptionsJSON(flags),
+	require.Equal(t, "", flags.semanticOptionsJSON(),
 		"empty options must serialize to an empty string so the upload form skips the field rather than sending {}")
 }
 
@@ -32,7 +32,7 @@ func TestBuildSemanticOptionsJSON_IncludesSemanticFlags(t *testing.T) {
 	v.Set("flatten-params", true)
 	v.Set("match-inline-refs", true)
 	v.Set("auto-upgrade", true)
-	out := buildSemanticOptionsJSON(flags)
+	out := flags.semanticOptionsJSON()
 
 	var parsed map[string]any
 	require.NoError(t, json.Unmarshal([]byte(out), &parsed))
@@ -52,7 +52,7 @@ func TestBuildSemanticOptionsJSON_DoesNotLeakFilteringFlags(t *testing.T) {
 	v.Set("format", "yaml")
 	v.Set("color", "always")
 
-	out := buildSemanticOptionsJSON(flags)
+	out := flags.semanticOptionsJSON()
 	require.Equal(t, "", out, "no semantic flags set — output must be empty even when filtering/presentation flags are present")
 }
 

--- a/load/source.go
+++ b/load/source.go
@@ -3,6 +3,7 @@ package load
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 )
 
@@ -112,4 +113,22 @@ func (source *Source) DisplayPath() string {
 		return source.Path
 	}
 	return source.Path[strings.Index(source.Path, ":")+1:]
+}
+
+// ReadRaw returns the raw, unparsed bytes of the spec source. Unlike the
+// loaders in this package (which parse into an openapi3.T), ReadRaw is for
+// callers that need the original document bytes verbatim, e.g. uploading the
+// spec to a remote service. It supports file and git-revision sources; for git
+// revisions it reuses the same "git show" plumbing as the loaders, including
+// authoritative blob-hash handling. Stdin and URL sources are not supported and
+// return an error.
+func (source *Source) ReadRaw() ([]byte, error) {
+	switch source.Type {
+	case SourceTypeGitRevision:
+		return readGitRefContent(source.Path)
+	case SourceTypeFile:
+		return os.ReadFile(source.Path)
+	default:
+		return nil, fmt.Errorf("cannot read raw bytes from source %q", source.Path)
+	}
 }


### PR DESCRIPTION
Two small cleanups in the `--open` path (`internal/open_review.go`), both behavior-preserving.

## 1. `readSpecSource` re-implemented git reading that already lives in `load`

The git-revision branch of `readSpecSource` shelled out to `git show` and reproduced the blob-hash fallback that `load` already provides, unexported, via `readGitRefContent` (`gitShow` / `blobHashFromRef`). Worse, the local copy detected blob hashes with a hex *heuristic* (`looksLikeHex`, 4-40 hex chars) instead of asking git authoritatively with `git cat-file -t`, so a 7-character branch name like `abcdef0` could be misclassified as a blob.

This adds `load.Source.ReadRaw()`, which returns the raw, unparsed spec bytes for file and git-revision sources and reuses the loaders' existing git-show plumbing (authoritative blob handling included). `readSpecSource` now keeps only the `--open`-specific policy (reject stdin/URL with the user-facing messages, basename the upload filename via `DisplayPath`) and delegates the actual read. The redundant `splitRefPath`, `looksLikeHex`, and `displayNameFromRef` helpers are deleted.

`ReadRaw` deliberately returns raw bytes without parsing into an `openapi3.T` (the upload needs the document verbatim); its doc comment notes this since it differs from the rest of the package's loaders.

## 2. `buildSemanticOptionsJSON` is now a `Flags` method

It took `*Flags` and read only flag state, so it's now `(flags *Flags) semanticOptionsJSON()`, parallel to the existing `toConfig()` projection. While here, `getIncludePathParams()` / `getMatchInlineRefs()` getters are added and both `toConfig()` and the new method route through them, removing the asymmetry where those two flags were read via viper directly while every other flag used a typed getter.

## Verification

`go build ./...`, `go vet`, and the full `load` + `internal` test suites pass. No behavior change; the existing `--open` upload tests cover the read path and the options serialization end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)