### PR TITLE
fix(checker): nullable-via-type-array detection is symmetric and ignores the untyped case

### DIFF
--- a/checker/check_request_property_became_not_nuallable.go
+++ b/checker/check_request_property_became_not_nuallable.go
@@ -28,7 +28,7 @@ func RequestPropertyBecameNotNullableCheck(diffReport *diff.Diff, operationsSour
 			// OpenAPI 3.1: type changed from ["string", "null"] to "string"
 			result = append(result, info.newChange(RequestBodyBecomeNotNullableId, nil, "").
 				WithSources(baseSource, revisionSource))
-		} else if nullAddedToTypeArray(info.schemaDiff.TypeDiff) {
+		} else if nullAddedToTypeArray(info.schemaDiff.TypeDiff, info.schemaDiff.Base.Type) {
 			// OpenAPI 3.1: type changed from "string" to ["string", "null"]
 			result = append(result, info.newChange(RequestBodyBecomeNullableId, nil, "").
 				WithSources(baseSource, revisionSource))
@@ -50,7 +50,7 @@ func RequestPropertyBecameNotNullableCheck(diffReport *diff.Diff, operationsSour
 			} else if nullRemovedFromTypeArray(p.propertyDiff.TypeDiff, p.propertyDiff.Revision.Type) {
 				result = append(result, p.newChange(RequestPropertyBecomeNotNullableId, []any{propName}, "").
 					WithSources(propBaseSource, propRevisionSource))
-			} else if nullAddedToTypeArray(p.propertyDiff.TypeDiff) {
+			} else if nullAddedToTypeArray(p.propertyDiff.TypeDiff, p.propertyDiff.Base.Type) {
 				result = append(result, p.newChange(RequestPropertyBecomeNullableId, []any{propName}, "").
 					WithSources(propBaseSource, propRevisionSource))
 			}

--- a/checker/check_request_property_became_not_nuallable.go
+++ b/checker/check_request_property_became_not_nuallable.go
@@ -24,7 +24,7 @@ func RequestPropertyBecameNotNullableCheck(diffReport *diff.Diff, operationsSour
 				result = append(result, info.newChange(RequestBodyBecomeNullableId, nil, "").
 					WithSources(baseSource, revisionSource))
 			}
-		} else if nullRemovedFromTypeArray(info.schemaDiff.TypeDiff) {
+		} else if nullRemovedFromTypeArray(info.schemaDiff.TypeDiff, info.schemaDiff.Revision.Type) {
 			// OpenAPI 3.1: type changed from ["string", "null"] to "string"
 			result = append(result, info.newChange(RequestBodyBecomeNotNullableId, nil, "").
 				WithSources(baseSource, revisionSource))
@@ -47,7 +47,7 @@ func RequestPropertyBecameNotNullableCheck(diffReport *diff.Diff, operationsSour
 					result = append(result, p.newChange(RequestPropertyBecomeNullableId, []any{propName}, "").
 						WithSources(propBaseSource, propRevisionSource))
 				}
-			} else if nullRemovedFromTypeArray(p.propertyDiff.TypeDiff) {
+			} else if nullRemovedFromTypeArray(p.propertyDiff.TypeDiff, p.propertyDiff.Revision.Type) {
 				result = append(result, p.newChange(RequestPropertyBecomeNotNullableId, []any{propName}, "").
 					WithSources(propBaseSource, propRevisionSource))
 			} else if nullAddedToTypeArray(p.propertyDiff.TypeDiff) {

--- a/checker/check_request_property_became_not_nuallable_test.go
+++ b/checker/check_request_property_became_not_nuallable_test.go
@@ -267,3 +267,21 @@ func TestRequestBodyTypeRemovedEntirelyStaysNullable(t *testing.T) {
 	require.False(t, containsId(errs, checker.RequestBodyBecomeNotNullableId),
 		"removing the type entirely leaves the schema nullable (untyped accepts null); must not report became-not-nullable")
 }
+
+// CL: adding an explicit type (including null) to a previously untyped body must
+// NOT report became-nullable. An untyped schema already accepts null, so adding
+// [object, null] does not introduce nullability. Mirror of the type-removed case. (#1004)
+func TestRequestBodyTypeAddedFromUntypedStaysNullable(t *testing.T) {
+	s1, err := open("../data/checker/request_body_nullable_31_revision.yaml") // type: [object, "null"]
+	require.NoError(t, err)
+	s2, err := open("../data/checker/request_body_nullable_31_revision.yaml")
+	require.NoError(t, err)
+	// Base is untyped; revision keeps [object, null]. Untyped already accepts null.
+	s1.Spec.Paths.Value("/products").Post.RequestBody.Value.Content["application/json"].Schema.Value.Type = nil
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyBecameNotNullableCheck), d, osm, checker.INFO)
+	require.False(t, containsId(errs, checker.RequestBodyBecomeNullableId),
+		"adding a type to a previously untyped schema does not add nullability (untyped already accepts null)")
+}

