### PR TITLE
ci: pin goreleaser-action to the v2 major instead of `latest`

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -26,7 +26,11 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
+          # Pin to the v2 major. goreleaser-action no longer treats `latest`
+          # as the absolute latest (it warns and locks to `~> v2` anyway), and
+          # an unpinned `latest` risks a future goreleaser v3 silently breaking
+          # releases via config-schema changes. Bump deliberately when adopting v3.
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GO_RELEASER_GITHUB_TOKEN }}


### PR DESCRIPTION
The release workflow's goreleaser-action emits:

> Warning: You are using 'latest' as default version. Will lock to '~> v2'.

`version: latest` is no longer the absolute latest in goreleaser-action@v6 (it self-locks to `~> v2`), and leaving it unpinned means a future **goreleaser v3 could silently break the release** via config-schema changes, exactly the class of problem the recent `brews` → `homebrew_casks` deprecation was, except a hard break instead of a warning.

Pins `version: "~> v2"` in `release_build.yml` — deterministic, silences the warning, stays on the tested major, and still picks up v2 patches/minors. Bump deliberately when adopting v3.

Does not affect the in-flight v1.18.2 release (that already triggered with the committed config); this is for future releases.
