### PR TITLE
Add --fetch flag to fetch missing git revisions from origin

### DIFF
--- a/docs/GIT-REVISION.md
+++ b/docs/GIT-REVISION.md
@@ -45,6 +45,22 @@ oasdiff detects the `<ref>:<path>` pattern and runs `git show <ref>:<path>` inte
 
 The command must be run from within the git repository that contains the spec.
 
+## Fetching missing commits (`--fetch`)
+
+oasdiff reads git revisions from your local object store only; it does not modify your repository by default. If the commit you reference is not in the local clone (a common case when reviewing someone else's PR commit, or in a shallow clone), `git show` fails and oasdiff prints the exact command to fetch it:
+
+```
+git fetch origin <ref>
+```
+
+Pass `--fetch` to let oasdiff run that fetch for you, against the `origin` remote, before reading the spec:
+
+```bash
+oasdiff changelog --fetch <base-sha>:openapi.yaml <revision-sha>:openapi.yaml
+```
+
+`--fetch` downloads the missing git objects into your local repository (it does not move any branch or ref). Because it mutates the repository, it is opt-in. Only revisions whose commit is genuinely missing trigger a fetch; commits already present are read directly.
+
 ## GitHub Actions
 
 Git revision syntax is particularly useful in CI/CD. The following workflow detects breaking changes between the base branch and the PR branch without needing a separate checkout step or temp files:

--- a/internal/cmd_flags.go
+++ b/internal/cmd_flags.go
@@ -24,7 +24,7 @@ func addCommonDiffFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringSlice("exclude-extensions", nil, "OpenAPI Extension names to exclude from diff (e.g., x-internal)")
 	cmd.PersistentFlags().Bool("allow-external-refs", true, "allow external $refs in specs; disable to prevent SSRF when processing untrusted specs")
 	cmd.PersistentFlags().Bool("auto-upgrade", false, "canonicalize both specs to the latest OpenAPI 3.x before diffing; useful for cross-version comparisons (e.g. 3.0 vs 3.1)")
-	cmd.PersistentFlags().Bool("fetch", false, "when a base or revision is a git revision whose commit is missing locally, fetch it from the 'origin' remote first (downloads git objects into your local repository)")
+	cmd.PersistentFlags().Bool("fetch", false, "fetch missing git revisions from the 'origin' remote (writes objects to your local repo)")
 
 	addHiddenFlattenFlag(cmd)
 	addHiddenCircularDepFlag(cmd)

--- a/internal/cmd_flags.go
+++ b/internal/cmd_flags.go
@@ -24,6 +24,7 @@ func addCommonDiffFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringSlice("exclude-extensions", nil, "OpenAPI Extension names to exclude from diff (e.g., x-internal)")
 	cmd.PersistentFlags().Bool("allow-external-refs", true, "allow external $refs in specs; disable to prevent SSRF when processing untrusted specs")
 	cmd.PersistentFlags().Bool("auto-upgrade", false, "canonicalize both specs to the latest OpenAPI 3.x before diffing; useful for cross-version comparisons (e.g. 3.0 vs 3.1)")
+	cmd.PersistentFlags().Bool("fetch", false, "when a base or revision is a git revision whose commit is missing locally, fetch it from the 'origin' remote first (downloads git objects into your local repository)")
 
 	addHiddenFlattenFlag(cmd)
 	addHiddenCircularDepFlag(cmd)

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -111,6 +111,10 @@ func (flags *Flags) getAutoUpgrade() bool {
 	return flags.v.GetBool("auto-upgrade")
 }
 
+func (flags *Flags) getFetch() bool {
+	return flags.v.GetBool("fetch")
+}
+
 func (flags *Flags) getIncludePathParams() bool {
 	return flags.v.GetBool("include-path-params")
 }

--- a/internal/handlers.go
+++ b/internal/handlers.go
@@ -44,11 +44,15 @@ func getRun(runner runner) cobra.PositionalArgs {
 		}
 
 		if len(args) > 0 {
-			flags.setBase(load.NewSource(args[0]))
+			base := load.NewSource(args[0])
+			base.Fetch = flags.getFetch()
+			flags.setBase(base)
 		}
 
 		if len(args) > 1 {
-			flags.setRevision(load.NewSource(args[1]))
+			revision := load.NewSource(args[1])
+			revision.Fetch = flags.getFetch()
+			flags.setRevision(revision)
 		}
 
 		// by now flags have been parsed successfully so we don't need to show usage on any errors

--- a/internal/viper.go
+++ b/internal/viper.go
@@ -207,6 +207,7 @@ type Config struct {
 	IncludePathParams      bool     `mapstructure:"include-path-params"`
 	AllowExternalRefs      bool     `mapstructure:"allow-external-refs"`
 	AutoUpgrade            bool     `mapstructure:"auto-upgrade"`
+	Fetch                  bool     `mapstructure:"fetch"`
 	Template               string   `mapstructure:"template"`
 }
 

--- a/load/load.go
+++ b/load/load.go
@@ -21,7 +21,7 @@ func from(loader *openapi3.Loader, source *Source) (*openapi3.T, error) {
 	case SourceTypeURL:
 		return loader.LoadFromURI(source.Uri)
 	case SourceTypeGitRevision:
-		return loadFromGitRevision(loader, source.Path)
+		return loadFromGitRevision(loader, source.Path, source.Fetch)
 	default:
 		return loader.LoadFromFile(source.Path)
 	}
@@ -38,8 +38,8 @@ func from(loader *openapi3.Loader, source *Source) (*openapi3.T, error) {
 // Blob-hash refs (e.g. "abc1234:openapi.yaml" where abc1234 is a git blob object hash)
 // are supported via readGitRefContent. The path portion is preserved on the ref string
 // passed downstream for source labels and relative $ref resolution.
-func loadFromGitRevision(loader *openapi3.Loader, gitRef string) (*openapi3.T, error) {
-	out, err := readGitRefContent(gitRef)
+func loadFromGitRevision(loader *openapi3.Loader, gitRef string, fetch bool) (*openapi3.T, error) {
+	out, err := readGitRefContent(gitRef, fetch)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load spec from git revision %q: %w", gitRef, err)
 	}
@@ -116,24 +116,45 @@ func loadFromGitRevision(loader *openapi3.Loader, gitRef string) (*openapi3.T, e
 // `git show <blob-hex>:<path>` is not valid git syntax. Callers keep the full
 // `<ref>:<path>` string for the loader's URL key so source labels and relative
 // $ref resolution stay correct.
-func readGitRefContent(gitRef string) ([]byte, error) {
+func readGitRefContent(gitRef string, fetch bool) ([]byte, error) {
 	if hex, ok := blobHashFromRef(gitRef); ok {
 		return gitShow(hex)
 	}
 	out, err := gitShow(gitRef)
-	if err != nil {
-		return nil, hintMissingObject(gitRef, err)
+	if err == nil {
+		return out, nil
 	}
-	return out, nil
+	// "git show" failed. When --fetch is set and the only problem is that the
+	// commit isn't in this clone, fetch that commit from origin and retry once.
+	// This is the opt-in counterpart to hintMissingObject: instead of telling
+	// the reviewer to run "git fetch origin <ref>" themselves, oasdiff runs it
+	// for them (mutating the repo by downloading objects). A path that doesn't
+	// exist within an already-local commit is not a fetch problem, so we only
+	// fetch when the commit itself is absent.
+	if fetch {
+		ref := refBeforeColon(gitRef)
+		if !commitExistsLocally(ref) {
+			if ferr := gitFetch(ref); ferr != nil {
+				return nil, fmt.Errorf(
+					"failed to fetch git revision %q from origin: %w\n\noriginal error: %v",
+					ref, ferr, err)
+			}
+			if out, err = gitShow(gitRef); err == nil {
+				return out, nil
+			}
+		}
+	}
+	return nil, hintMissingObject(gitRef, err)
 }
 
 // hintMissingObject augments a "git show" failure with a recovery hint when the
 // failure is that the commit named before the colon is not present in the local
-// clone. oasdiff resolves "<ref>:<path>" against local objects only and
-// deliberately never fetches or otherwise mutates the repository, so a reviewer
-// who hasn't fetched the PR branch (or a shallow clone lacking the base commit)
+// clone. By default oasdiff resolves "<ref>:<path>" against local objects only
+// and does not fetch or otherwise mutate the repository, so a reviewer who
+// hasn't fetched the PR branch (or a shallow clone lacking the base commit)
 // would otherwise be left with git's terse error. We hand them the exact command
-// to fetch the commit themselves; the repository stays untouched.
+// to fetch the commit themselves, and point at the --fetch flag that does it
+// automatically; the repository stays untouched unless they opt in.
 //
 // The hint fires only when the commit genuinely doesn't resolve locally. A path
 // that doesn't exist within an existing commit is returned unchanged (its message
@@ -145,10 +166,7 @@ func hintMissingObject(gitRef string, err error) error {
 	if strings.Contains(err.Error(), "is git installed") {
 		return err
 	}
-	ref := gitRef
-	if before, _, found := strings.Cut(gitRef, ":"); found {
-		ref = before
-	}
+	ref := refBeforeColon(gitRef)
 	if commitExistsLocally(ref) {
 		return err
 	}
@@ -156,7 +174,28 @@ func hintMissingObject(gitRef string, err error) error {
 		"oasdiff reads git revisions from local objects only and does not modify your repository.\n"+
 		"Commit %q is not in this clone. Fetch it yourself with:\n\n"+
 		"    git fetch origin %s\n\n"+
-		"then re-run oasdiff", err, ref, ref)
+		"then re-run oasdiff, or re-run with --fetch to let oasdiff fetch it for you", err, ref, ref)
+}
+
+// refBeforeColon returns the "<ref>" portion of a "<ref>:<path>" git revision,
+// or the whole string when there is no colon.
+func refBeforeColon(gitRef string) string {
+	if before, _, found := strings.Cut(gitRef, ":"); found {
+		return before
+	}
+	return gitRef
+}
+
+// gitFetch downloads the named commit/ref from the "origin" remote into the
+// local object store so a subsequent "git show <ref>:<path>" can resolve it. It
+// mutates the repository (adds objects; no local ref or branch is moved), which
+// is why it runs only under the opt-in --fetch flag. It mirrors the manual
+// "git fetch origin <ref>" that hintMissingObject suggests when --fetch is off.
+func gitFetch(ref string) error {
+	if out, err := exec.Command("git", "fetch", "origin", ref).CombinedOutput(); err != nil {
+		return fmt.Errorf("%s", strings.TrimSpace(string(out)))
+	}
+	return nil
 }
 
 // commitExistsLocally reports whether ref names an object already present in the

--- a/load/source.go
+++ b/load/source.go
@@ -20,6 +20,12 @@ type Source struct {
 	Path string
 	Uri  *url.URL
 	Type SourceType
+
+	// Fetch, when true, lets a git-revision source fetch a missing commit from
+	// the "origin" remote before reading it (see the --fetch flag). It mutates
+	// the local repository by downloading objects, so it is opt-in and defaults
+	// to false; only SourceTypeGitRevision sources consult it.
+	Fetch bool
 }
 
 // NewSource creates a Source by categorizing the input path as stdin, URL, git revision, or file.
@@ -125,7 +131,7 @@ func (source *Source) DisplayPath() string {
 func (source *Source) ReadRaw() ([]byte, error) {
 	switch source.Type {
 	case SourceTypeGitRevision:
-		return readGitRefContent(source.Path)
+		return readGitRefContent(source.Path, source.Fetch)
 	case SourceTypeFile:
 		return os.ReadFile(source.Path)
 	default:

--- a/load/spec_info_git_fetch_test.go
+++ b/load/spec_info_git_fetch_test.go
@@ -1,0 +1,116 @@
+//go:build unix
+
+package load_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/oasdiff/load"
+	"github.com/stretchr/testify/require"
+)
+
+const specV1 = `openapi: "3.0.0"
+info:
+  title: Test
+  version: "1.0"
+paths: {}
+`
+
+const specV2 = `openapi: "3.0.0"
+info:
+  title: Test
+  version: "2.0"
+paths: {}
+`
+
+func gitRun(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	return strings.TrimSpace(string(out))
+}
+
+// TestLoadInfo_GitRevisionFetch verifies the --fetch flag: a git-revision source
+// whose commit is missing from the local clone is fetched from "origin" when
+// Source.Fetch is true, and without it the load fails with the actionable hint
+// that points at --fetch.
+func TestLoadInfo_GitRevisionFetch(t *testing.T) {
+	origin := t.TempDir()
+	gitRun(t, origin, "git", "init")
+	gitRun(t, origin, "git", "config", "user.email", "test@test.com")
+	gitRun(t, origin, "git", "config", "user.name", "Test")
+	// Let the local transport serve a specific commit by SHA on fetch.
+	gitRun(t, origin, "git", "config", "uploadpack.allowAnySHA1InWant", "true")
+	gitRun(t, origin, "git", "config", "uploadpack.allowReachableSHA1InWant", "true")
+
+	require.NoError(t, os.WriteFile(filepath.Join(origin, "openapi.yaml"), []byte(specV1), 0644))
+	gitRun(t, origin, "git", "add", "openapi.yaml")
+	gitRun(t, origin, "git", "commit", "-m", "v1")
+
+	// Clone while origin is at v1, so the clone will lack the next commit.
+	clone := t.TempDir()
+	gitRun(t, filepath.Dir(clone), "git", "clone", origin, clone)
+
+	// Advance origin to v2 — the commit the clone is missing.
+	require.NoError(t, os.WriteFile(filepath.Join(origin, "openapi.yaml"), []byte(specV2), 0644))
+	gitRun(t, origin, "git", "add", "openapi.yaml")
+	gitRun(t, origin, "git", "commit", "-m", "v2")
+	v2sha := gitRun(t, origin, "git", "rev-parse", "HEAD")
+
+	// Run from inside the clone, where v2 is not present.
+	oldDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(clone))
+	defer os.Chdir(oldDir) //nolint:errcheck
+
+	require.Error(t, exec.Command("git", "cat-file", "-e", v2sha).Run(),
+		"precondition: the clone must not already have v2")
+
+	ref := v2sha + ":openapi.yaml"
+
+	// Without --fetch: the commit is missing, so the load fails and the hint
+	// points at --fetch.
+	_, err = load.NewSpecInfo(openapi3.NewLoader(), load.NewSource(ref))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--fetch")
+
+	// With --fetch: oasdiff fetches v2 from origin and loads it.
+	src := load.NewSource(ref)
+	src.Fetch = true
+	specInfo, err := load.NewSpecInfo(openapi3.NewLoader(), src)
+	require.NoError(t, err)
+	require.Equal(t, "2.0", specInfo.GetVersion())
+
+	// The fetch populated the local object store.
+	require.NoError(t, exec.Command("git", "cat-file", "-e", v2sha).Run())
+}
+
+// TestLoadInfo_GitRevisionFetchNoOriginFails verifies that --fetch surfaces a
+// clear error when there is no "origin" remote to fetch from (rather than
+// silently falling through).
+func TestLoadInfo_GitRevisionFetchNoOrigin(t *testing.T) {
+	dir := t.TempDir()
+	gitRun(t, dir, "git", "init")
+	gitRun(t, dir, "git", "config", "user.email", "test@test.com")
+	gitRun(t, dir, "git", "config", "user.name", "Test")
+
+	oldDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	defer os.Chdir(oldDir) //nolint:errcheck
+
+	// A plausible-looking but absent commit SHA.
+	ref := "0123456789012345678901234567890123456789:openapi.yaml"
+	src := load.NewSource(ref)
+	src.Fetch = true
+	_, err = load.NewSpecInfo(openapi3.NewLoader(), src)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "fetch")
+}


### PR DESCRIPTION
## What

Adds a `--fetch` flag to the comparison commands (`diff`, `breaking`, `changelog`, `summary`). When a base or revision is a git revision (`<ref>:<path>`) whose commit is missing from the local clone, `--fetch` fetches that commit from the `origin` remote before reading the spec.

```bash
oasdiff changelog --fetch <base-sha>:openapi.yaml <revision-sha>:openapi.yaml
```

## Why

oasdiff reads git revisions from the local object store only and does not modify the repository. When the referenced commit isn't local (reviewing someone else's PR commit, or a shallow clone), `git show <ref>:<path>` fails. Today oasdiff prints an actionable hint:

```
git fetch origin <ref>
```

`--fetch` runs that step automatically. Because it downloads objects into the local repository, it is **opt-in** and defaults to false.

## Behaviour

- Only a genuinely missing commit triggers a fetch; commits already present are read directly, and a path that doesn't exist within a present commit is not treated as a fetch problem (no pointless fetch).
- On a missing commit with `--fetch`: fetch `origin <ref>`, then retry `git show` once.
- No local branch or ref is moved; only objects are downloaded.
- The off-by-default hint now also mentions `--fetch`.

## Changes

- `load`: `Source.Fetch` threaded through `from` / `loadFromGitRevision` / `readGitRefContent`; fetch-and-retry-once logic; `gitFetch` helper.
- `internal`: `--fetch` registered on the common diff flags, set on both base and revision sources, added to the viper config struct.
- Tests: clone-before-commit fetch path (loads a commit the clone lacked) and the no-origin error path.
- Docs: new "Fetching missing commits" section in `GIT-REVISION.md`.

All existing tests pass; `gofmt` / `go vet` clean.