### PR TITLE
load: actionable hint when a git revision's commit isn't in the local clone

### DIFF
--- a/load/load.go
+++ b/load/load.go
@@ -120,7 +120,50 @@ func readGitRefContent(gitRef string) ([]byte, error) {
 	if hex, ok := blobHashFromRef(gitRef); ok {
 		return gitShow(hex)
 	}
-	return gitShow(gitRef)
+	out, err := gitShow(gitRef)
+	if err != nil {
+		return nil, hintMissingObject(gitRef, err)
+	}
+	return out, nil
+}
+
+// hintMissingObject augments a "git show" failure with a recovery hint when the
+// failure is that the commit named before the colon is not present in the local
+// clone. oasdiff resolves "<ref>:<path>" against local objects only and
+// deliberately never fetches or otherwise mutates the repository, so a reviewer
+// who hasn't fetched the PR branch (or a shallow clone lacking the base commit)
+// would otherwise be left with git's terse error. We hand them the exact command
+// to fetch the commit themselves; the repository stays untouched.
+//
+// The hint fires only when the commit genuinely doesn't resolve locally. A path
+// that doesn't exist within an existing commit is returned unchanged (its message
+// is already actionable), and so is a "git not installed" failure (there is
+// nothing to fetch). git's own "git show" message conflates the missing-commit
+// and missing-path cases when the path happens to exist in the working tree, so
+// we probe the object directly rather than parse the message text.
+func hintMissingObject(gitRef string, err error) error {
+	if strings.Contains(err.Error(), "is git installed") {
+		return err
+	}
+	ref := gitRef
+	if before, _, found := strings.Cut(gitRef, ":"); found {
+		ref = before
+	}
+	if commitExistsLocally(ref) {
+		return err
+	}
+	return fmt.Errorf("%w\n\n"+
+		"oasdiff reads git revisions from local objects only and does not modify your repository.\n"+
+		"Commit %q is not in this clone. Fetch it yourself with:\n\n"+
+		"    git fetch origin %s\n\n"+
+		"then re-run oasdiff", err, ref, ref)
+}
+
+// commitExistsLocally reports whether ref names an object already present in the
+// local repository, via "git cat-file -e". Returns false when the object is
+// absent or when git cannot run.
+func commitExistsLocally(ref string) bool {
+	return exec.Command("git", "cat-file", "-e", ref).Run() == nil
 }
 
 // blobHashFromRef returns (hex, true) when the part before `:` in gitRef names

--- a/load/spec_info_git_test.go
+++ b/load/spec_info_git_test.go
@@ -80,6 +80,45 @@ func TestLoadInfo_GitRevisionNotFound(t *testing.T) {
 
 	_, err = load.NewSpecInfo(openapi3.NewLoader(), load.NewSource("HEAD:nonexistent.yaml"))
 	require.ErrorContains(t, err, "failed to load spec from git revision")
+	// A path that doesn't exist within an existing commit is already a clear
+	// error; it must not be rewritten into a fetch hint.
+	require.NotContains(t, err.Error(), "git fetch origin")
+}
+
+// TestLoadInfo_GitRevisionMissingCommit verifies that referencing a commit that
+// is not present in the local clone yields an actionable "git fetch" hint, and
+// that oasdiff leaves the repository untouched rather than fetching the commit
+// itself.
+func TestLoadInfo_GitRevisionMissingCommit(t *testing.T) {
+	dir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(out))
+	}
+
+	run("git", "init")
+	run("git", "config", "user.email", "test@test.com")
+	run("git", "config", "user.name", "Test")
+
+	specPath := filepath.Join(dir, "openapi.yaml")
+	require.NoError(t, os.WriteFile(specPath, []byte(minimalSpec), 0644))
+	run("git", "add", "openapi.yaml")
+	run("git", "commit", "-m", "add spec")
+
+	oldDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	defer os.Chdir(oldDir) //nolint:errcheck
+
+	// A syntactically valid SHA that names no object in this clone.
+	missing := "0123456789012345678901234567890123456789"
+	_, err = load.NewSpecInfo(openapi3.NewLoader(), load.NewSource(missing+":openapi.yaml"))
+	require.ErrorContains(t, err, "git fetch origin "+missing)
+	require.ErrorContains(t, err, "does not modify your repository")
 }
 
 // TestLoadInfo_TwoGitRevisionsSharedLoader verifies that loading two different git revisions


### PR DESCRIPTION
## Problem

oasdiff reads `<ref>:<path>` sources (e.g. `abc1234:openapi.yaml`) by shelling out to `git show`, which resolves the ref **only against objects already present in the local clone** and never reaches the network. When the commit isn't present locally, the user hits a terse git error and is stuck. This is exactly the situation a reviewer lands in after following a shared review command: they haven't fetched the PR commit, or their clone is shallow and lacks the base commit.

## Why not just fetch?

oasdiff is a read tool. Having it run `git fetch` on its own would silently reach the network and write to the user's `.git` (new objects, a rewritten `FETCH_HEAD`, and with a shallow fetch even a `.git/shallow` marker that changes how later git commands behave). That is a surprising side effect for a diff command and is not something the user consented to.

## Fix

Turn the dead-end into an actionable, read-only error that names the exact command to run:

```
... <git's original message>

oasdiff reads git revisions from local objects only and does not modify your repository.
Commit "abc1234" is not in this clone; fetch it yourself with:

    git fetch origin abc1234

then re-run oasdiff
```

The user performs and sees the fetch themselves; the repository is left untouched.

The hint fires **only** when the commit genuinely doesn't resolve locally, probed directly with `git cat-file -e`. Two cases are deliberately passed through unchanged:

- A path that doesn't exist within an existing commit (git already says so clearly).
- A "git not installed" failure (there is nothing to fetch).

Detection probes the object rather than parsing git's message text, because `git show` conflates the missing-commit and missing-path cases ("path 'x' exists on disk, but not in '<sha>'") when the path happens to exist in the working tree.

## Tests

- New `TestLoadInfo_GitRevisionMissingCommit`: references a valid-but-absent SHA in a real repo and asserts the `git fetch origin <sha>` hint appears and the repo-untouched wording is present.
- Extended `TestLoadInfo_GitRevisionNotFound` to assert a missing *path* in an existing commit does **not** get rewritten into a fetch hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)