--- a/checker/check_request_property_became_not_nuallable_test.go
+++ b/checker/check_request_property_became_not_nuallable_test.go
@@ -249,3 +249,21 @@ func TestResponseTypeCheckerSuppressedForNullOnly31(t *testing.T) {
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyTypeChangedCheck), d, osm, checker.INFO)
 	require.Empty(t, errs)
 }
+
+// CL: removing the type keyword entirely (3.1) must NOT report became-not-nullable.
+// An untyped schema accepts any value, including null, so the body is still
+// nullable; only narrowing to a non-null type set removes null. (#1004)
+func TestRequestBodyTypeRemovedEntirelyStaysNullable(t *testing.T) {
+	s1, err := open("../data/checker/request_body_nullable_31_revision.yaml") // type: [object, "null"]
+	require.NoError(t, err)
+	s2, err := open("../data/checker/request_body_nullable_31_revision.yaml")
+	require.NoError(t, err)
+	// Revision drops the type entirely: untyped, so null is still accepted.
+	s2.Spec.Paths.Value("/products").Post.RequestBody.Value.Content["application/json"].Schema.Value.Type = nil
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyBecameNotNullableCheck), d, osm, checker.INFO)
+	require.False(t, containsId(errs, checker.RequestBodyBecomeNotNullableId),
+		"removing the type entirely leaves the schema nullable (untyped accepts null); must not report became-not-nullable")
+}

