### PR TITLE
docs: lead the README with the CLI, not the Go package

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@
 ![oasdiff banner](https://github.com/yonatanmgr/oasdiff/assets/31913495/ac9b154e-72d1-4969-bc3b-f527bbe7751d)
 
 
-Command-line and Go package to compare and detect breaking changes in OpenAPI specs.
+Command-line tool to compare and detect breaking changes in OpenAPI specs.
 
 Run it locally, in CI via the [GitHub Action](https://github.com/oasdiff/oasdiff-action), or use the hosted PR review workflow at [oasdiff.com](https://www.oasdiff.com) to approve or reject each change with a CI commit status.
 


### PR DESCRIPTION
## What

Change the README's opening line from:

> Command-line and Go package to compare and detect breaking changes in OpenAPI specs.

to:

> Command-line tool to compare and detect breaking changes in OpenAPI specs.

## Why

Someone who lands on the repo wants a one-line answer to "what does this do for me?" oasdiff is a command-line tool that compares OpenAPI specs and tells you what changed and what's breaking, whether you run it in your terminal, in CI through the GitHub Action, or via the hosted PR review. Leading with that answers the question right away.

If you want to import oasdiff as a Go library, that hasn't changed: the package is still there and still documented through the GoDoc badge and the `go install` instruction further down.