### PR TITLE
feat(load): add NewSpecInfoFromData for in-memory specs with a source name

### DIFF
--- a/load/spec_info.go
+++ b/load/spec_info.go
@@ -70,6 +70,29 @@ func NewSpecInfoFromGlob(loader *openapi3.Loader, glob string, options ...Option
 	return specInfos, nil
 }
 
+// NewSpecInfoFromData creates a SpecInfo from raw OpenAPI bytes already held in
+// memory, labeling its source as name. name is loaded as the spec's path, so
+// source-location reporting (e.g. the file name shown for each change) uses it
+// rather than a temp path or an empty value. It is the in-memory counterpart to
+// NewSpecInfo: no filesystem access, so relative file $refs are not resolved
+// (intra-spec "#/..." refs still are). As elsewhere in this package, callers
+// comparing two specs should use a fresh loader per spec so the loader's
+// document cache does not collide when both share a name.
+func NewSpecInfoFromData(loader *openapi3.Loader, data []byte, name string, options ...Option) (*SpecInfo, error) {
+	spec, err := loader.LoadFromDataWithPath(data, &url.URL{Path: name})
+	if err != nil {
+		return nil, err
+	}
+
+	specInfos := []*SpecInfo{newSpecInfo(spec, name)}
+	for _, option := range options {
+		if specInfos, err = option(loader, specInfos); err != nil {
+			return nil, err
+		}
+	}
+	return specInfos[0], nil
+}
+
 func loadSpecInfo(loader *openapi3.Loader, source *Source) (*SpecInfo, error) {
 	s, err := from(loader, source)
 	if err != nil {

--- a/load/spec_info_test.go
+++ b/load/spec_info_test.go
@@ -139,3 +139,28 @@ func TestSpecInfo_FlattenError_Typed(t *testing.T) {
 
 	require.EqualError(t, err, `failed to flatten allOf in "../data/allof/invalid.yaml": unable to resolve Type conflict: all Type values must be identical`)
 }
+
+func TestSpecInfo_FromData(t *testing.T) {
+	data, err := os.ReadFile("../data/openapi-test1.yaml")
+	require.NoError(t, err)
+
+	specInfo, err := load.NewSpecInfoFromData(openapi3.NewLoader(), data, "myspec.yaml")
+	require.NoError(t, err)
+	require.NotNil(t, specInfo.Spec)
+	// The provided name is the source label, not a temp path.
+	require.Equal(t, "myspec.yaml", specInfo.Url)
+	require.Equal(t, specInfo.Spec.Info.Version, specInfo.GetVersion())
+}
+
+func TestSpecInfo_FromData_InvalidData(t *testing.T) {
+	_, err := load.NewSpecInfoFromData(openapi3.NewLoader(), []byte("not: [valid"), "myspec.yaml")
+	require.Error(t, err)
+}
+
+func TestSpecInfo_FromData_Options(t *testing.T) {
+	data, err := os.ReadFile("../data/openapi-test1.yaml")
+	require.NoError(t, err)
+
+	_, err = load.NewSpecInfoFromData(openapi3.NewLoader(), data, "myspec.yaml", load.WithFlattenAllOf(), load.WithFlattenParams())
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Adds `load.NewSpecInfoFromData(loader, data, name, options...)` — the in-memory counterpart to `NewSpecInfo`.

It loads an OpenAPI spec from bytes already held in memory and labels its source with a caller-provided `name`, so source-location reporting (the file shown for each change, `BaseSource`/`RevisionSource.file`) uses that name instead of a temp path or an empty value. It loads via `LoadFromDataWithPath` (the same mechanism the git-revision path uses) so the parsed elements' origins carry the name, and it runs the same `Option` pipeline (`WithFlattenAllOf`, etc.).

**Motivation:** callers that already hold the spec bytes (e.g. a service handling uploaded specs) currently write them to temp files just to get a sensible source label. This lets them load from memory and still display the original filename. (Supports `oasdiff-service#189`, which moves those handlers off the write-to-disk-then-read flow.)

Tests cover the happy path (Url set to the name, spec + version populated), invalid data, and the options pipeline. As with `NewSpecInfo`, callers comparing two specs should use a fresh loader per spec (documented on the function).

🤖 Generated with [Claude Code](https://claude.com/claude-code)