### PR TITLE
fix(checker): prevent panic on one-sided sub-schema diffs

### DIFF
--- a/checker/media_type_walker.go
+++ b/checker/media_type_walker.go
@@ -67,6 +67,16 @@ func (info mediaTypeInfo) newChange(id string, args []any, comment string) ApiCh
 // specific sources.
 func (info mediaTypeInfo) walkProperties(processor func(p propertyInfo)) {
 	CheckModifiedPropertiesDiff(info.schemaDiff, func(propertyPath, propertyName string, propertyDiff, parent *diff.SchemaDiff) {
+		// The traversal also descends into single-valued sub-schemas (items,
+		// not, if/then/else, contentSchema, ...). When such a sub-schema exists
+		// on only one side (e.g. `items` removed in the revision), its diff has
+		// a nil Base or Revision schema. The property-level checks all read
+		// Base/Revision (ReadOnly, WriteOnly, Extensions, ...) and have nothing
+		// actionable to say about a side that doesn't exist, so guard once here
+		// rather than in every check.
+		if propertyDiff == nil || propertyDiff.Base == nil || propertyDiff.Revision == nil {
+			return
+		}
 		processor(propertyInfo{
 			mediaTypeInfo: info,
 			propertyPath:  propertyPath,

--- a/checker/media_type_walker_test.go
+++ b/checker/media_type_walker_test.go
@@ -1,0 +1,31 @@
+package checker_test
+
+import (
+	"testing"
+
+	"github.com/oasdiff/oasdiff/checker"
+	"github.com/oasdiff/oasdiff/diff"
+	"github.com/stretchr/testify/require"
+)
+
+// A single-valued sub-schema (here: an array property's `items`) that exists
+// in the base but not the revision produces a sub-schema diff with a nil
+// Revision. The property-level checks read the Revision schema (ReadOnly,
+// constraints, ...), so walkProperties must not hand them a one-sided diff.
+// Regression: this used to panic with a nil pointer dereference, crashing the
+// whole process for any spec pair that removed a sub-schema on one side.
+func TestWalkPropertiesSkipsOneSidedSubSchemaDiff(t *testing.T) {
+	s1, err := open("../data/checker/nil_revision_subschema_base.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/checker/nil_revision_subschema_revision.yaml")
+	require.NoError(t, err)
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+
+	// Every property check runs against a diff whose `items` sub-schema is
+	// present only in the base; none of them may panic on the missing side.
+	require.NotPanics(t, func() {
+		checker.CheckBackwardCompatibilityUntilLevel(checker.NewConfig(checker.GetAllChecks()), d, osm, checker.INFO)
+	})
+}

--- a/data/checker/nil_revision_subschema_base.yaml
+++ b/data/checker/nil_revision_subschema_base.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.0
+info:
+  title: test
+  version: "1.0"
+paths:
+  /test:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                foo:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      bar:
+                        type: integer
+                        maximum: 100
+      responses:
+        "200":
+          description: ok

--- a/data/checker/nil_revision_subschema_revision.yaml
+++ b/data/checker/nil_revision_subschema_revision.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.0
+info:
+  title: test
+  version: "1.0"
+paths:
+  /test:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                foo:
+                  type: array
+      responses:
+        "200":
+          description: ok


### PR DESCRIPTION
## What

A spec comparison can crash oasdiff with a nil pointer dereference:

```
runtime error: invalid memory address or nil pointer dereference
checker.RequestPropertyMaxSetCheck.func1.1  ->  check_request_property_max_set.go:40
```

The property-level checks walk every modified property under a request/response body schema, descending into single-valued sub-schemas (`items`, `not`, `if`/`then`/`else`, `contentSchema`, ...). When such a sub-schema exists on only one side of the diff (for example, an array property that removes its `items` in the revision), its diff has a nil `Base` or `Revision` schema. Every property check reads that schema (`ReadOnly`, `WriteOnly`, `Extensions`, numeric constraints), so it dereferenced a nil pointer and the whole process crashed.

This is reproducible from any spec pair that removes a sub-schema on one side. A handful of checks (`list-of-types-changed`, `type-changed`, `default-value-changed`, `const-changed`) already guarded `Revision == nil` individually; the ~20 others did not.

## Fix

Guard once in `walkProperties`, the single helper every property check funnels through: skip a property diff that is missing either `Base` or `Revision`. A side that doesn't exist is not actionable for these checks (they compare two existing schemas), so dropping it is correct, and it protects current and future checks in one place rather than repeating the guard in each.

## Test

`TestWalkPropertiesSkipsOneSidedSubSchemaDiff` runs every check against a spec pair that removes an array property's `items` in the revision. It panics without the fix and passes with it. Full `checker`, `diff`, and `formatters` suites stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)