### PR TITLE
Encrypt the --open review end-to-end (share specs without the host reading them)

### DIFF
--- a/internal/changelog.go
+++ b/internal/changelog.go
@@ -82,7 +82,7 @@ func getChangelog(flags *Flags, stdout io.Writer, level checker.Level, isBreakin
 	}
 
 	if flags.getOpen() {
-		if err := uploadAndOpen(flags, stdout, isBreaking); err != nil {
+		if err := uploadAndOpen(flags, stdout, isBreaking, errs, diffResult.specInfoPair, diffResult.diffReport.Empty()); err != nil {
 			return false, getErrUploadAndOpenFailed(err)
 		}
 	}

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -1,8 +1,6 @@
 package internal
 
 import (
-	"encoding/json"
-
 	"github.com/oasdiff/oasdiff/diff"
 	"github.com/oasdiff/oasdiff/load"
 	"github.com/spf13/viper"
@@ -36,39 +34,6 @@ func (flags *Flags) toConfig() *diff.Config {
 	config.MatchInlineRefs = flags.getMatchInlineRefs()
 
 	return config
-}
-
-// semanticOptionsJSON returns a JSON object of the semantic comparison flags
-// the visitor passed (flatten-allof, flatten-params, etc.), for callers that
-// forward comparison settings to another renderer (the --open web review
-// upload). Filtering and presentation flags are deliberately excluded: the web
-// UI owns those interactively. Returns "" when no semantic flags are set, so
-// the upload omits the field rather than sending an empty object.
-func (flags *Flags) semanticOptionsJSON() string {
-	opts := map[string]any{}
-	if flags.getFlattenAllOf() {
-		opts["flatten-allof"] = true
-	}
-	if flags.getFlattenParams() {
-		opts["flatten-params"] = true
-	}
-	if flags.getCaseInsensitiveHeaders() {
-		opts["case-insensitive-headers"] = true
-	}
-	if flags.getAutoUpgrade() {
-		opts["auto-upgrade"] = true
-	}
-	if flags.getMatchInlineRefs() {
-		opts["match-inline-refs"] = true
-	}
-	if flags.getIncludePathParams() {
-		opts["include-path-params"] = true
-	}
-	if len(opts) == 0 {
-		return ""
-	}
-	b, _ := json.Marshal(opts)
-	return string(b)
 }
 
 func (flags *Flags) getViper() *viper.Viper {

--- a/internal/open_review.go
+++ b/internal/open_review.go
@@ -25,9 +25,12 @@ import (
 	"github.com/oasdiff/oasdiff/load"
 )
 
-// oasdiffSiteURL is the base URL of the web product. Overridable via the
-// OASDIFF_URL env var for local development and tests; in production this
-// is the canonical oasdiff.com.
+// oasdiffSiteURL is the base URL of the web product. Defaults to the canonical
+// oasdiff.com; set the OASDIFF_URL env var to point --open at a different
+// deployment -- a local dev server, or a self-hosted oasdiff. The target must
+// be a full web deployment: --open uploads to its /api/encrypted-review route
+// and the review renders at /review/e, so a bare API service (api.oasdiff.com)
+// won't work.
 func oasdiffSiteURL() string {
 	if u := os.Getenv("OASDIFF_URL"); u != "" {
 		return strings.TrimRight(u, "/")

--- a/internal/open_review.go
+++ b/internal/open_review.go
@@ -59,12 +59,12 @@ const encryptedReviewBlobVersion = 1
 // It is byte-identical to what oasdiff-service's /public/changelog returns for
 // the plaintext path, so the review page renders it the same way.
 type reviewPayload struct {
-	BaseSpec         string          `json:"base_spec"`
-	RevisionSpec     string          `json:"revision_spec"`
-	BaseFilename     string          `json:"base_filename"`
-	RevisionFilename string          `json:"revision_filename"`
-	Changes          json.RawMessage `json:"changes"`
-	Mode             string          `json:"mode"`
+	BaseSpec         string          `json:"base_spec" yaml:"base_spec"`
+	RevisionSpec     string          `json:"revision_spec" yaml:"revision_spec"`
+	BaseFilename     string          `json:"base_filename" yaml:"base_filename"`
+	RevisionFilename string          `json:"revision_filename" yaml:"revision_filename"`
+	Changes          json.RawMessage `json:"changes" yaml:"changes"`
+	Mode             string          `json:"mode" yaml:"mode"`
 }
 
 // uploadAndOpen runs at the end of `oasdiff changelog --open` (and

--- a/internal/open_review.go
+++ b/internal/open_review.go
@@ -3,12 +3,14 @@ package internal
 import (
 	"bytes"
 	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"mime/multipart"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -18,6 +20,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/oasdiff/oasdiff/checker"
+	"github.com/oasdiff/oasdiff/formatters"
 	"github.com/oasdiff/oasdiff/load"
 )
 
@@ -31,22 +35,47 @@ func oasdiffSiteURL() string {
 	return "https://www.oasdiff.com"
 }
 
+// encryptedReviewBlobVersion is the first byte of the uploaded blob. It lets
+// the browser decryptor reject a format it doesn't understand instead of
+// trying to decrypt garbage. Bump it only on an incompatible layout change.
+const encryptedReviewBlobVersion = 1
+
+// reviewPayload is the cleartext bundle the CLI encrypts and uploads. It is
+// never seen by oasdiff.com in cleartext: the CLI AES-256-GCM-encrypts the
+// JSON below with a fresh random key, uploads only the ciphertext, and puts
+// the key in the review URL's #fragment (which browsers never send to a
+// server). The browser decrypts and renders.
+//
+// BaseSpec / RevisionSpec hold each spec's bytes verbatim as a string. A YAML
+// spec stays YAML text and a JSON spec stays JSON text -- this JSON object is
+// only the envelope that bundles the several fields into one blob; it does not
+// reformat or reparse the spec content.
+//
+// Changes is the JSON changelog the CLI already computed, embedded raw. The
+// server can't recompute it (it can't read the specs), so the CLI ships it.
+// It is byte-identical to what oasdiff-service's /public/changelog returns for
+// the plaintext path, so the review page renders it the same way.
+type reviewPayload struct {
+	BaseSpec         string          `json:"base_spec"`
+	RevisionSpec     string          `json:"revision_spec"`
+	BaseFilename     string          `json:"base_filename"`
+	RevisionFilename string          `json:"revision_filename"`
+	Changes          json.RawMessage `json:"changes"`
+	Mode             string          `json:"mode"`
+}
+
 // uploadAndOpen runs at the end of `oasdiff changelog --open` (and
-// `breaking --open`): uploads the two spec sources to oasdiff.com, prints
-// the resulting review URL, and opens it in the default browser. The
-// terminal changelog/breaking output has already been printed by the caller;
-// --open is purely additive.
+// `breaking --open`): it bundles the two specs and the computed changelog,
+// encrypts the bundle with a fresh key, uploads only the ciphertext to
+// oasdiff.com, prints the resulting review URL (with the key in its
+// #fragment), and opens it in the default browser. The terminal
+// changelog/breaking output has already been printed by the caller; --open is
+// purely additive.
 //
-// isBreaking is the visitor's subcommand intent: true when invoked via
-// `oasdiff breaking`, false via `oasdiff changelog`. We forward this as the
-// upload's `mode` field so the rendered /review/local page filters its
-// severity view to match what the visitor saw in their terminal — the same
-// reasoning that semantic comparison flags (flatten-params etc.) are
-// forwarded but filtering / presentation flags are not.
-//
-// Sign-in: if no access token is stored locally, the CLI runs the first-run
-// browser handshake. See enterprise/docs/cli-local-review.md for the design.
-func uploadAndOpen(flags *Flags, stdout io.Writer, isBreaking bool) error {
+// There is no sign-in: the upload is zero-knowledge, so oasdiff.com stores an
+// opaque blob it cannot read and never needs to know who the visitor is. The
+// decryption key lives only in the URL fragment on the visitor's machine.
+func uploadAndOpen(flags *Flags, stdout io.Writer, isBreaking bool, errs checker.Changes, specInfoPair *load.SpecInfoPair, diffEmpty bool) error {
 	baseBytes, baseName, err := readSpecSource(flags.getBase())
 	if err != nil {
 		return fmt.Errorf("read base spec: %w", err)
@@ -56,27 +85,140 @@ func uploadAndOpen(flags *Flags, stdout io.Writer, isBreaking bool) error {
 		return fmt.Errorf("read revision spec: %w", err)
 	}
 
-	options := flags.semanticOptionsJSON()
-
-	accessToken, err := readOrMintAccessToken(stdout)
+	changesJSON, err := renderChangelogJSON(flags, errs, specInfoPair, isBreaking, diffEmpty)
 	if err != nil {
-		return err
+		return fmt.Errorf("render changelog: %w", err)
 	}
 
 	mode := "changelog"
 	if isBreaking {
 		mode = "breaking"
 	}
-	reviewURL, expiresAt, err := postPreviewReview(accessToken, baseName, baseBytes, revName, revBytes, options, mode)
+
+	plaintext, err := json.Marshal(reviewPayload{
+		BaseSpec:         string(baseBytes),
+		RevisionSpec:     string(revBytes),
+		BaseFilename:     baseName,
+		RevisionFilename: revName,
+		Changes:          changesJSON,
+		Mode:             mode,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal review payload: %w", err)
+	}
+
+	blob, key, err := encryptReviewPayload(plaintext)
+	if err != nil {
+		return fmt.Errorf("encrypt review: %w", err)
+	}
+
+	reviewID, expiresAt, err := postEncryptedReview(blob)
 	if err != nil {
 		return err
 	}
+
+	// The key rides in the URL #fragment. Browsers never transmit the
+	// fragment to a server (not in the request path, query, or Referer), so
+	// neither oasdiff.com nor any intermediary sees the key -- only code
+	// running in the visitor's own browser can read it.
+	reviewURL := fmt.Sprintf("%s/review/e/%s#k=%s",
+		oasdiffSiteURL(),
+		url.PathEscape(reviewID),
+		base64.RawURLEncoding.EncodeToString(key),
+	)
 
 	fmt.Fprintf(stdout, "\nOpening %s (expires %s)\n", reviewURL, expiresAt.Format("2006-01-02 15:04 MST"))
 	if err := openBrowser(reviewURL); err != nil {
 		fmt.Fprintf(stdout, "Could not open browser automatically: %v\nOpen this URL manually: %s\n", err, reviewURL)
 	}
 	return nil
+}
+
+// renderChangelogJSON produces the JSON changelog bytes embedded in the
+// encrypted payload. It mirrors oasdiff-service's /public/changelog rendering
+// (FormatJSON + WrapInObject) so the review page consumes identical bytes
+// whether the review came through the plaintext path or the encrypted one.
+// Color is forced off: the output is data, not a terminal render.
+func renderChangelogJSON(flags *Flags, errs checker.Changes, specInfoPair *load.SpecInfoPair, isBreaking, diffEmpty bool) ([]byte, error) {
+	formatter, err := formatters.Lookup(string(formatters.FormatJSON), formatters.FormatterOpts{Language: flags.getLang()})
+	if err != nil {
+		return nil, err
+	}
+	return formatter.RenderChangelog(
+		errs,
+		formatters.RenderOpts{WrapInObject: true, ColorMode: checker.ColorNever, IsBreaking: isBreaking, DiffEmpty: diffEmpty},
+		specInfoPair.GetBaseVersion(),
+		specInfoPair.GetRevisionVersion(),
+	)
+}
+
+// encryptReviewPayload encrypts plaintext with a freshly generated 256-bit key
+// using AES-256-GCM. It returns the upload blob and the key. The blob layout
+// is: version(1) || nonce(12) || ciphertext+tag. The key is returned to the
+// caller (it goes in the URL fragment) and is never uploaded.
+func encryptReviewPayload(plaintext []byte) (blob, key []byte, err error) {
+	key = make([]byte, 32) // AES-256
+	if _, err := rand.Read(key); err != nil {
+		return nil, nil, fmt.Errorf("generate key: %w", err)
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, nil, err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, nil, fmt.Errorf("generate nonce: %w", err)
+	}
+	ciphertext := gcm.Seal(nil, nonce, plaintext, nil)
+
+	blob = make([]byte, 0, 1+len(nonce)+len(ciphertext))
+	blob = append(blob, encryptedReviewBlobVersion)
+	blob = append(blob, nonce...)
+	blob = append(blob, ciphertext...)
+	return blob, key, nil
+}
+
+// postEncryptedReview uploads the opaque ciphertext blob to oasdiff.com and
+// returns the assigned review id plus its TTL expiry. The request is
+// anonymous (no credentials): the server stores a blob it cannot read, so it
+// has nothing to attribute to a user. The body is the raw blob; the response
+// is JSON {review_id, expires_at}.
+func postEncryptedReview(blob []byte) (string, time.Time, error) {
+	endpoint := oasdiffSiteURL() + "/api/encrypted-review"
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, endpoint, bytes.NewReader(blob))
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+	req.Header.Set("User-Agent", "oasdiff-cli")
+
+	client := &http.Client{Timeout: 5 * time.Minute}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("upload to %s: %w", endpoint, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", time.Time{}, fmt.Errorf("upload failed (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+
+	var parsed struct {
+		ReviewID  string `json:"review_id" yaml:"review_id"`
+		ExpiresAt int64  `json:"expires_at" yaml:"expires_at"`
+	}
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return "", time.Time{}, fmt.Errorf("parse response: %w", err)
+	}
+	if parsed.ReviewID == "" {
+		return "", time.Time{}, fmt.Errorf("response missing review_id: %s", string(respBody))
+	}
+	return parsed.ReviewID, time.Unix(parsed.ExpiresAt, 0).UTC(), nil
 }
 
 // readSpecSource returns the raw bytes of a spec source and a display
@@ -103,90 +245,6 @@ func readSpecSource(source *load.Source) ([]byte, string, error) {
 	return body, filepath.Base(source.DisplayPath()), nil
 }
 
-// postPreviewReview uploads the two spec files to oasdiff.com and returns
-// the rendered review URL plus its TTL expiry timestamp. mode is "breaking"
-// or "changelog"; the server uses it to default the rendered /review/local
-// page's severity filter.
-func postPreviewReview(accessToken, baseName string, baseBytes []byte, revName string, revBytes []byte, options, mode string) (string, time.Time, error) {
-	body := &bytes.Buffer{}
-	writer := multipart.NewWriter(body)
-
-	if err := addFilePart(writer, "base", baseName, baseBytes); err != nil {
-		return "", time.Time{}, err
-	}
-	if err := addFilePart(writer, "revision", revName, revBytes); err != nil {
-		return "", time.Time{}, err
-	}
-	if options != "" {
-		if err := writer.WriteField("options", options); err != nil {
-			return "", time.Time{}, fmt.Errorf("write options field: %w", err)
-		}
-	}
-	if mode != "" {
-		if err := writer.WriteField("mode", mode); err != nil {
-			return "", time.Time{}, fmt.Errorf("write mode field: %w", err)
-		}
-	}
-	if err := writer.Close(); err != nil {
-		return "", time.Time{}, fmt.Errorf("close multipart writer: %w", err)
-	}
-
-	endpoint := oasdiffSiteURL() + "/api/preview-review"
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, endpoint, body)
-	if err != nil {
-		return "", time.Time{}, err
-	}
-	req.Header.Set("Content-Type", writer.FormDataContentType())
-	req.Header.Set("Authorization", "Bearer "+accessToken)
-	req.Header.Set("User-Agent", "oasdiff-cli")
-
-	client := &http.Client{Timeout: 5 * time.Minute}
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", time.Time{}, fmt.Errorf("upload to %s: %w", endpoint, err)
-	}
-	defer resp.Body.Close()
-
-	respBody, _ := io.ReadAll(resp.Body)
-
-	if resp.StatusCode == http.StatusUnauthorized {
-		// Stale token. Clear it and ask the user to retry, which will trigger
-		// a fresh first-run handshake. We do not retry automatically because
-		// running the OAuth dance silently after a successful diff would
-		// surprise the user.
-		_ = deleteStoredAccessToken()
-		return "", time.Time{}, fmt.Errorf("stored credentials are no longer valid; cleared them. Run the command again to sign in")
-	}
-	if resp.StatusCode != http.StatusOK {
-		return "", time.Time{}, fmt.Errorf("upload failed (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
-	}
-
-	var parsed struct {
-		ReviewId  string `json:"review_id" yaml:"review_id"`
-		ExpiresAt int64  `json:"expires_at" yaml:"expires_at"`
-	}
-	if err := json.Unmarshal(respBody, &parsed); err != nil {
-		return "", time.Time{}, fmt.Errorf("parse response: %w", err)
-	}
-	if parsed.ReviewId == "" {
-		return "", time.Time{}, fmt.Errorf("response missing review_id: %s", string(respBody))
-	}
-	reviewURL := oasdiffSiteURL() + "/review/local/" + url.PathEscape(parsed.ReviewId)
-	expiresAt := time.Unix(parsed.ExpiresAt, 0).UTC()
-	return reviewURL, expiresAt, nil
-}
-
-func addFilePart(writer *multipart.Writer, fieldName, fileName string, body []byte) error {
-	part, err := writer.CreateFormFile(fieldName, fileName)
-	if err != nil {
-		return fmt.Errorf("create form file %s: %w", fieldName, err)
-	}
-	if _, err := part.Write(body); err != nil {
-		return fmt.Errorf("write %s body: %w", fieldName, err)
-	}
-	return nil
-}
-
 // openBrowser opens the URL in the default browser. xdg-open / open / start
 // cover Linux, macOS, and Windows. Non-zero exit from the opener is treated
 // as a soft failure — the caller prints the URL for the user to follow
@@ -209,151 +267,4 @@ func openBrowser(targetURL string) error {
 		return fmt.Errorf("don't know how to open a browser on %s", runtime.GOOS)
 	}
 	return cmd.Start()
-}
-
-// credentialsPath returns the platform-appropriate path to the CLI auth
-// credentials file. Linux: $XDG_CONFIG_HOME/oasdiff/credentials. macOS:
-// ~/Library/Application Support/oasdiff/credentials. Windows:
-// %AppData%\oasdiff\credentials.
-func credentialsPath() (string, error) {
-	configDir, err := os.UserConfigDir()
-	if err != nil {
-		return "", fmt.Errorf("locate user config dir: %w", err)
-	}
-	return filepath.Join(configDir, "oasdiff", "credentials"), nil
-}
-
-// readStoredAccessToken loads a previously issued access token. Returns
-// ("", nil) when no token is stored (first run). Returns ("", err) for
-// real filesystem failures (permission denied, etc.).
-func readStoredAccessToken() (string, error) {
-	path, err := credentialsPath()
-	if err != nil {
-		return "", err
-	}
-	body, err := os.ReadFile(path)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return "", nil
-		}
-		return "", fmt.Errorf("read credentials: %w", err)
-	}
-	return strings.TrimSpace(string(body)), nil
-}
-
-// writeStoredAccessToken persists a freshly minted access token. File mode
-// 0600 because the token is a credential — same care as ~/.ssh/id_*.
-func writeStoredAccessToken(token string) error {
-	path, err := credentialsPath()
-	if err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
-		return fmt.Errorf("create config dir: %w", err)
-	}
-	return os.WriteFile(path, []byte(token+"\n"), 0600)
-}
-
-func deleteStoredAccessToken() error {
-	path, err := credentialsPath()
-	if err != nil {
-		return err
-	}
-	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return err
-	}
-	return nil
-}
-
-// readOrMintAccessToken returns the stored access token, or runs the
-// first-run browser sign-in if none is stored. The sign-in flow opens a
-// random-port HTTP listener on 127.0.0.1, opens the visitor's browser at
-// /cli-login?port=N, waits for the GET callback with the token in the
-// query string, and writes it to credentialsPath() before returning.
-func readOrMintAccessToken(stdout io.Writer) (string, error) {
-	token, err := readStoredAccessToken()
-	if err != nil {
-		return "", err
-	}
-	if token != "" {
-		return token, nil
-	}
-	fmt.Fprintf(stdout, "\nFirst time on this machine. Opening browser to sign in...\n")
-	token, err = signInViaBrowser(stdout)
-	if err != nil {
-		return "", err
-	}
-	if err := writeStoredAccessToken(token); err != nil {
-		return "", err
-	}
-	path, _ := credentialsPath()
-	fmt.Fprintf(stdout, "Stored credentials at %s\n", path)
-	return token, nil
-}
-
-// signInViaBrowser runs the localhost-handoff dance. Binds to 127.0.0.1 on a
-// random high port; opens the visitor's browser at /cli-login?port=N; waits
-// up to 5 minutes for a GET callback whose query string carries access_token;
-// returns the token.
-//
-// The handoff is a GET (top-level navigation) rather than a POST because
-// browsers warn on HTTPS → HTTP form submissions even when the destination
-// is loopback. Top-level navigations to HTTP are silently allowed. The
-// listener's response page uses history.replaceState to scrub the token
-// from the address bar.
-//
-// Edge cases (SSH / WSL / Codespaces where the browser and CLI run on
-// different hosts) are not handled in v1; the listener times out and the
-// caller surfaces the failure to the visitor. The deferred v2 fix is a
-// copy-paste fallback — see enterprise/docs/cli-local-review.md.
-func signInViaBrowser(stdout io.Writer) (string, error) {
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		return "", fmt.Errorf("bind local listener: %w", err)
-	}
-	defer ln.Close()
-	port := ln.Addr().(*net.TCPAddr).Port
-
-	tokenCh := make(chan string, 1)
-	errCh := make(chan error, 1)
-
-	mux := http.NewServeMux()
-	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-		token := strings.TrimSpace(r.URL.Query().Get("access_token"))
-		if token == "" {
-			http.Error(w, "missing access_token", http.StatusBadRequest)
-			errCh <- errors.New("callback missing access_token")
-			return
-		}
-		// Scrub the token from the address bar before the visitor can read
-		// or share it. history.replaceState replaces the loopback URL
-		// (which carried the token in its query string) with a clean path
-		// on the same loopback origin.
-		fmt.Fprintln(w, `<!doctype html><html><head><script>history.replaceState(null,'','/');</script></head><body style="font-family:sans-serif;text-align:center;padding:4rem"><h2>oasdiff CLI is signed in</h2><p>You can close this tab and return to your terminal.</p></body></html>`)
-		tokenCh <- token
-	})
-
-	server := &http.Server{Handler: mux, ReadHeaderTimeout: 10 * time.Second}
-	go func() { _ = server.Serve(ln) }()
-	defer func() { _ = server.Shutdown(context.Background()) }()
-
-	loginURL := fmt.Sprintf("%s/cli-login?port=%d", oasdiffSiteURL(), port)
-	if err := openBrowser(loginURL); err != nil {
-		fmt.Fprintf(stdout, "Could not open browser automatically: %v\nOpen this URL manually: %s\n", err, loginURL)
-	} else {
-		fmt.Fprintf(stdout, "  -> %s\n", loginURL)
-	}
-
-	select {
-	case token := <-tokenCh:
-		return token, nil
-	case err := <-errCh:
-		return "", err
-	case <-time.After(5 * time.Minute):
-		return "", errors.New("sign-in timed out after 5 minutes — no callback received from the browser")
-	}
 }

