### PR TITLE
docs: pin oasdiff-action examples to the @v0 moving major tag

### DIFF
--- a/docs/CONTRIB.md
+++ b/docs/CONTRIB.md
@@ -16,7 +16,7 @@ The simplest contribution is to use oasdiff in your projects and tell others abo
 If your team uses GitHub, install the [oasdiff GitHub Action](https://github.com/oasdiff/oasdiff-action) to automatically detect breaking changes on every pull request:
 
 ```yaml
-- uses: oasdiff/oasdiff-action/changelog@v0.1.1
+- uses: oasdiff/oasdiff-action/changelog@v0
   with:
     base: 'origin/${{ github.base_ref }}:openapi.yaml'
     revision: 'HEAD:openapi.yaml'

--- a/docs/GIT-REVISION.md
+++ b/docs/GIT-REVISION.md
@@ -79,7 +79,7 @@ jobs:
         with:
           fetch-depth: 0          # full history needed for git refs
 
-      - uses: oasdiff/oasdiff-action/breaking@v0.1.1
+      - uses: oasdiff/oasdiff-action/breaking@v0
         with:
           base: 'origin/${{ github.base_ref }}:openapi.yaml'
           revision: 'HEAD:openapi.yaml'


### PR DESCRIPTION
The two `oasdiff-action` workflow snippets in the docs used an exact version pin:

- `docs/GIT-REVISION.md` (`breaking@`)
- `docs/CONTRIB.md` (`changelog@`)

Point them at the moving major tag **`@v0`** so copied workflows get later patches and minors automatically, matching the action README's Versioning section and the oasdiff.com examples. The release tooling re-points `v0` to each stable release, and its docs-bump regex only matches exact `X.Y.Z` refs, so it leaves `@v0` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)