### PR TITLE
docs: refresh --open for the encrypted review flow; live checks catalog

### DIFF
--- a/docs/BREAKING-CHANGES.md
+++ b/docs/BREAKING-CHANGES.md
@@ -19,18 +19,18 @@ oasdiff changelog https://raw.githubusercontent.com/oasdiff/oasdiff/main/data/op
 ```
 
 ## Side-by-side review in your browser (`--open`)
-Both `breaking` and `changelog` accept an `--open` flag. After printing the usual terminal output, the CLI uploads the two specs to [oasdiff.com](https://www.oasdiff.com) and opens the rendered side-by-side review in your browser — the same view paying customers see, with approve/reject buttons present (disabled on the free tier) and the diff anchored at each change site.
+Both `breaking` and `changelog` accept an `--open` flag. After printing the usual terminal output, the CLI uploads the comparison to [oasdiff.com](https://www.oasdiff.com) and opens the rendered side-by-side review in your browser, with the diff anchored at each change site. The approve/reject buttons are shown but disabled; they are enabled only with [oasdiff Pro](https://www.oasdiff.com/pricing).
 
 ```
 oasdiff changelog HEAD~1:openapi.yaml HEAD:openapi.yaml --open
 ```
 
-The first run on a new machine opens a browser to sign in with GitHub and stores a credential at `~/.config/oasdiff/credentials` (or the platform equivalent on macOS / Windows). Subsequent runs skip the sign-in step.
+The comparison is encrypted on your machine before upload, with a one-time key that lives only in the review link (the part after the `#`) and is never sent to our servers, so what we store we cannot read. There is no sign-in and no account.
 
-The resulting URL is unguessable and shareable for 7 days — paste it into a PR comment or Slack and reviewers can open the review without installing the CLI themselves. Only semantic comparison flags (`--flatten-allof`, `--flatten-params`, `--match-inline-refs`, `--case-insensitive-headers`, `--auto-upgrade`, `--include-path-params`) are applied to the uploaded comparison; presentation and filtering flags (`--format`, `--color`, `--lang`, `--fail-on`, `--level`, `--include-checks`, `--severity-levels`) only affect the terminal output.
+The resulting URL works for 7 days. Paste it into a PR comment or Slack and reviewers can open the review without installing the CLI themselves. Anyone you give the full link to can open it (the part after the `#` is the decryption key), so treat it like a secret. Only semantic comparison flags (`--flatten-allof`, `--flatten-params`, `--match-inline-refs`, `--case-insensitive-headers`, `--auto-upgrade`, `--include-path-params`) are applied to the uploaded comparison; presentation and filtering flags (`--format`, `--color`, `--lang`, `--fail-on`, `--level`, `--include-checks`, `--severity-levels`) only affect the terminal output.
 
 ## Checks