--- a/internal/open_review_unix_test.go
+++ b/internal/open_review_unix_test.go
@@ -4,57 +4,23 @@ package internal
 
 import (
 	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/base64"
 	"encoding/json"
 	"io"
-	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
+	"regexp"
 	"testing"
 
+	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/load"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 )
-
-func TestBuildSemanticOptionsJSON_OmitsEmpty(t *testing.T) {
-	flags := NewFlags()
-	require.Equal(t, "", flags.semanticOptionsJSON(),
-		"empty options must serialize to an empty string so the upload form skips the field rather than sending {}")
-}
-
-func TestBuildSemanticOptionsJSON_IncludesSemanticFlags(t *testing.T) {
-	flags := NewFlags()
-	v := flags.getViper()
-	v.Set("flatten-params", true)
-	v.Set("match-inline-refs", true)
-	v.Set("auto-upgrade", true)
-	out := flags.semanticOptionsJSON()
-
-	var parsed map[string]any
-	require.NoError(t, json.Unmarshal([]byte(out), &parsed))
-	require.Equal(t, true, parsed["flatten-params"])
-	require.Equal(t, true, parsed["match-inline-refs"])
-	require.Equal(t, true, parsed["auto-upgrade"])
-}
-
-func TestBuildSemanticOptionsJSON_DoesNotLeakFilteringFlags(t *testing.T) {
-	flags := NewFlags()
-	v := flags.getViper()
-	// Filtering and presentation flags must not appear in the options JSON
-	// — the web UI owns those.
-	v.Set("fail-on", "WARN")
-	v.Set("level", "ERR")
-	v.Set("include-checks", []string{"foo"})
-	v.Set("format", "yaml")
-	v.Set("color", "always")
-
-	out := flags.semanticOptionsJSON()
-	require.Equal(t, "", out, "no semantic flags set — output must be empty even when filtering/presentation flags are present")
-}
 
 func TestReadSpecSource_FromFile(t *testing.T) {
 	dir := t.TempDir()
@@ -102,266 +68,166 @@ func TestReadSpecSource_StdinRejected(t *testing.T) {
 	require.Contains(t, err.Error(), "stdin")
 }
 
-func TestCredentialsFile_RoundTrip(t *testing.T) {
-	// os.UserConfigDir() honors $XDG_CONFIG_HOME on Linux (falls back to
-	// $HOME/.config). Setting both makes the path deterministic on every
-	// runner regardless of the runner's actual home.
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
-	t.Setenv("HOME", dir)
-
-	// First read returns empty (no token yet).
-	tok, err := readStoredAccessToken()
+// decryptBlob is the test-side mirror of the browser decryptor: it reverses
+// the version(1) || nonce(12) || ciphertext+tag layout using the key the CLI
+// returned. If this round-trips, a correct WebCrypto implementation will too.
+func decryptBlob(t *testing.T, blob, key []byte) []byte {
+	t.Helper()
+	require.Equal(t, byte(encryptedReviewBlobVersion), blob[0], "first byte must be the format version")
+	block, err := aes.NewCipher(key)
 	require.NoError(t, err)
-	require.Equal(t, "", tok, "fresh machine returns empty rather than an error so first-run sign-in can run")
-
-	const issued = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
-	require.NoError(t, writeStoredAccessToken(issued))
-
-	got, err := readStoredAccessToken()
+	gcm, err := cipher.NewGCM(block)
 	require.NoError(t, err)
-	require.Equal(t, issued, got)
-
-	// File mode must be 0600 — the token is a credential.
-	path, err := credentialsPath()
-	require.NoError(t, err)
-	info, err := os.Stat(path)
-	require.NoError(t, err)
-	require.Equal(t, os.FileMode(0600), info.Mode()&0777, "credentials file must be readable only by the owner")
-
-	// Delete is idempotent: removing twice doesn't error.
-	require.NoError(t, deleteStoredAccessToken())
-	require.NoError(t, deleteStoredAccessToken())
+	nonce := blob[1 : 1+gcm.NonceSize()]
+	ciphertext := blob[1+gcm.NonceSize():]
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	require.NoError(t, err, "ciphertext must decrypt with the returned key")
+	return plaintext
 }
 
-func TestUploadAndOpen_PostsToServer(t *testing.T) {
-	// Stand up a stub w3 /api/preview-review that captures the request and
-	// returns a fake review_id. We then check the CLI built the multipart
-	// body correctly: verified credentials in the Authorization header,
-	// base / revision file parts populated, options field round-tripped.
-	captured := struct {
-		auth         string
-		baseBody     string
-		revBody      string
-		baseFilename string
-		revFilename  string
-		username     string
-		options      string
-		mode         string
-	}{}
+func TestEncryptReviewPayload_RoundTrip(t *testing.T) {
+	plaintext := []byte(`{"hello":"world","spec":"openapi: 3.0.0"}`)
+	blob, key, err := encryptReviewPayload(plaintext)
+	require.NoError(t, err)
+	require.Len(t, key, 32, "AES-256 needs a 256-bit key")
 
+	// The blob must not contain the plaintext anywhere — it is ciphertext.
+	require.NotContains(t, string(blob), "openapi: 3.0.0")
+
+	got := decryptBlob(t, blob, key)
+	require.Equal(t, plaintext, got)
+
+	// Two encryptions of the same plaintext must differ (fresh key + nonce),
+	// so a server seeing two identical specs can't tell they're identical.
+	blob2, key2, err := encryptReviewPayload(plaintext)
+	require.NoError(t, err)
+	require.NotEqual(t, key, key2, "each upload must use a fresh key")
+	require.NotEqual(t, blob, blob2, "ciphertext must not be deterministic")
+}
+
+func TestPostEncryptedReview_PostsBlobAnonymously(t *testing.T) {
+	var (
+		gotContentType string
+		gotAuth        string
+		gotBody        []byte
+	)
 	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/api/preview-review", r.URL.Path)
-		captured.auth = r.Header.Get("Authorization")
-		require.NoError(t, r.ParseMultipartForm(8<<20))
-		baseFile, baseHdr, err := r.FormFile("base")
-		require.NoError(t, err)
-		baseBytes, _ := io.ReadAll(baseFile)
-		captured.baseBody = string(baseBytes)
-		captured.baseFilename = baseHdr.Filename
-		revFile, revHdr, err := r.FormFile("revision")
-		require.NoError(t, err)
-		revBytes, _ := io.ReadAll(revFile)
-		captured.revBody = string(revBytes)
-		captured.revFilename = revHdr.Filename
-		captured.username = r.PostFormValue("github_username")
-		captured.options = r.PostFormValue("options")
-		captured.mode = r.PostFormValue("mode")
-		w.Header().Set("Content-Type", "application/json")
+		require.Equal(t, "/api/encrypted-review", r.URL.Path)
+		gotContentType = r.Header.Get("Content-Type")
+		gotAuth = r.Header.Get("Authorization")
+		gotBody, _ = io.ReadAll(r.Body)
 		_, _ = w.Write([]byte(`{"review_id":"abc-123","expires_at":1700000000}`))
 	}))
 	defer stub.Close()
-
-	// Seed credentials so the test doesn't try to open a browser.
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
-	t.Setenv("HOME", dir)
-	t.Setenv("OASDIFF_URL", stub.URL)
-	require.NoError(t, writeStoredAccessToken("11111111-1111-1111-1111-111111111111"))
-
-	// Seed two spec files on disk.
-	tmpdir := t.TempDir()
-	basePath := filepath.Join(tmpdir, "openapi.yaml")
-	revPath := filepath.Join(tmpdir, "openapi.yaml") // same path, different file via revision arg
-	require.NoError(t, os.WriteFile(basePath, []byte("openapi: 3.0.0\nbase\n"), 0644))
-	revFileDir := t.TempDir()
-	revPath2 := filepath.Join(revFileDir, "openapi.yaml")
-	require.NoError(t, os.WriteFile(revPath2, []byte("openapi: 3.0.0\nrev\n"), 0644))
-
-	flags := NewFlags()
-	flags.setBase(load.NewSource(basePath))
-	flags.setRevision(load.NewSource(revPath2))
-	flags.getViper().Set("flatten-params", true)
-
-	var out bytes.Buffer
-	require.NoError(t, uploadAndOpen(flags, &out, false))
-
-	require.Equal(t, "Bearer 11111111-1111-1111-1111-111111111111", captured.auth,
-		"the stored access token must be sent as Bearer auth, not in a form field")
-	require.Equal(t, "openapi: 3.0.0\nbase\n", captured.baseBody)
-	require.Equal(t, "openapi: 3.0.0\nrev\n", captured.revBody)
-	require.Equal(t, "openapi.yaml", captured.baseFilename)
-	require.Equal(t, "openapi.yaml", captured.revFilename)
-	require.JSONEq(t, `{"flatten-params":true}`, captured.options,
-		"semantic flags must round-trip into the options field; filtering and presentation flags must not appear here")
-	require.Equal(t, "changelog", captured.mode,
-		"isBreaking=false maps to mode=changelog so the rendered page shows every change")
-	// The CLI builds the URL from the stub's base, not hard-coded, so we
-	// just check it appears in stdout for the user to follow.
-	require.Contains(t, out.String(), "/review/local/abc-123")
-	_ = revPath // silence unused (kept for symmetry with the earlier path)
-	_ = viper.New()
-}
-
-func TestUploadAndOpen_BreakingSendsModeBreaking(t *testing.T) {
-	// When the visitor ran `oasdiff breaking --open`, the upload must carry
-	// mode=breaking so the rendered /review/local page defaults its severity
-	// filter to breaking-only and matches the terminal output.
-	var capturedMode string
-	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.NoError(t, r.ParseMultipartForm(8<<20))
-		capturedMode = r.PostFormValue("mode")
-		_, _ = w.Write([]byte(`{"review_id":"r1","expires_at":0}`))
-	}))
-	defer stub.Close()
-
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
-	t.Setenv("HOME", dir)
-	t.Setenv("OASDIFF_URL", stub.URL)
-	require.NoError(t, writeStoredAccessToken("11111111-1111-1111-1111-111111111111"))
-
-	tmpdir := t.TempDir()
-	basePath := filepath.Join(tmpdir, "openapi.yaml")
-	require.NoError(t, os.WriteFile(basePath, []byte("openapi: 3.0.0\n"), 0644))
-	revFileDir := t.TempDir()
-	revPath := filepath.Join(revFileDir, "openapi.yaml")
-	require.NoError(t, os.WriteFile(revPath, []byte("openapi: 3.0.0\n"), 0644))
-
-	flags := NewFlags()
-	flags.setBase(load.NewSource(basePath))
-	flags.setRevision(load.NewSource(revPath))
-
-	var out bytes.Buffer
-	require.NoError(t, uploadAndOpen(flags, &out, true))
-	require.Equal(t, "breaking", capturedMode,
-		"isBreaking=true must propagate as mode=breaking on the upload")
-}
-
-func TestUploadAndOpen_401ClearsCredentials(t *testing.T) {
-	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-		_, _ = w.Write([]byte(`{"error":"invalid or revoked access token"}`))
-	}))
-	defer stub.Close()
-
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
-	t.Setenv("HOME", dir)
-	t.Setenv("OASDIFF_URL", stub.URL)
-	require.NoError(t, writeStoredAccessToken("11111111-1111-1111-1111-111111111111"))
-
-	tmpdir := t.TempDir()
-	basePath := filepath.Join(tmpdir, "openapi.yaml")
-	revPath := filepath.Join(tmpdir, "openapi2.yaml")
-	require.NoError(t, os.WriteFile(basePath, []byte("openapi: 3.0.0\n"), 0644))
-	require.NoError(t, os.WriteFile(revPath, []byte("openapi: 3.0.0\n"), 0644))
-
-	flags := NewFlags()
-	flags.setBase(load.NewSource(basePath))
-	flags.setRevision(load.NewSource(revPath))
-
-	var out bytes.Buffer
-	err := uploadAndOpen(flags, &out, false)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "credentials")
-
-	// The stale token must have been cleared so the next run re-issues.
-	stored, _ := readStoredAccessToken()
-	require.Equal(t, "", stored, "401 must clear stored credentials so the next invocation triggers a fresh sign-in")
-}
-
-func TestSignInViaBrowser_CapturesCallback(t *testing.T) {
-	// We can't easily fake the browser opening, but we can short-circuit
-	// the wait by having a goroutine GET the listener right after the
-	// CLI starts it. To find the port, monkey-patch openBrowser via the
-	// environment: OASDIFF_URL is a stub server that, when /cli-login is
-	// hit, immediately GETs back to the local listener.
-	const issuedToken = "deadbeef-dead-beef-dead-beefdeadbeef"
-
-	// httptest stub that imitates the /cli-login page: when the CLI calls
-	// openBrowser, we instead end up here, parse the port, and call back.
-	// The production page uses a meta-refresh + JS navigation to the
-	// loopback URL; the test approximates that with an http.Get.
-	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		port := r.URL.Query().Get("port")
-		require.NotEmpty(t, port)
-		go func() {
-			_, err := http.Get("http://127.0.0.1:" + port + "/callback?access_token=" + issuedToken)
-			require.NoError(t, err)
-		}()
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer stub.Close()
 	t.Setenv("OASDIFF_URL", stub.URL)
 
-	// openBrowser will shell out to xdg-open/open. We can't intercept that
-	// without an injected dependency — instead, drive the callback directly
-	// via a stub net.Listener flow: trigger the callback ourselves.
-	//
-	// We piggyback on the fact that openBrowser is fire-and-forget: it
-	// returns immediately without waiting for the browser. Our stub server
-	// would not actually be visited by xdg-open in the test environment
-	// (there is no display); instead, we directly do the POST in another
-	// goroutine using a known listener port.
-	//
-	// Simpler approach: call signInViaBrowser in a goroutine and discover
-	// the port by inspecting the listener it creates — but the function
-	// doesn't expose the port. So we instead test the timeout path here
-	// (cheap, deterministic) and rely on the callback path being covered
-	// by integration tests against the real /cli-login page in w3.
-	_ = issuedToken // documented above
-}
-
-func TestPostPreviewReviewSendsMultipart(t *testing.T) {
-	// Tighter, lower-level test of the upload helper to lock the contract
-	// with the w3 proxy: every field name and Content-Type the proxy
-	// expects must be exactly as agreed.
-	received := struct {
-		contentType string
-		auth        string
-	}{}
-	receivedBody := &bytes.Buffer{}
-
-	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		received.contentType = r.Header.Get("Content-Type")
-		received.auth = r.Header.Get("Authorization")
-		_, _ = io.Copy(receivedBody, r.Body)
-		_, _ = w.Write([]byte(`{"review_id":"x","expires_at":0}`))
-	}))
-	defer stub.Close()
-	t.Setenv("OASDIFF_URL", stub.URL)
-
-	url, _, err := postPreviewReview("tok", "base.yaml", []byte("openapi: 3.0.0\nbase\n"), "rev.yaml", []byte("openapi: 3.0.0\nrev\n"), `{"flatten-params":true}`, "changelog")
+	blob := []byte{encryptedReviewBlobVersion, 9, 9, 9}
+	id, expires, err := postEncryptedReview(blob)
 	require.NoError(t, err)
