### PR TITLE
fix(open): make --open non-fatal and reject composed mode cleanly

### DIFF
--- a/internal/changelog.go
+++ b/internal/changelog.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/formatters"
@@ -83,7 +84,11 @@ func getChangelog(flags *Flags, stdout io.Writer, level checker.Level, isBreakin
 
 	if flags.getOpen() {
 		if err := uploadAndOpen(flags, stdout, isBreaking, errs, diffResult.specInfoPair, diffResult.diffReport.Empty()); err != nil {
-			return false, getErrUploadAndOpenFailed(err)
+			// --open is additive: an upload error, unsupported source, or
+			// composed mode must not change the exit code or pre-empt --fail-on.
+			// Warn to stderr (not stdout, so it never corrupts piped --format
+			// json/yaml output) and continue.
+			_, _ = fmt.Fprintf(os.Stderr, "warning: could not open the side-by-side review: %v\n", err)
 		}
 	}
 

--- a/internal/changelog.go
+++ b/internal/changelog.go
@@ -48,6 +48,15 @@ func runChangelog(flags *Flags, stdout io.Writer) (bool, *ReturnError) {
 
 func getChangelog(flags *Flags, stdout io.Writer, level checker.Level, isBreaking bool) (bool, *ReturnError) {
 
+	// --open builds a side-by-side review of exactly two specs; composed mode
+	// (-c) diffs a glob of many files, which the review can't represent. This is
+	// a static flag incompatibility (unlike a runtime upload problem, which is
+	// non-fatal below), so reject it up front instead of running the whole diff
+	// and then warning.
+	if flags.getOpen() && flags.getComposed() {
+		return false, getErrInvalidFlags(fmt.Errorf("--open cannot be used with composed mode (-c): the side-by-side review compares exactly two specs"))
+	}
+
 	diffResult, returnErr := calcDiff(flags)
 	if returnErr != nil {
 		return false, returnErr

--- a/internal/changelog.go
+++ b/internal/changelog.go
@@ -48,15 +48,6 @@ func runChangelog(flags *Flags, stdout io.Writer) (bool, *ReturnError) {
 
 func getChangelog(flags *Flags, stdout io.Writer, level checker.Level, isBreaking bool) (bool, *ReturnError) {
 
-	// --open builds a side-by-side review of exactly two specs; composed mode
-	// (-c) diffs a glob of many files, which the review can't represent. This is
-	// a static flag incompatibility (unlike a runtime upload problem, which is
-	// non-fatal below), so reject it up front instead of running the whole diff
-	// and then warning.
-	if flags.getOpen() && flags.getComposed() {
-		return false, getErrInvalidFlags(fmt.Errorf("--open cannot be used with composed mode (-c): the side-by-side review compares exactly two specs"))
-	}
-
 	diffResult, returnErr := calcDiff(flags)
 	if returnErr != nil {
 		return false, returnErr

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -118,13 +118,6 @@ func getErrDisallowedExternalRef(err error) *ReturnError {
 	return getError(err, 123)
 }
 
-func getErrUploadAndOpenFailed(err error) *ReturnError {
-	return getError(
-		fmt.Errorf("--open failed: %w", err),
-		130,
-	)
-}
-
 // asFlattenError returns the *load.FlattenError in err's chain, or nil if err is
 // a genuine load failure. Centralised so every spec-loading site stays a single
 // line at the call site.

--- a/internal/handlers.go
+++ b/internal/handlers.go
@@ -23,6 +23,9 @@ func getParseArgs() cobra.PositionalArgs {
 		if err := checkStdinWithComposed(cmd, args); err != nil {
 			return err
 		}
+		if err := checkOpenWithComposed(cmd); err != nil {
+			return err
+		}
 		if err := checkColor(cmd); err != nil {
 			return err
 		}
@@ -83,6 +86,38 @@ func checkColor(cmd *cobra.Command) error {
 	}
 
 	return errors.New(`--color flag is only relevant with 'text' or 'singleline' formats`)
+}
+
+func checkOpenWithComposed(cmd *cobra.Command) error {
+
+	// --open exists only on breaking and changelog; diff and summary share
+	// getParseArgs but don't define it.
+	if cmd.Flags().Lookup("open") == nil {
+		return nil
+	}
+
+	open, err := cmd.Flags().GetBool("open")
+	if err != nil {
+		return errors.New("failed to get open flag")
+	}
+
+	if !open {
+		return nil
+	}
+
+	composed, err := cmd.Flags().GetBool("composed")
+	if err != nil {
+		return errors.New("failed to get composed flag")
+	}
+
+	if composed {
+		// --open builds a side-by-side review of exactly two specs; composed
+		// mode (-c) diffs a glob of many files, which the review can't
+		// represent.
+		return errors.New("--open cannot be used with composed mode (-c): the side-by-side review compares exactly two specs")
+	}
+
+	return nil
 }
 
 func checkStdinWithComposed(cmd *cobra.Command, args []string) error {

--- a/internal/open_review.go
+++ b/internal/open_review.go
@@ -79,6 +79,13 @@ type reviewPayload struct {
 // opaque blob it cannot read and never needs to know who the visitor is. The
 // decryption key lives only in the URL fragment on the visitor's machine.
 func uploadAndOpen(flags *Flags, stdout io.Writer, isBreaking bool, errs checker.Changes, specInfoPair *load.SpecInfoPair, diffEmpty bool) error {
+	// The encrypted review carries exactly two specs; composed mode (-c) diffs
+	// globs of many files, which the payload and the review page can't represent.
+	// Fail with a clear message instead of letting readSpecSource try to read the
+	// literal glob string from disk ("no such file or directory").
+	if flags.getComposed() {
+		return fmt.Errorf("--open does not support composed mode (-c)")
+	}
 	baseBytes, baseName, err := readSpecSource(flags.getBase())
 	if err != nil {
 		return fmt.Errorf("read base spec: %w", err)

--- a/internal/open_review.go
+++ b/internal/open_review.go
@@ -43,11 +43,12 @@ func oasdiffSiteURL() string {
 // trying to decrypt garbage. Bump it only on an incompatible layout change.
 const encryptedReviewBlobVersion = 1
 
-// reviewPayload is the cleartext bundle the CLI encrypts and uploads. It is
-// never seen by oasdiff.com in cleartext: the CLI AES-256-GCM-encrypts the
-// JSON below with a fresh random key, uploads only the ciphertext, and puts
-// the key in the review URL's #fragment (which browsers never send to a
-// server). The browser decrypts and renders.
+// reviewPayload is the cleartext bundle the CLI encrypts and uploads. The
+// server (oasdiff.com by default, or whatever OASDIFF_URL points at) never
+// sees it in cleartext: the CLI AES-256-GCM-encrypts the JSON below with a
+// fresh random key, uploads only the ciphertext, and puts the key in the
+// review URL's #fragment (which browsers never send to a server). The browser
+// decrypts and renders.
 //
 // BaseSpec / RevisionSpec hold each spec's bytes verbatim as a string. A YAML
 // spec stays YAML text and a JSON spec stays JSON text -- this JSON object is
@@ -56,8 +57,8 @@ const encryptedReviewBlobVersion = 1
 //
 // Changes is the JSON changelog the CLI already computed, embedded raw. The
 // server can't recompute it (it can't read the specs), so the CLI ships it.
-// It is byte-identical to what oasdiff-service's /public/changelog returns for
-// the plaintext path, so the review page renders it the same way.
+// It is byte-identical to what the service's /public/changelog returns for the
+// plaintext path, so the review page renders it the same way.
 type reviewPayload struct {
 	BaseSpec         string          `json:"base_spec" yaml:"base_spec"`
 	RevisionSpec     string          `json:"revision_spec" yaml:"revision_spec"`
@@ -69,13 +70,13 @@ type reviewPayload struct {
 
 // uploadAndOpen runs at the end of `oasdiff changelog --open` (and
 // `breaking --open`): it bundles the two specs and the computed changelog,
-// encrypts the bundle with a fresh key, uploads only the ciphertext to
-// oasdiff.com, prints the resulting review URL (with the key in its
-// #fragment), and opens it in the default browser. The terminal
-// changelog/breaking output has already been printed by the caller; --open is
-// purely additive.
+// encrypts the bundle with a fresh key, uploads only the ciphertext to the
+// configured server (oasdiff.com by default; see oasdiffSiteURL), prints the
+// resulting review URL (with the key in its #fragment), and opens it in the
+// default browser. The terminal changelog/breaking output has already been
+// printed by the caller; --open is purely additive.
 //
-// There is no sign-in: the upload is zero-knowledge, so oasdiff.com stores an
+// There is no sign-in: the upload is zero-knowledge, so the server stores an
 // opaque blob it cannot read and never needs to know who the visitor is. The
 // decryption key lives only in the URL fragment on the visitor's machine.
 func uploadAndOpen(flags *Flags, stdout io.Writer, isBreaking bool, errs checker.Changes, specInfoPair *load.SpecInfoPair, diffEmpty bool) error {
@@ -129,7 +130,7 @@ func uploadAndOpen(flags *Flags, stdout io.Writer, isBreaking bool, errs checker
 
 	// The key rides in the URL #fragment. Browsers never transmit the
 	// fragment to a server (not in the request path, query, or Referer), so
-	// neither oasdiff.com nor any intermediary sees the key -- only code
+	// neither the server nor any intermediary sees the key -- only code
 	// running in the visitor's own browser can read it.
 	reviewURL := fmt.Sprintf("%s/review/e/%s#k=%s",
 		oasdiffSiteURL(),
@@ -145,7 +146,7 @@ func uploadAndOpen(flags *Flags, stdout io.Writer, isBreaking bool, errs checker
 }
 
 // renderChangelogJSON produces the JSON changelog bytes embedded in the
-// encrypted payload. It mirrors oasdiff-service's /public/changelog rendering
+// encrypted payload. It mirrors the service's /public/changelog rendering
 // (FormatJSON + WrapInObject) so the review page consumes identical bytes
 // whether the review came through the plaintext path or the encrypted one.
 // Color is forced off: the output is data, not a terminal render.
@@ -192,11 +193,11 @@ func encryptReviewPayload(plaintext []byte) (blob, key []byte, err error) {
 	return blob, key, nil
 }
 
-// postEncryptedReview uploads the opaque ciphertext blob to oasdiff.com and
-// returns the assigned review id plus its TTL expiry. The request is
-// anonymous (no credentials): the server stores a blob it cannot read, so it
-// has nothing to attribute to a user. The body is the raw blob; the response
-// is JSON {review_id, expires_at}.
+// postEncryptedReview uploads the opaque ciphertext blob to the configured
+// server (see oasdiffSiteURL) and returns the assigned review id plus its TTL
+// expiry. The request is anonymous (no credentials): the server stores a blob
+// it cannot read, so it has nothing to attribute to a user. The body is the
+// raw blob; the response is JSON {review_id, expires_at}.
 func postEncryptedReview(blob []byte) (string, time.Time, error) {
 	endpoint := oasdiffSiteURL() + "/api/encrypted-review"
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, endpoint, bytes.NewReader(blob))

--- a/internal/open_review.go
+++ b/internal/open_review.go
@@ -80,8 +80,9 @@ type reviewPayload struct {
 // opaque blob it cannot read and never needs to know who the visitor is. The
 // decryption key lives only in the URL fragment on the visitor's machine.
 func uploadAndOpen(flags *Flags, stdout io.Writer, isBreaking bool, errs checker.Changes, specInfoPair *load.SpecInfoPair, diffEmpty bool) error {
-	// Composed mode (-c) is rejected up front in getChangelog (--open compares
-	// exactly two specs), so it never reaches here.
+	// Composed mode (-c) is rejected up front in argument validation
+	// (checkOpenWithComposed: --open compares exactly two specs), so it never
+	// reaches here.
 	baseBytes, baseName, err := readSpecSource(flags.getBase())
 	if err != nil {
 		return fmt.Errorf("read base spec: %w", err)

--- a/internal/open_review.go
+++ b/internal/open_review.go
@@ -80,13 +80,8 @@ type reviewPayload struct {
 // opaque blob it cannot read and never needs to know who the visitor is. The
 // decryption key lives only in the URL fragment on the visitor's machine.
 func uploadAndOpen(flags *Flags, stdout io.Writer, isBreaking bool, errs checker.Changes, specInfoPair *load.SpecInfoPair, diffEmpty bool) error {
-	// The encrypted review carries exactly two specs; composed mode (-c) diffs
-	// globs of many files, which the payload and the review page can't represent.
-	// Fail with a clear message instead of letting readSpecSource try to read the
-	// literal glob string from disk ("no such file or directory").
-	if flags.getComposed() {
-		return fmt.Errorf("--open does not support composed mode (-c)")
-	}
+	// Composed mode (-c) is rejected up front in getChangelog (--open compares
+	// exactly two specs), so it never reaches here.
 	baseBytes, baseName, err := readSpecSource(flags.getBase())
 	if err != nil {
 		return fmt.Errorf("read base spec: %w", err)

--- a/internal/run_test.go
+++ b/internal/run_test.go
@@ -43,6 +43,19 @@ func Test_InvalidFlag(t *testing.T) {
 	require.Equal(t, 100, internal.Run(cmdToArgs("oasdiff diff data/openapi-test1.yaml data/openapi-test1.yaml --invalid"), io.Discard, io.Discard))
 }
 
+func Test_OpenWithComposedRejected(t *testing.T) {
+	// --open compares exactly two specs, so it can't be combined with composed
+	// mode (-c). Rejected at argument validation before any diff runs.
+	for _, cmd := range []string{
+		"oasdiff changelog ../data/openapi-test1.yaml ../data/openapi-test1.yaml --composed --open",
+		"oasdiff breaking ../data/openapi-test1.yaml ../data/openapi-test1.yaml -c --open",
+	} {
+		var stderr bytes.Buffer
+		require.Equal(t, 100, internal.Run(cmdToArgs(cmd), io.Discard, &stderr), cmd)
+		require.Contains(t, stderr.String(), "--open cannot be used with composed mode (-c)", cmd)
+	}
+}
+
 func Test_BasicDiff(t *testing.T) {
 	var stdout bytes.Buffer
 	require.Zero(t, internal.Run(cmdToArgs("oasdiff diff ../data/openapi-test1.yaml ../data/openapi-test3.yaml --exclude-elements endpoints"), &stdout, io.Discard))


### PR DESCRIPTION
## What

Two fixes to `--open` (on `breaking` and `changelog`).

### 1. `--open` is now non-fatal for runtime failures

The changelog/breaking output is already printed before the upload runs. Previously, an upload error (or an unsupported spec source) returned exit code `130`, which pre-empted `--fail-on` and changed the command's exit status. A side-by-side review that could not be uploaded should never alter the result of the check.

Now a runtime `--open` failure (upload error, unreachable host, unsupported source) is warned to **stderr** (so piped `--format json/yaml` output on stdout stays clean) and the command continues to its normal `--fail-on` exit.

Also removes the now-dead `getErrUploadAndOpenFailed`.

### 2. `--open` + composed (`-c`) is rejected at argument validation

Composed mode diffs a glob of many files, which the two-spec review can't represent. This is a **static, user-fixable incompatibility**, so it's validated up front in `getParseArgs` (alongside the existing `checkStdinWithComposed` / `checkColor` checks) as `checkOpenWithComposed`, failing before any diff runs with exit `100` and a clear message:

```
--open cannot be used with composed mode (-c): the side-by-side review compares exactly two specs
```

That distinction is deliberate: a transient upload blip can't be fixed by editing your command (so it warns and continues, per #1), but `-c --open` can (so it fails fast like any invalid flag combination). `checkOpenWithComposed` no-ops on `diff`/`summary`, which share `getParseArgs` but don't define `--open`.

### 3. Comments generalized to "the server"

`--open` uploads to `oasdiffSiteURL()`, which defaults to oasdiff.com but follows `OASDIFF_URL` for a local dev server or self-hosted deployment. The zero-knowledge comments hardcoded "oasdiff.com" as the destination; reworded to "the server" so they stay accurate for any `OASDIFF_URL` target.

## Test

`go build ./...`, `go vet`, and `go test ./internal/` pass. New `Test_OpenWithComposedRejected` covers both `breaking` and `changelog`; verified `diff -c` / `summary -c` (no `--open` flag) are unaffected.

## Related

- oasdiff/oasdiff-action#164 (action side: format-independent no-change detection + skip `--open` in composed mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)