### PR TITLE
Note client-side encryption in the --open flag help

### DIFF
--- a/internal/breaking_changes.go
+++ b/internal/breaking_changes.go
@@ -20,7 +20,7 @@ func getBreakingChangesCmd() *cobra.Command {
 	addCommonDiffFlags(&cmd)
 	addCommonBreakingFlags(&cmd)
 	enumWithOptions(&cmd, newEnumValue(GetBreakingLevels(), ""), "fail-on", "o", "exit with return code 1 when output includes errors with this level or higher")
-	cmd.PersistentFlags().Bool("open", false, "after printing the breaking changes, upload the comparison to oasdiff.com and open the side-by-side review in a browser")
+	cmd.PersistentFlags().Bool("open", false, "after printing the breaking changes, encrypt the comparison and upload it to oasdiff.com, then open the side-by-side review in a browser")
 
 	return &cmd
 }

--- a/internal/changelog.go
+++ b/internal/changelog.go
@@ -26,7 +26,7 @@ func getChangelogCmd() *cobra.Command {
 	addCommonBreakingFlags(&cmd)
 	enumWithOptions(&cmd, newEnumValue(GetSupportedLevels(), ""), "fail-on", "o", "exit with return code 1 when output includes errors with this level or higher")
 	enumWithOptions(&cmd, newEnumValue(GetSupportedLevels(), LevelInfo), "level", "", "output errors with this level or higher")
-	cmd.PersistentFlags().Bool("open", false, "after printing the changelog, upload the comparison to oasdiff.com and open the side-by-side review in a browser")
+	cmd.PersistentFlags().Bool("open", false, "after printing the changelog, encrypt the comparison and upload it to oasdiff.com, then open the side-by-side review in a browser")
 
 	return &cmd
 }


### PR DESCRIPTION
`oasdiff changelog/breaking --help` described `--open` as "upload the comparison to oasdiff.com", which to a privacy-conscious reader looks like specs being sent in clear to a server.

Changed both flag descriptions to "encrypt the comparison and upload it to oasdiff.com, then open the side-by-side review in a browser". The single added clause signals that encryption happens client-side, before upload, without expanding the one-line help into a paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)