--- a/checker/check_response_property_became_nuallable.go
+++ b/checker/check_response_property_became_nuallable.go
@@ -17,7 +17,7 @@ func ResponsePropertyBecameNullableCheck(diffReport *diff.Diff, operationsSource
 		if info.schemaDiff.NullableDiff != nil && info.schemaDiff.NullableDiff.To == true {
 			result = append(result, info.newChange(ResponseBodyBecameNullableId, nil, "").
 				WithSources(baseSource, revisionSource))
-		} else if nullAddedToTypeArray(info.schemaDiff.TypeDiff) {
+		} else if nullAddedToTypeArray(info.schemaDiff.TypeDiff, info.schemaDiff.Base.Type) {
 			// OpenAPI 3.1: type changed from "string" to ["string", "null"]
 			result = append(result, info.newChange(ResponseBodyBecameNullableId, nil, "").
 				WithSources(baseSource, revisionSource))
@@ -38,7 +38,7 @@ func ResponsePropertyBecameNullableCheck(diffReport *diff.Diff, operationsSource
 				return
 			}
 			// OpenAPI 3.1: type changed from "string" to ["string", "null"]
-			if nullAddedToTypeArray(p.propertyDiff.TypeDiff) {
+			if nullAddedToTypeArray(p.propertyDiff.TypeDiff, p.propertyDiff.Base.Type) {
 				result = append(result, p.newChange(
 					ResponsePropertyBecameNullableId,
 					[]any{propertyFullName(p.propertyPath, p.propertyName), info.responseStatus},

--- a/checker/nullable_type_utils.go
+++ b/checker/nullable_type_utils.go
@@ -1,6 +1,7 @@
 package checker
 
 import (
+	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 )
 
@@ -25,9 +26,17 @@ func nullAddedToTypeArray(typeDiff *diff.StringsDiff) bool {
 	return false
 }
 
-// nullRemovedFromTypeArray returns true if "null" was removed from the type array (OpenAPI 3.1 became not-nullable)
-func nullRemovedFromTypeArray(typeDiff *diff.StringsDiff) bool {
+// nullRemovedFromTypeArray returns true if "null" was removed from the type array
+// and the revision still constrains the type (OpenAPI 3.1 became not-nullable).
+// If the revision dropped the type keyword entirely, the schema is untyped and
+// accepts any value, including null, so it did NOT become non-nullable, even
+// though "null" appears in the deleted set. revisionType is the revision
+// schema's type. See #1004.
+func nullRemovedFromTypeArray(typeDiff *diff.StringsDiff, revisionType *openapi3.Types) bool {
 	if typeDiff == nil {
+		return false
+	}
+	if revisionType == nil || len(*revisionType) == 0 {
 		return false
 	}
 	for _, t := range typeDiff.Deleted {

--- a/checker/nullable_type_utils.go
+++ b/checker/nullable_type_utils.go
@@ -13,9 +13,17 @@ func isNullTypeChange(typeDiff *diff.StringsDiff) bool {
 	return onlyNull(typeDiff.Added) && onlyNull(typeDiff.Deleted)
 }
 
-// nullAddedToTypeArray returns true if "null" was added to the type array (OpenAPI 3.1 nullable)
-func nullAddedToTypeArray(typeDiff *diff.StringsDiff) bool {
+// nullAddedToTypeArray returns true if "null" was added to the type array and the
+// base already constrained the type (OpenAPI 3.1 became nullable). If the base had
+// no type keyword, it was untyped and already accepted any value, including null,
+// so introducing an explicit type that contains null does NOT make it newly
+// nullable, even though "null" appears in the added set. baseType is the base
+// schema's type. Mirror of nullRemovedFromTypeArray; see #1004.
+func nullAddedToTypeArray(typeDiff *diff.StringsDiff, baseType *openapi3.Types) bool {
 	if typeDiff == nil {
+		return false
+	}
+	if baseType == nil || len(*baseType) == 0 {
 		return false
 	}
 	for _, t := range typeDiff.Added {

--- a/checker/nullable_type_utils.go
+++ b/checker/nullable_type_utils.go
@@ -1,6 +1,8 @@
 package checker
 
 import (
+	"slices"
+
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/diff"
 )
@@ -26,12 +28,7 @@ func nullAddedToTypeArray(typeDiff *diff.StringsDiff, baseType *openapi3.Types) 
 	if baseType == nil || len(*baseType) == 0 {
 		return false
 	}
-	for _, t := range typeDiff.Added {
-		if t == "null" {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(typeDiff.Added, "null")
 }
 
 // nullRemovedFromTypeArray returns true if "null" was removed from the type array
@@ -47,12 +44,7 @@ func nullRemovedFromTypeArray(typeDiff *diff.StringsDiff, revisionType *openapi3
 	if revisionType == nil || len(*revisionType) == 0 {
 		return false
 	}
-	for _, t := range typeDiff.Deleted {
-		if t == "null" {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(typeDiff.Deleted, "null")
 }
 
 func onlyNull(types []string) bool {


### PR DESCRIPTION
Fixes #1004 (and its mirror).

OpenAPI 3.1 expresses nullability through the `type` array (`["string","null"]`). The two helpers that detect this only looked at whether `"null"` was in the added/deleted set, which misfires at the boundary where the `type` keyword is added or removed entirely. An **untyped** schema accepts any value, *including null*, so:

- **became-not-nullable** (`nullRemovedFromTypeArray`): removing the `type` keyword entirely (`["string","null"]` → no type) was reported as `request-body/property-became-not-nullable` (ERR), but the schema is still nullable. **This was the CI-failing false positive in #1004.**
- **became-nullable** (`nullAddedToTypeArray`): adding an explicit type that includes null to a previously untyped schema (no type → `["string","null"]`) was reported as `became-nullable` (INFO), but null was already accepted. Spurious INFO, the exact mirror.

## Fix

- `nullRemovedFromTypeArray` now requires the **revision** to still constrain the type (skip when the revision is untyped).
- `nullAddedToTypeArray` now requires the **base** to have constrained the type (skip when the base was untyped).

Applied to both the request and response nullable checks. The genuine transitions (`[string]` ↔ `[string,null]`) still report correctly; existing nullable tests are unchanged.

## Tests

Two replicate-first regression tests (type removed entirely → no became-not-nullable; type added from untyped → no became-nullable), plus the existing nullable suite. Full module tests, `build`, `vet`, `gofmt` all green.

## Out of scope (noted for follow-up)

Request **parameters** have no nullable-via-type-array detection at all, so a 3.1 parameter flipping `[string,null]` ↔ `[string]` isn't reported as a nullability change. That's a coverage gap (enhancement), not a false positive, and is left for a separate issue.