### PR TITLE
refactor(formatters): drop redundant top-level `source` field from output (#926)

### DIFF
--- a/formatters/changes.go
+++ b/formatters/changes.go
@@ -17,7 +17,6 @@ type Change struct {
 	Operation      string          `json:"operation,omitempty" yaml:"operation,omitempty"`
 	OperationId    string          `json:"operationId,omitempty" yaml:"operationId,omitempty"`
 	Path           string          `json:"path,omitempty" yaml:"path,omitempty"`
-	Source         string          `json:"source,omitempty" yaml:"source,omitempty"`
 	Section        string          `json:"section,omitempty" yaml:"section,omitempty"`
 	IsBreaking     bool            `json:"-" yaml:"-"`
 	Attributes     map[string]any  `json:"attributes,omitempty" yaml:"attributes,omitempty"`
@@ -43,7 +42,6 @@ func NewChanges(originalChanges checker.Changes, l checker.Localizer) Changes {
 			Operation:      operation,
 			OperationId:    change.GetOperationId(),
 			Path:           path,
-			Source:         change.GetSource(),
 			Attributes:     change.GetAttributes(),
 			BaseSource:     change.GetBaseSource(),
 			RevisionSource: change.GetRevisionSource(),


### PR DESCRIPTION
Fixes #926.

The formatter `Change` struct (`formatters/changes.go`) carried two fields with the same file path:

- `source` (string) — the file path
- `revisionSource` (object) — `{file, line, column}`, where `file` is the same string

`source` is fully subsumed by `revisionSource.file`, so this drops it from the JSON/YAML output of `changelog`, `breaking`, and `diff`.

```json
// before
{ "id": "...", "source": "spec.yaml", "revisionSource": {"file": "spec.yaml", "line": 9, "column": 82} }
// after
{ "id": "...", "revisionSource": {"file": "spec.yaml", "line": 9, "column": 82} }
```

**Breaking change** for consumers parsing `source`: read `revisionSource.file` instead (same string). Both fields were already `omitempty`, so consumers that tolerate missing fields are unaffected.

`revisionSource` is unchanged, and the checker's `GetSource()` is untouched (still used for the text output). No golden fixtures or docs referenced the dropped field; full test suite passes.

This also keeps the cross-subcommand location vocabulary clean ahead of `validate --format json`, whose finding location object is named `source`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)