-Oasdiff supports over 250 checks, categorized into three levels:  
+Oasdiff supports hundreds of checks (browse the full catalog at [oasdiff.com/checks](https://www.oasdiff.com/checks)), categorized into three levels:  
 - `ERR` - Errors are definite breaking changes which should be avoided
 - `WARN` - Warnings are potential breaking changes which developers should be aware of, but cannot be confirmed programmatically as breaking
 - `INFO` - Non-breaking changes

--- a/docs/BREAKING-CHANGES.md
+++ b/docs/BREAKING-CHANGES.md
@@ -27,7 +27,7 @@ oasdiff changelog HEAD~1:openapi.yaml HEAD:openapi.yaml --open
 
 The comparison is encrypted on your machine before upload, with a one-time key that lives only in the review link (the part after the `#`) and is never sent to our servers, so what we store we cannot read. There is no sign-in and no account.
 
-The resulting URL works for 7 days. Paste it into a PR comment or Slack and reviewers can open the review without installing the CLI themselves. Anyone you give the full link to can open it (the part after the `#` is the decryption key), so treat it like a secret. Only semantic comparison flags (`--flatten-allof`, `--flatten-params`, `--match-inline-refs`, `--case-insensitive-headers`, `--auto-upgrade`, `--include-path-params`) are applied to the uploaded comparison; presentation and filtering flags (`--format`, `--color`, `--lang`, `--fail-on`, `--level`, `--include-checks`, `--severity-levels`) only affect the terminal output.
+The resulting URL works for 7 days. Paste it into a PR comment or Slack and reviewers can open the review without installing the CLI themselves. Anyone you give the full link to can open it (the part after the `#` is the decryption key), so treat it like a secret.
 
 ## Checks
 Oasdiff supports hundreds of checks (browse the full catalog at [oasdiff.com/checks](https://www.oasdiff.com/checks)), categorized into three levels:  

--- a/docs/BREAKING-CHANGES.md
+++ b/docs/BREAKING-CHANGES.md
@@ -30,7 +30,7 @@ The comparison is encrypted on your machine before upload, with a one-time key t
 The resulting URL works for 7 days. Paste it into a PR comment or Slack and reviewers can open the review without installing the CLI themselves. Anyone you give the full link to can open it (the part after the `#` is the decryption key), so treat it like a secret.
 
 ## Checks
-Oasdiff supports hundreds of checks (browse the full catalog at [oasdiff.com/checks](https://www.oasdiff.com/checks)), categorized into three levels:  
+Oasdiff supports hundreds of checks (run `oasdiff checks` for the current list, or browse the full catalog at [oasdiff.com/checks](https://www.oasdiff.com/checks)), categorized into three levels:  
 - `ERR` - Errors are definite breaking changes which should be avoided
 - `WARN` - Warnings are potential breaking changes which developers should be aware of, but cannot be confirmed programmatically as breaking
 - `INFO` - Non-breaking changes

--- a/docs/CHECKS.md
+++ b/docs/CHECKS.md
@@ -24,9 +24,11 @@ oasdiff checks --severity info
 ```
 
 Checks are categorized into three severity levels:
-- `error` — definite breaking changes which should be avoided (~111 checks)
-- `warn` — potential breaking changes which cannot be confirmed programmatically (~24 checks)
-- `info` — non-breaking changes (~170 checks)
+- `error` — definite breaking changes which should be avoided
+- `warn` — potential breaking changes which cannot be confirmed programmatically
+- `info` — non-breaking changes
+
+Run `oasdiff checks` for the current list, or browse the full catalog at [oasdiff.com/checks](https://www.oasdiff.com/checks).
 
 ## Categorization
 Every check is categorized along independent axes, emitted as fields in the `json` and `yaml` output:

--- a/docs/USAGE_EXAMPLES.md
+++ b/docs/USAGE_EXAMPLES.md
@@ -71,7 +71,7 @@ See [CHANGELOG-TEMPLATE.md](CHANGELOG-TEMPLATE.md) for full documentation and ex
 oasdiff changelog HEAD~1:openapi.yaml HEAD:openapi.yaml --open
 oasdiff breaking HEAD~1:openapi.yaml HEAD:openapi.yaml --open
 ```
-After printing the changelog, uploads both specs to oasdiff.com and opens the rendered side-by-side review in your browser. First run prompts for GitHub sign-in; subsequent runs skip it. See [BREAKING-CHANGES.md](BREAKING-CHANGES.md#side-by-side-review-in-your-browser-open) for the full flow.
+After printing the changelog, encrypts the comparison on your machine, uploads only the ciphertext to oasdiff.com, and opens the rendered side-by-side review in your browser. No sign-in: the decryption key stays in the review link's `#` fragment and is never sent to our servers. The link works for 7 days and is shareable with anyone (the key is part of it). See [BREAKING-CHANGES.md](BREAKING-CHANGES.md#side-by-side-review-in-your-browser-open) for the full flow.
 
 ## OpenAPI diff for endpoints containing "/api" in the path
 ```bash


### PR DESCRIPTION
Documentation review pass, focused on what went stale with the encrypted `--open` review (#1001) plus a couple of count/catalog issues.

## `--open` is no longer sign-in / plaintext
`BREAKING-CHANGES.md` and `USAGE_EXAMPLES.md` still described the old flow: a GitHub sign-in on first run, a `~/.config/oasdiff/credentials` file, and `/review/local` links. As of #1001, `--open`:
- encrypts the comparison on your machine and uploads only the ciphertext,
- opens `oasdiff.com/review/e/<id>#k=<key>` with the decryption key in the URL fragment, never sent to our servers,
- has no sign-in and no account.

Updated both docs to match, noted the link is shareable for 7 days and that the fragment is the key (treat the link like a secret), and clarified that approve/reject in the rendered review is Pro-only.

## Hardcoded check counts
- `BREAKING-CHANGES.md`: "over 250 checks" replaced with a link to the live catalog at oasdiff.com/checks.
- `CHECKS.md`: dropped the per-severity counts (~111 / ~24 / ~170, which drift) in favor of `oasdiff checks` and the catalog link.

## Scope notes
This was a full read of all ~30 files in `docs/`. The rest were accurate; internal anchor links checked out. One thing intentionally left for the release: a couple of action examples pin `@v0.0.57` (a valid current release) and should bump to `v0.1.0` when that ships, so I left them to the release rather than referencing an unreleased tag here.