### PR TITLE
fix(config): allow match-inline-refs in config + guard against flag drift

### DIFF
--- a/docs/CONFIG-FILES.md
+++ b/docs/CONFIG-FILES.md
@@ -28,7 +28,7 @@ export OASDIFF_CONFIG=./my-config.yaml
 oasdiff diff base.yaml revision.yaml
 ```
 
-The configuration file supports the exact same flags that are supported by the command-line.
+The configuration file supports the same flags that are supported by the command-line, except `--open`. `--open` uploads the comparison and opens an interactive side-by-side review in a browser, so it is a command-line-only action and is not read from a config file (a config file is shared and committed, and would otherwise upload and open a review on every run).
 Notes:
 1. Command-line flags take precedence over configuration file settings.
 2. **Boolean flags**: to set a boolean flag to `false` on the command line, use `=` syntax: `--flag=false`.

--- a/internal/config_coverage_test.go
+++ b/internal/config_coverage_test.go
@@ -1,0 +1,67 @@
+package internal
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+)
+
+// flagsNotInConfigFile lists persistent flags that are intentionally NOT
+// settable from a config file, so the drift guard below skips them:
+//   - open: an interactive one-shot action (encrypt the comparison, upload it,
+//     and open a browser). Persisting it in a committed config would upload and
+//     open a review on every run, so it is command-line only.
+//   - config: the path to the config file itself.
+//
+// Hidden (deprecated) flags are skipped separately via flag.Hidden, so they
+// don't need to be listed here.
+var flagsNotInConfigFile = map[string]bool{
+	"open":   true,
+	"config": true,
+}
+
+// Test_ConfigFileCoversAllFlags guards against config drift.
+//
+// validateViperConfig unmarshals the config file into the Config struct with
+// UnmarshalExact, which rejects any key not present in the struct. So a
+// persistent flag missing from Config doesn't just go unread, it makes a config
+// file that sets that flag fail to load entirely (every oasdiff command exits
+// with a config error). This test asserts the inverse: every visible,
+// non-excluded persistent flag on a config-loading command has a matching
+// Config field, so users can put any real flag in .oasdiff.* without surprise.
+func Test_ConfigFileCoversAllFlags(t *testing.T) {
+	configKeys := map[string]bool{}
+	ct := reflect.TypeFor[Config]()
+	for i := range ct.NumField() {
+		if tag := ct.Field(i).Tag.Get("mapstructure"); tag != "" {
+			configKeys[tag] = true
+		}
+	}
+
+	// Every command whose RunE is getRun(...) loads a config file via RunViper.
+	commands := []*cobra.Command{
+		getDiffCmd(),
+		getSummaryCmd(),
+		getBreakingChangesCmd(),
+		getChangelogCmd(),
+		getChecksCmd(),
+		getFlattenCmd(),
+		getUpgradeCmd(),
+		getValidateCmd(),
+	}
+
+	for _, cmd := range commands {
+		cmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
+			if f.Hidden || flagsNotInConfigFile[f.Name] {
+				return
+			}
+			require.Truef(t, configKeys[f.Name],
+				"flag %q on the %q command is settable on the command line but missing from the Config struct in viper.go. "+
+					"Add a mapstructure field for it, or add it to flagsNotInConfigFile if it must not be config-settable.",
+				f.Name, cmd.Name())
+		})
+	}
+}

--- a/internal/config_coverage_test.go
+++ b/internal/config_coverage_test.go
@@ -34,9 +34,8 @@ var flagsNotInConfigFile = map[string]bool{
 // Config field, so users can put any real flag in .oasdiff.* without surprise.
 func Test_ConfigFileCoversAllFlags(t *testing.T) {
 	configKeys := map[string]bool{}
-	ct := reflect.TypeFor[Config]()
-	for i := range ct.NumField() {
-		if tag := ct.Field(i).Tag.Get("mapstructure"); tag != "" {
+	for field := range reflect.TypeFor[Config]().Fields() {
+		if tag := field.Tag.Get("mapstructure"); tag != "" {
 			configKeys[tag] = true
 		}
 	}

--- a/internal/viper.go
+++ b/internal/viper.go
@@ -205,6 +205,7 @@ type Config struct {
 	StripPrefixBase        string   `mapstructure:"strip-prefix-base"`
 	StripPrefixRevision    string   `mapstructure:"strip-prefix-revision"`
 	IncludePathParams      bool     `mapstructure:"include-path-params"`
+	MatchInlineRefs        bool     `mapstructure:"match-inline-refs"`
 	AllowExternalRefs      bool     `mapstructure:"allow-external-refs"`
 	AutoUpgrade            bool     `mapstructure:"auto-upgrade"`
 	Fetch                  bool     `mapstructure:"fetch"`


### PR DESCRIPTION
## What

The config file is validated with `UnmarshalExact` against the `Config` struct, so a persistent flag missing from `Config` doesn't just go unread, it makes **any config file that sets it fail to load entirely** (every command exits with a config error).

`match-inline-refs` (a visible, default-on diff flag) was missing from `Config`, so this:

```yaml
# .oasdiff.yaml
match-inline-refs: false
```

was rejected with `'internal.Config' has invalid keys: match-inline-refs` (exit 107). This PR adds it.

## Drift guard

`Config` is a hand-maintained mirror of the flag set with nothing tying the two together, which is how `match-inline-refs` (and others) slipped through. `Test_ConfigFileCoversAllFlags` closes that: it walks every persistent flag on the config-loading commands and asserts each is either a `Config` field or deliberately excluded. Adding a new flag without a `Config` field now fails the test instead of silently rejecting users' configs.

- Hidden (deprecated) flags (`flatten`, `max-circular-dep`, `include-checks`) are skipped via `flag.Hidden`, they're intentionally not config-settable.
- `open` and `config` are in an explicit, commented exclusion list. `--open` is an interactive one-shot action (encrypt the comparison, upload it, open a browser); persisting it in a committed config would upload and open a review on every run, so it's command-line only.

## Docs

`CONFIG-FILES.md` claimed the config file supports "the exact same flags that are supported by the command-line." Corrected to call out the `--open` exception.

## Test

`go vet` and `go test ./internal/` pass. Verified `match-inline-refs: false` in `.oasdiff.yaml` now loads (was exit 107).

🤖 Generated with [Claude Code](https://claude.com/claude-code)