### PR TITLE
release: migrate goreleaser Homebrew publish to homebrew_casks (closes #965)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,16 +20,27 @@ release:
 universal_binaries:
  - replace: true
 
-brews:
+homebrew_casks:
  -
    name: oasdiff
    homepage: "https://github.com/oasdiff/oasdiff"
+   description: "A diff tool for OpenAPI Specification."
    repository:
      owner: oasdiff
      name: homebrew-oasdiff
    commit_author:
      name: Reuven Harrison
      email: reuvenharrison@gmail.com
+   # The binary is unsigned. Homebrew quarantines cask artifacts (formulae, the
+   # previous `brews` output, were not quarantined), so without this Gatekeeper
+   # blocks it with "oasdiff is damaged and cannot be opened". Strip the
+   # com.apple.quarantine xattr on install.
+   hooks:
+     post:
+       install: |
+         if OS.mac?
+           system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/oasdiff"]
+         end
 
 nfpms:
   # note that this is an array of nfpm configs


### PR DESCRIPTION
Closes #965.

goreleaser deprecated the top-level `brews` field (Homebrew **formula**) in favor of `homebrew_casks` (introduced in v2.10). Since the release pipeline runs goreleaser `latest`, every release printed:

> DEPRECATED: brews should not be used anymore

This switches the Homebrew publish to a cask.

## The non-mechanical part: macOS quarantine

Casks are not the same as formulae for an **unsigned** binary. Homebrew applies the `com.apple.quarantine` xattr to cask artifacts (it did **not** to the formula we shipped before), so without intervention Gatekeeper blocks the binary with *"oasdiff is damaged and cannot be opened"*. goreleaser does not add the workaround automatically, so the config includes a `postflight` hook that strips the xattr, guarded by `if OS.mac?`.

## Verified locally (goreleaser v2.16.0)

- `goreleaser check` passes, no deprecation warning.
- `goreleaser release --snapshot` generates a valid `Casks/oasdiff.rb` covering macOS (universal) and Linux (intel/arm), with the quarantine `postflight` present and `binary "oasdiff"`.

## Required follow-up after the first cask release (not in this PR)

The tap repo `oasdiff/homebrew-oasdiff` currently holds a root **formula** (`oasdiff.rb`). goreleaser now writes `Casks/oasdiff.rb` and will **not** touch the old formula, so after the first release the tap will contain both. With both present, `brew install oasdiff` is ambiguous and tends to resolve to the stale formula. So once a release has produced the cask and it is confirmed working:

1. Delete the stale root `oasdiff.rb` formula from `oasdiff/homebrew-oasdiff`.
2. Existing formula users do a one-time `brew uninstall oasdiff && brew install oasdiff` to move onto the cask (Homebrew does not auto-convert a formula install to a cask).

The documented install command (`brew install oasdiff`) does not need to change: it resolves to the cask once the stale formula is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)