### PR TITLE
refactor(load): remove the public WithIdentity option

### DIFF
--- a/load/option.go
+++ b/load/option.go
@@ -10,17 +10,12 @@ import (
 // Option functions can be used to preprocess specs after loading them
 type Option func(*openapi3.Loader, []*SpecInfo) ([]*SpecInfo, error)
 
-// WithIdentity returns the original SpecInfos
-func WithIdentity() Option {
-	return func(loader *openapi3.Loader, specInfos []*SpecInfo) ([]*SpecInfo, error) {
-		return specInfos, nil
-	}
-}
-
-// GetOption returns the requested option or the identity option
+// GetOption returns the requested option, or a no-op option when disabled.
 func GetOption(option Option, enable bool) Option {
 	if !enable {
-		return WithIdentity()
+		return func(_ *openapi3.Loader, specInfos []*SpecInfo) ([]*SpecInfo, error) {
+			return specInfos, nil
+		}
 	}
 	return option
 }

--- a/load/spec_info_test.go
+++ b/load/spec_info_test.go
@@ -121,7 +121,7 @@ func TestSpecInfo_Options(t *testing.T) {
 }
 
 func TestSpecInfo_GlobOptions(t *testing.T) {
-	_, err := load.NewSpecInfoFromGlob(openapi3.NewLoader(), "../data/*.yaml", load.WithIdentity(), load.WithFlattenAllOf(), load.WithFlattenParams())
+	_, err := load.NewSpecInfoFromGlob(openapi3.NewLoader(), "../data/*.yaml", load.WithFlattenAllOf(), load.WithFlattenParams())
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
`load.WithIdentity()` was a no-op `Option` that returned specs unchanged. Its only callers were `GetOption` (which returned it as the disabled-feature case) and one test; nothing in oasdiff-service or oasdiff-action used it.

This inlines the no-op inside `GetOption` and drops the test's redundant use, so the no-op becomes an implementation detail rather than a public symbol to maintain and document.

`GetOption(option, enable)` is unchanged and remains the way to apply an option conditionally.

**Breaking (Go package):** the exported `load.WithIdentity` is removed. Any external caller should use `load.GetOption(opt, false)` instead. Worth a "Go package changes" line in the next release notes.

Build clean, `load` tests green.