### PR TITLE
docs: document the hosted MCP server

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,0 +1,38 @@
+# MCP server
+
+oasdiff is available as a hosted [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server, so AI assistants like Claude and Cursor can run it for you. Ask "does this change break the API?" and the assistant calls oasdiff on your specs and reads back the result.
+
+It is a remote server over the Streamable HTTP transport, hosted at `https://api.oasdiff.com/mcp`. No install, no API key.
+
+## Tools
+
+- detect breaking changes between two OpenAPI specs
+- generate a changelog
+- diff two specs
+- validate a spec
+
+Specs are passed as text by the assistant; external `$ref` URLs are not resolved, so a spec must be self-contained.
+
+## Connect
+
+Claude Code:
+
+```
+claude mcp add --transport http oasdiff https://api.oasdiff.com/mcp
+```
+
+Cursor, in `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (per project):
+
+```json
+{
+  "mcpServers": {
+    "oasdiff": {
+      "url": "https://api.oasdiff.com/mcp"
+    }
+  }
+}
+```
+
+Any MCP client that speaks Streamable HTTP works: point it at `https://api.oasdiff.com/mcp`.
+
+Full guide: [oasdiff.com/docs/mcp](https://www.oasdiff.com/docs/mcp)

--- a/docs/README.md
+++ b/docs/README.md
@@ -123,6 +123,7 @@ Shape and enrich the report.
 - [Configuration file](CONFIG-FILES.md)
 - [Embed in a Go program](GO.md)
 - [GitHub Action](https://github.com/oasdiff/oasdiff-action) for CI — and [oasdiff.com](https://www.oasdiff.com) for teams, which adds a per-change PR comment with approve/reject and commit-status checks
+- [MCP server](MCP.md) — call oasdiff from an AI assistant (Claude, Cursor, ...) via the hosted server at `https://api.oasdiff.com/mcp`
 
 ### Reference
 - [OpenAPI 3.1 support](OPENAPI-31.md) — what's supported


### PR DESCRIPTION
Adds `docs/MCP.md` and a link in the README's **How to run** section, documenting that oasdiff is available as a hosted MCP server at `https://api.oasdiff.com/mcp` (Streamable HTTP, no install or API key) and how to connect Claude Code, Cursor, and other MCP clients.

Framed as a pointer to the hosted offering and a way to *run* oasdiff, alongside Docker and the GitHub Action. It does not claim the CLI itself embeds an MCP server (the server is a separate hosted service). Concise on purpose, with a link to the full guide at oasdiff.com/docs/mcp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)