-	require.Contains(t, url, "/review/local/x")
-	require.True(t, strings.HasPrefix(received.contentType, "multipart/form-data"),
-		"the proxy expects multipart, not JSON — locking the contract here so a refactor surprises this test rather than the deployed proxy")
-	require.Equal(t, "Bearer tok", received.auth)
+	require.Equal(t, "abc-123", id)
+	require.Equal(t, int64(1700000000), expires.Unix())
+	require.Equal(t, "application/octet-stream", gotContentType)
+	require.Empty(t, gotAuth, "the encrypted upload is anonymous; no Authorization header is sent")
+	require.Equal(t, blob, gotBody, "the raw ciphertext blob must be the request body")
+}
 
-	// Sanity-parse the multipart body to confirm the field names match
-	// what the w3 route reads (base / revision / options).
-	boundary := received.contentType[len("multipart/form-data; boundary="):]
-	reader := multipart.NewReader(receivedBody, boundary)
-	gotFields := map[string]bool{}
-	for {
-		part, err := reader.NextPart()
-		if err != nil {
-			break
-		}
-		gotFields[part.FormName()] = true
-	}
-	require.True(t, gotFields["base"])
-	require.True(t, gotFields["revision"])
-	require.True(t, gotFields["options"])
+func TestPostEncryptedReview_ServerError(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusRequestEntityTooLarge)
+		_, _ = w.Write([]byte(`{"error":"too large"}`))
+	}))
+	defer stub.Close()
+	t.Setenv("OASDIFF_URL", stub.URL)
+
+	_, _, err := postEncryptedReview([]byte{1, 2, 3})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "413")
+}
+
+// keyFragmentRe extracts the base64url key from a #k= fragment.
+var keyFragmentRe = regexp.MustCompile(`#k=([A-Za-z0-9_-]+)`)
+
+func TestUploadAndOpen_EncryptsSpecsAndEmitsFragmentURL(t *testing.T) {
+	// End-to-end: stand up a stub /api/encrypted-review, run uploadAndOpen
+	// against two real spec files, capture the uploaded blob, pull the key
+	// out of the emitted #fragment, decrypt, and assert the payload carries
+	// both specs verbatim and the right mode. This is the zero-knowledge
+	// contract: the server only ever sees the opaque blob; only the
+	// fragment key (which never leaves the URL) unlocks it.
+	var uploadedBlob []byte
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/encrypted-review", r.URL.Path)
+		uploadedBlob, _ = io.ReadAll(r.Body)
+		_, _ = w.Write([]byte(`{"review_id":"r-1","expires_at":0}`))
+	}))
+	defer stub.Close()
+	t.Setenv("OASDIFF_URL", stub.URL)
+
+	baseDir := t.TempDir()
+	basePath := filepath.Join(baseDir, "openapi.yaml")
+	require.NoError(t, os.WriteFile(basePath, []byte("openapi: 3.0.0\nbase\n"), 0644))
+	revDir := t.TempDir()
+	revPath := filepath.Join(revDir, "openapi.yaml")
+	require.NoError(t, os.WriteFile(revPath, []byte("openapi: 3.0.0\nrev\n"), 0644))
+
+	flags := NewFlags()
+	flags.setBase(load.NewSource(basePath))
+	flags.setRevision(load.NewSource(revPath))
+
+	var out bytes.Buffer
+	// nil specInfoPair is safe (version getters return "n/a"); empty changes
+	// is a valid changelog.
+	require.NoError(t, uploadAndOpen(flags, &out, false, checker.Changes{}, nil, true))
+
+	// The emitted URL must point at the encrypted review surface and carry
+	// the key only in the fragment.
+	require.Contains(t, out.String(), "/review/e/r-1#k=")
+	m := keyFragmentRe.FindStringSubmatch(out.String())
+	require.Len(t, m, 2, "the URL must contain a #k= fragment")
+	key, err := base64.RawURLEncoding.DecodeString(m[1])
+	require.NoError(t, err)
+	require.Len(t, key, 32)
+
+	// The server-visible blob must not leak the spec content in cleartext.
+	require.NotContains(t, string(uploadedBlob), "base")
+	require.NotContains(t, string(uploadedBlob), "rev")
+
+	var payload reviewPayload
+	require.NoError(t, json.Unmarshal(decryptBlob(t, uploadedBlob, key), &payload))
+	require.Equal(t, "openapi: 3.0.0\nbase\n", payload.BaseSpec, "base spec must round-trip verbatim")
+	require.Equal(t, "openapi: 3.0.0\nrev\n", payload.RevisionSpec, "revision spec must round-trip verbatim")
+	require.Equal(t, "openapi.yaml", payload.BaseFilename)
+	require.Equal(t, "openapi.yaml", payload.RevisionFilename)
+	require.Equal(t, "changelog", payload.Mode, "isBreaking=false maps to mode=changelog")
+	require.NotEmpty(t, payload.Changes, "the computed changelog must be embedded so the page needs no recompute")
+}
+
+func TestUploadAndOpen_BreakingSetsModeBreaking(t *testing.T) {
+	var uploadedBlob []byte
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		uploadedBlob, _ = io.ReadAll(r.Body)
+		_, _ = w.Write([]byte(`{"review_id":"r2","expires_at":0}`))
+	}))
+	defer stub.Close()
+	t.Setenv("OASDIFF_URL", stub.URL)
+
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "openapi.yaml")
+	require.NoError(t, os.WriteFile(basePath, []byte("openapi: 3.0.0\n"), 0644))
+	revDir := t.TempDir()
+	revPath := filepath.Join(revDir, "openapi.yaml")
+	require.NoError(t, os.WriteFile(revPath, []byte("openapi: 3.0.0\n"), 0644))
+
+	flags := NewFlags()
+	flags.setBase(load.NewSource(basePath))
+	flags.setRevision(load.NewSource(revPath))
+
+	var out bytes.Buffer
+	require.NoError(t, uploadAndOpen(flags, &out, true, checker.Changes{}, nil, true))
+
+	key, err := base64.RawURLEncoding.DecodeString(keyFragmentRe.FindStringSubmatch(out.String())[1])
+	require.NoError(t, err)
+	var payload reviewPayload
+	require.NoError(t, json.Unmarshal(decryptBlob(t, uploadedBlob, key), &payload))
+	require.Equal(t, "breaking", payload.Mode, "isBreaking=true must propagate as mode=breaking")
 }


### PR DESCRIPTION
## What

`oasdiff changelog --open` and `oasdiff breaking --open` upload the comparison to a web app so it can be viewed as a side-by-side review and shared by link. This change makes that upload **end-to-end encrypted**.

The CLI bundles the two specs, their filenames, and the changelog it computed, AES-256-GCM-encrypts the bundle with a fresh random key, and uploads only the ciphertext. The key is placed in the review URL's `#fragment`, which browsers never transmit to a server, so the host stores a blob it cannot read and your spec content never leaves your machine in cleartext.

## Why

OpenAPI specs are frequently private. Sharing a rendered review of a diff is useful, but uploading the specs in cleartext to do so isn't acceptable for many users. End-to-end encryption makes the share safe: the host (and anyone who later gains access to its storage) only ever sees ciphertext. Only someone you give the full link to (key included) can read it.

A side benefit: because the upload carries nothing readable, there's nothing to attribute to an account, so the previous browser sign-in step is gone. `--open` now works with no account.

## How it renders without the host reading the specs

The browser decrypts the payload and renders from it directly. The CLI embeds the JSON changelog it already computed (`FormatJSON` + `WrapInObject`), since the host can't recompute it without the specs.

## Notes

- Blob layout (the contract with the browser decryptor): `version(1) || nonce(12) || AES-256-GCM(payload)`. Fresh 256-bit key and nonce per upload, so identical specs don't produce identical ciphertext.
- The upload target defaults to `oasdiff.com` and is overridable with the `OASDIFF_URL` environment variable, so you can point it at your own deployment.
- `semanticOptionsJSON` and its tests are removed with the old plaintext upload: the comparison flags are already applied in the embedded changelog.

## Tests

`internal/open_review_unix_test.go`: AES-GCM round-trip (including non-deterministic ciphertext), the anonymous upload contract (octet-stream, no auth header), and a full `uploadAndOpen` test that extracts the key from the emitted `#fragment`, decrypts the captured upload, and asserts both specs round-trip verbatim while the raw blob leaks nothing in cleartext.