### PR TITLE
fix(checker): type-set widening (request) and narrowing (response) are not breaking

### DIFF
--- a/checker/check_request_property_type_changed_test.go
+++ b/checker/check_request_property_type_changed_test.go
@@ -340,9 +340,8 @@ func setRequestBodyType(t *testing.T, s *load.SpecInfo, types *openapi3.Types) {
 	s.Spec.Paths.Value("/test").Post.RequestBody.Value.Content["application/json"].Schema.Value.Type = types
 }
 
-// BC: widening a request type set ([string] -> [string, integer]) is backward
-// compatible (the server accepts every type it did before plus more) and must
-// NOT be reported as a breaking request-body-type-changed. Mirror of the
+// BC: widening a request type set ([string] -> [string, integer]) is not
+// breaking; the server accepts every type it did before plus more. Mirror of the
 // response narrowing case.
 func TestRequestBodyTypeWideningMultiTypeNotBreaking(t *testing.T) {
 	s1, err := open("../data/type-change/simple-request.yaml")
@@ -359,8 +358,8 @@ func TestRequestBodyTypeWideningMultiTypeNotBreaking(t *testing.T) {
 		"widening a request type set is non-breaking; must not report request-body-type-changed")
 }
 
-// BC: removing the type entirely from a request ([string] -> no type) is a
-// generalization (the server now accepts any value), so it is backward compatible.
+// BC: removing the type entirely from a request ([string] -> no type) is not
+// breaking; the server now accepts any value (a generalization).
 func TestRequestBodyTypeRemovedNotBreaking(t *testing.T) {
 	s1, err := open("../data/type-change/simple-request.yaml")
 	require.NoError(t, err)
@@ -376,9 +375,8 @@ func TestRequestBodyTypeRemovedNotBreaking(t *testing.T) {
 		"removing the type from a request accepts any value; non-breaking")
 }
 
-// BC (guard): narrowing a request type set ([string, integer] -> [string]) IS
-// breaking under a strongly-typed media type; a client sending integer is now
-// rejected.
+// BC: narrowing a request type set ([string, integer] -> [string]) is breaking
+// under a strongly-typed media type; a client sending integer is now rejected.
 func TestRequestBodyTypeNarrowingStillBreaking(t *testing.T) {
 	s1, err := open("../data/type-change/simple-request.yaml")
 	require.NoError(t, err)
@@ -394,8 +392,8 @@ func TestRequestBodyTypeNarrowingStillBreaking(t *testing.T) {
 		"narrowing a request type set is breaking")
 }
 
-// BC (guard): adding a type constraint to a previously untyped request
-// (no type -> [string]) restricts the accepted values, so it is breaking.
+// BC: adding a type constraint to a previously untyped request (no type ->
+// [string]) is breaking; it restricts the accepted values.
 func TestRequestBodyTypeAddedFromUntypedStillBreaking(t *testing.T) {
 	s1, err := open("../data/type-change/simple-request.yaml")
 	require.NoError(t, err)
@@ -411,11 +409,11 @@ func TestRequestBodyTypeAddedFromUntypedStillBreaking(t *testing.T) {
 		"constraining a previously untyped request is breaking")
 }
 
-// BC (guard): a request type widening that co-occurs with a breaking format
-// change must still be reported; the safe type axis must not mask the format
-// axis. [integer] -> [integer, string] widens the type (backward compatible),
-// but int64 -> int32 narrows the format (a client sending an int64 value is now
-// rejected), which is breaking.
+// BC: a request type widening that co-occurs with a breaking format change is
+// breaking; the safe type axis must not mask the format axis. [integer] ->
+// [integer, string] widens the type (not breaking on its own), but int64 ->
+// int32 narrows the format (a client sending an int64 value is now rejected),
+// which is breaking.
 func TestRequestBodyTypeWidenWithBreakingFormatStillBreaking(t *testing.T) {
 	s1, err := open("../data/type-change/simple-request.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_property_type_changed_test.go
+++ b/checker/check_request_property_type_changed_test.go
@@ -333,3 +333,104 @@ func TestRequestPropertyTypeChangedReadOnlyProperty(t *testing.T) {
 	errs := checker.RequestPropertyTypeChangedCheck(d, osm, &checker.Config{})
 	require.Len(t, errs, 0)
 }
+
+// setRequestBodyType sets the request body schema type on the /test POST.
+func setRequestBodyType(t *testing.T, s *load.SpecInfo, types *openapi3.Types) {
+	t.Helper()
+	s.Spec.Paths.Value("/test").Post.RequestBody.Value.Content["application/json"].Schema.Value.Type = types
+}
+
+// BC: widening a request type set ([string] -> [string, integer]) is backward
+// compatible (the server accepts every type it did before plus more) and must
+// NOT be reported as a breaking request-body-type-changed. Mirror of the
+// response narrowing case.
+func TestRequestBodyTypeWideningMultiTypeNotBreaking(t *testing.T) {
+	s1, err := open("../data/type-change/simple-request.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/type-change/simple-request.yaml")
+	require.NoError(t, err)
+	setRequestBodyType(t, s1, &openapi3.Types{"string"})
+	setRequestBodyType(t, s2, &openapi3.Types{"string", "integer"})
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyTypeChangedCheck), d, osm, checker.INFO)
+	require.False(t, containsId(errs, checker.RequestBodyTypeChangedId),
+		"widening a request type set is non-breaking; must not report request-body-type-changed")
+}
+
+// BC: removing the type entirely from a request ([string] -> no type) is a
+// generalization (the server now accepts any value), so it is backward compatible.
+func TestRequestBodyTypeRemovedNotBreaking(t *testing.T) {
+	s1, err := open("../data/type-change/simple-request.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/type-change/simple-request.yaml")
+	require.NoError(t, err)
+	setRequestBodyType(t, s1, &openapi3.Types{"string"})
+	setRequestBodyType(t, s2, nil)
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyTypeChangedCheck), d, osm, checker.INFO)
+	require.False(t, containsId(errs, checker.RequestBodyTypeChangedId),
+		"removing the type from a request accepts any value; non-breaking")
+}
+
+// BC (guard): narrowing a request type set ([string, integer] -> [string]) IS
+// breaking under a strongly-typed media type; a client sending integer is now
+// rejected.
+func TestRequestBodyTypeNarrowingStillBreaking(t *testing.T) {
+	s1, err := open("../data/type-change/simple-request.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/type-change/simple-request.yaml")
+	require.NoError(t, err)
+	setRequestBodyType(t, s1, &openapi3.Types{"string", "integer"})
+	setRequestBodyType(t, s2, &openapi3.Types{"string"})
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyTypeChangedCheck), d, osm, checker.ERR)
+	require.True(t, containsId(errs, checker.RequestBodyTypeChangedId),
+		"narrowing a request type set is breaking")
+}
+
+// BC (guard): adding a type constraint to a previously untyped request
+// (no type -> [string]) restricts the accepted values, so it is breaking.
+func TestRequestBodyTypeAddedFromUntypedStillBreaking(t *testing.T) {
+	s1, err := open("../data/type-change/simple-request.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/type-change/simple-request.yaml")
+	require.NoError(t, err)
+	setRequestBodyType(t, s1, nil)
+	setRequestBodyType(t, s2, &openapi3.Types{"string"})
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyTypeChangedCheck), d, osm, checker.ERR)
+	require.True(t, containsId(errs, checker.RequestBodyTypeChangedId),
+		"constraining a previously untyped request is breaking")
+}
+
+// BC (guard): a request type widening that co-occurs with a breaking format
+// change must still be reported; the safe type axis must not mask the format
+// axis. [integer] -> [integer, string] widens the type (backward compatible),
+// but int64 -> int32 narrows the format (a client sending an int64 value is now
+// rejected), which is breaking.
+func TestRequestBodyTypeWidenWithBreakingFormatStillBreaking(t *testing.T) {
+	s1, err := open("../data/type-change/simple-request.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/type-change/simple-request.yaml")
+	require.NoError(t, err)
+	base := s1.Spec.Paths.Value("/test").Post.RequestBody.Value.Content["application/json"].Schema.Value
+	base.Type = &openapi3.Types{"integer"}
+	base.Format = "int64"
+	rev := s2.Spec.Paths.Value("/test").Post.RequestBody.Value.Content["application/json"].Schema.Value
+	rev.Type = &openapi3.Types{"integer", "string"}
+	rev.Format = "int32"
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyTypeChangedCheck), d, osm, checker.ERR)
+	require.True(t, containsId(errs, checker.RequestBodyTypeChangedId),
+		"a type widening must not mask a co-occurring breaking format change (int64 -> int32)")
+}

--- a/checker/check_response_property_type_changed_test.go
+++ b/checker/check_response_property_type_changed_test.go
@@ -196,9 +196,9 @@ func setResponseBodyType(t *testing.T, s *load.SpecInfo, types *openapi3.Types) 
 	s.Spec.Paths.Value("/test").Get.Responses.Value("200").Value.Content["application/json"].Schema.Value.Type = types
 }
 
-// BC: narrowing a response type set ([string, integer] -> [string]) is backward
-// compatible (the server returns fewer kinds of values) and must NOT be reported
-// as a breaking response-body-type-changed. (#1003 / #989 Gap 2)
+// BC: narrowing a response type set ([string, integer] -> [string]) is not
+// breaking; the server returns fewer kinds of values, all of which the client
+// already handled. (#1003 / #989 Gap 2)
 func TestResponseBodyTypeNarrowingMultiTypeNotBreaking(t *testing.T) {
 	s1, err := open("../data/type-change/simple-response.yaml")
 	require.NoError(t, err)
@@ -214,8 +214,8 @@ func TestResponseBodyTypeNarrowingMultiTypeNotBreaking(t *testing.T) {
 		"narrowing a response type set is non-breaking; must not report response-body-type-changed")
 }
 
-// BC: adding a type constraint to a previously untyped response (no type -> [string])
-// narrows what the server returns, so it is backward compatible.
+// BC: narrowing a previously untyped response to a concrete type (no type ->
+// [string]) is not breaking; the server returns fewer kinds of values.
 func TestResponseBodyTypeAddedFromUntypedNotBreaking(t *testing.T) {
 	s1, err := open("../data/type-change/simple-response.yaml")
 	require.NoError(t, err)
@@ -231,7 +231,7 @@ func TestResponseBodyTypeAddedFromUntypedNotBreaking(t *testing.T) {
 		"narrowing an untyped response to a concrete type is non-breaking")
 }
 
-// BC (guard): widening a response type set ([string] -> [string, integer]) IS breaking;
+// BC: widening a response type set ([string] -> [string, integer]) is breaking;
 // the server may now return a type the client did not handle.
 func TestResponseBodyTypeWideningStillBreaking(t *testing.T) {
 	s1, err := open("../data/type-change/simple-response.yaml")
@@ -248,7 +248,7 @@ func TestResponseBodyTypeWideningStillBreaking(t *testing.T) {
 		"widening a response type set is breaking")
 }
 
-// BC (guard): removing the type entirely from a response ([string] -> no type) IS
+// BC: removing the type entirely from a response ([string] -> no type) is
 // breaking; the server may now return any value.
 func TestResponseBodyTypeRemovedStillBreaking(t *testing.T) {
 	s1, err := open("../data/type-change/simple-response.yaml")
@@ -265,11 +265,11 @@ func TestResponseBodyTypeRemovedStillBreaking(t *testing.T) {
 		"removing the type from a response is breaking")
 }
 
-// BC (guard): a response type narrowing that co-occurs with a breaking format
-// change must still be reported; the safe type axis must not mask the format
-// axis. [string, integer] -> [integer] narrows the type (backward compatible),
-// but int32 -> int64 widens the format (the server may now return values outside
-// the range a client expecting int32 can hold), which is breaking.
+// BC: a response type narrowing that co-occurs with a breaking format change is
+// breaking; the safe type axis must not mask the format axis. [string, integer]
+// -> [integer] narrows the type (not breaking on its own), but int32 -> int64
+// widens the format (the server may now return values outside the range a client
+// expecting int32 can hold), which is breaking.
 func TestResponseBodyTypeNarrowWithBreakingFormatStillBreaking(t *testing.T) {
 	s1, err := open("../data/type-change/simple-response.yaml")
 	require.NoError(t, err)

--- a/checker/check_response_property_type_changed_test.go
+++ b/checker/check_response_property_type_changed_test.go
@@ -189,3 +189,102 @@ func TestResponseEmbeddedAdditionalPropertyTypeChangedCheck(t *testing.T) {
 		OperationId: "get_value",
 	}, errs[0])
 }
+
+// setResponseBodyType sets the 200 response body schema type on the /test GET.
+func setResponseBodyType(t *testing.T, s *load.SpecInfo, types *openapi3.Types) {
+	t.Helper()
+	s.Spec.Paths.Value("/test").Get.Responses.Value("200").Value.Content["application/json"].Schema.Value.Type = types
+}
+
+// BC: narrowing a response type set ([string, integer] -> [string]) is backward
+// compatible (the server returns fewer kinds of values) and must NOT be reported
+// as a breaking response-body-type-changed. (#1003 / #989 Gap 2)
+func TestResponseBodyTypeNarrowingMultiTypeNotBreaking(t *testing.T) {
+	s1, err := open("../data/type-change/simple-response.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/type-change/simple-response.yaml")
+	require.NoError(t, err)
+	setResponseBodyType(t, s1, &openapi3.Types{"string", "integer"})
+	setResponseBodyType(t, s2, &openapi3.Types{"string"})
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyTypeChangedCheck), d, osm, checker.INFO)
+	require.False(t, containsId(errs, checker.ResponseBodyTypeChangedId),
+		"narrowing a response type set is non-breaking; must not report response-body-type-changed")
+}
+
+// BC: adding a type constraint to a previously untyped response (no type -> [string])
+// narrows what the server returns, so it is backward compatible.
+func TestResponseBodyTypeAddedFromUntypedNotBreaking(t *testing.T) {
+	s1, err := open("../data/type-change/simple-response.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/type-change/simple-response.yaml")
+	require.NoError(t, err)
+	setResponseBodyType(t, s1, nil)
+	setResponseBodyType(t, s2, &openapi3.Types{"string"})
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyTypeChangedCheck), d, osm, checker.INFO)
+	require.False(t, containsId(errs, checker.ResponseBodyTypeChangedId),
+		"narrowing an untyped response to a concrete type is non-breaking")
+}
+
+// BC (guard): widening a response type set ([string] -> [string, integer]) IS breaking;
+// the server may now return a type the client did not handle.
+func TestResponseBodyTypeWideningStillBreaking(t *testing.T) {
+	s1, err := open("../data/type-change/simple-response.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/type-change/simple-response.yaml")
+	require.NoError(t, err)
+	setResponseBodyType(t, s1, &openapi3.Types{"string"})
+	setResponseBodyType(t, s2, &openapi3.Types{"string", "integer"})
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyTypeChangedCheck), d, osm, checker.ERR)
+	require.True(t, containsId(errs, checker.ResponseBodyTypeChangedId),
+		"widening a response type set is breaking")
+}
+
+// BC (guard): removing the type entirely from a response ([string] -> no type) IS
+// breaking; the server may now return any value.
+func TestResponseBodyTypeRemovedStillBreaking(t *testing.T) {
+	s1, err := open("../data/type-change/simple-response.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/type-change/simple-response.yaml")
+	require.NoError(t, err)
+	setResponseBodyType(t, s1, &openapi3.Types{"string"})
+	setResponseBodyType(t, s2, nil)
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyTypeChangedCheck), d, osm, checker.ERR)
+	require.True(t, containsId(errs, checker.ResponseBodyTypeChangedId),
+		"removing the type from a response is breaking")
+}
+
+// BC (guard): a response type narrowing that co-occurs with a breaking format
+// change must still be reported; the safe type axis must not mask the format
+// axis. [string, integer] -> [integer] narrows the type (backward compatible),
+// but int32 -> int64 widens the format (the server may now return values outside
+// the range a client expecting int32 can hold), which is breaking.
+func TestResponseBodyTypeNarrowWithBreakingFormatStillBreaking(t *testing.T) {
+	s1, err := open("../data/type-change/simple-response.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/type-change/simple-response.yaml")
+	require.NoError(t, err)
+	base := s1.Spec.Paths.Value("/test").Get.Responses.Value("200").Value.Content["application/json"].Schema.Value
+	base.Type = &openapi3.Types{"string", "integer"}
+	base.Format = "int32"
+	rev := s2.Spec.Paths.Value("/test").Get.Responses.Value("200").Value.Content["application/json"].Schema.Value
+	rev.Type = &openapi3.Types{"integer"}
+	rev.Format = "int64"
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyTypeChangedCheck), d, osm, checker.ERR)
+	require.True(t, containsId(errs, checker.ResponseBodyTypeChangedId),
+		"a type narrowing must not mask a co-occurring breaking format change (int32 -> int64)")
+}

--- a/checker/check_types.go
+++ b/checker/check_types.go
@@ -55,12 +55,16 @@ func isResponseTypeNarrowing(typeDiff *diff.StringsDiff, schemaDiff *diff.Schema
 	return typeDiff != nil && isTypeSetSubset(getRevisionType(schemaDiff), getBaseType(schemaDiff))
 }
 
-// isTypeSetSubset reports whether both sets are non-empty and every type in sub is
-// covered by some type in super (using the integer-within-number lattice). An
-// empty set means no type constraint (any value); that universe case is handled
-// by the empty-target-type short-circuit in typeFormatBreaking, not here.
+// isTypeSetSubset reports whether sub is non-empty and every type in it is
+// covered by some type in super (using the integer-within-number lattice).
+//
+// An empty sub is treated as not-a-subset rather than the vacuous "empty set is
+// a subset of anything": that keeps the empty-source cases (a type removed from
+// a response, or a constraint added to a previously untyped request) on the
+// breaking path. The empty-target case (no type constraint = any value) is
+// handled by the empty-target-type short-circuit in typeFormatBreaking, not here.
 func isTypeSetSubset(sub, super []string) bool {
-	if len(sub) == 0 || len(super) == 0 {
+	if len(sub) == 0 {
 		return false
 	}
 	for _, t := range sub {

--- a/checker/check_types.go
+++ b/checker/check_types.go
@@ -11,7 +11,17 @@ import (
 // requestTypeFormatBreaking reports whether a request type/format change is
 // breaking. Requests are contravariant, so the change is evaluated toward the
 // revision type.
+//
+// A type-set widening (the revision accepts every type the base did, plus
+// possibly more) is backward compatible on the type axis, but the diff-based
+// core only sees the added/removed types and would still flag a multi-type
+// widening. We detect it from the full type sets and drop the type axis; the
+// format axis is evaluated independently, so a co-occurring breaking format
+// change is still reported.
 func requestTypeFormatBreaking(typeDiff *diff.StringsDiff, formatDiff *diff.ValueDiff, mediaType string, schemaDiff *diff.SchemaDiff) bool {
+	if isRequestTypeWidening(typeDiff, schemaDiff) {
+		typeDiff = nil
+	}
 	return typeFormatBreaking(typeDiff, formatDiff, isStronglyTyped(mediaType), schemaDiff.Revision.Type)
 }
 
@@ -20,12 +30,9 @@ func requestTypeFormatBreaking(typeDiff *diff.StringsDiff, formatDiff *diff.Valu
 // base/revision direction reversed: the diffs are reversed and the change is
 // evaluated toward the base type.
 //
-// A type-set narrowing (the revision type set is contained in the base set) is
-// backward compatible on the type axis, but the diff-based core only sees the
-// added/removed types and would still flag a multi-type narrowing. We detect the
-// narrowing from the full type sets and drop the type axis; the format axis is
-// evaluated independently, so a co-occurring breaking format change is still
-// reported.
+// The mirror of the request widening case: a type-set narrowing (the revision
+// returns only types the base could) is backward compatible on the type axis,
+// and is detected and dropped the same way.
 func responseTypeFormatBreaking(typeDiff *diff.StringsDiff, formatDiff *diff.ValueDiff, mediaType string, schemaDiff *diff.SchemaDiff) bool {
 	if isResponseTypeNarrowing(typeDiff, schemaDiff) {
 		typeDiff = nil
@@ -33,29 +40,31 @@ func responseTypeFormatBreaking(typeDiff *diff.StringsDiff, formatDiff *diff.Val
 	return typeFormatBreaking(typeDiff.Reverse(), formatDiff.Reverse(), isStronglyTyped(mediaType), schemaDiff.Base.Type)
 }
 
-// isResponseTypeNarrowing reports whether a response type change is a narrowing:
-// the revision type set is contained in the base type set, so the server returns
-// a subset of the value kinds it returned before. That is backward compatible for
-// a response (a client prepared for the wider set still handles the narrower one).
-//
-// It requires an actual type change (typeDiff != nil). A revision that dropped
-// the type entirely (untyped) is the opposite, the server may now return
-// anything, so it is not a narrowing. A previously untyped base narrowed to a
-// concrete type is a narrowing.
+// isRequestTypeWidening reports whether a request type change widens the accepted
+// type set: the base set is contained in the revision set, so the server accepts
+// every type it did before plus possibly more. Backward compatible for a request.
+func isRequestTypeWidening(typeDiff *diff.StringsDiff, schemaDiff *diff.SchemaDiff) bool {
+	return typeDiff != nil && isTypeSetSubset(getBaseType(schemaDiff), getRevisionType(schemaDiff))
+}
+
+// isResponseTypeNarrowing reports whether a response type change narrows the
+// returned type set: the revision set is contained in the base set, so the server
+// returns only types it could before. Backward compatible for a response. Mirror
+// of isRequestTypeWidening.
 func isResponseTypeNarrowing(typeDiff *diff.StringsDiff, schemaDiff *diff.SchemaDiff) bool {
-	if typeDiff == nil {
+	return typeDiff != nil && isTypeSetSubset(getRevisionType(schemaDiff), getBaseType(schemaDiff))
+}
+
+// isTypeSetSubset reports whether both sets are non-empty and every type in sub is
+// covered by some type in super (using the integer-within-number lattice). An
+// empty set means no type constraint (any value); that universe case is handled
+// by the empty-target-type short-circuit in typeFormatBreaking, not here.
+func isTypeSetSubset(sub, super []string) bool {
+	if len(sub) == 0 || len(super) == 0 {
 		return false
 	}
-	base := getBaseType(schemaDiff)
-	revision := getRevisionType(schemaDiff)
-	if len(revision) == 0 {
-		return false
-	}
-	if len(base) == 0 {
-		return true
-	}
-	for _, t := range revision {
-		if !typeCoveredBy(t, base) {
+	for _, t := range sub {
+		if !typeCoveredBy(t, super) {
 			return false
 		}
 	}

--- a/checker/check_types.go
+++ b/checker/check_types.go
@@ -1,6 +1,7 @@
 package checker
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
@@ -18,8 +19,61 @@ func requestTypeFormatBreaking(typeDiff *diff.StringsDiff, formatDiff *diff.Valu
 // breaking. Responses are covariant, so it is the same check with the
 // base/revision direction reversed: the diffs are reversed and the change is
 // evaluated toward the base type.
+//
+// A type-set narrowing (the revision type set is contained in the base set) is
+// backward compatible on the type axis, but the diff-based core only sees the
+// added/removed types and would still flag a multi-type narrowing. We detect the
+// narrowing from the full type sets and drop the type axis; the format axis is
+// evaluated independently, so a co-occurring breaking format change is still
+// reported.
 func responseTypeFormatBreaking(typeDiff *diff.StringsDiff, formatDiff *diff.ValueDiff, mediaType string, schemaDiff *diff.SchemaDiff) bool {
+	if isResponseTypeNarrowing(typeDiff, schemaDiff) {
+		typeDiff = nil
+	}
 	return typeFormatBreaking(typeDiff.Reverse(), formatDiff.Reverse(), isStronglyTyped(mediaType), schemaDiff.Base.Type)
+}
+
+// isResponseTypeNarrowing reports whether a response type change is a narrowing:
+// the revision type set is contained in the base type set, so the server returns
+// a subset of the value kinds it returned before. That is backward compatible for
+// a response (a client prepared for the wider set still handles the narrower one).
+//
+// It requires an actual type change (typeDiff != nil). A revision that dropped
+// the type entirely (untyped) is the opposite, the server may now return
+// anything, so it is not a narrowing. A previously untyped base narrowed to a
+// concrete type is a narrowing.
+func isResponseTypeNarrowing(typeDiff *diff.StringsDiff, schemaDiff *diff.SchemaDiff) bool {
+	if typeDiff == nil {
+		return false
+	}
+	base := getBaseType(schemaDiff)
+	revision := getRevisionType(schemaDiff)
+	if len(revision) == 0 {
+		return false
+	}
+	if len(base) == 0 {
+		return true
+	}
+	for _, t := range revision {
+		if !typeCoveredBy(t, base) {
+			return false
+		}
+	}
+	return true
+}
+
+// isSubtype reports whether every value of type sub is also a valid value of
+// type super: the same type, or "integer" within "number" (every integer is a
+// number). This is the single source of the type-compatibility lattice, shared
+// by isTypeContained (diff-shaped) and typeCoveredBy (set-membership).
+func isSubtype(sub, super string) bool {
+	return sub == super || (sub == "integer" && super == "number")
+}
+
+// typeCoveredBy reports whether type t is covered by one of the base types (t is
+// a subtype of some base type).
+func typeCoveredBy(t string, base []string) bool {
+	return slices.ContainsFunc(base, func(b string) bool { return isSubtype(t, b) })
 }
 
 // typeFormatBreaking reports whether a type/format change toward toType is
@@ -54,7 +108,10 @@ note that we don't support multiple types currenty
 */
 func isTypeContained(to, from []string, stronglyTyped bool) bool {
 
-	if len(to) == 1 && to[0] == "number" && len(from) == 1 && from[0] == "integer" {
+	// from (the old type) is a subtype of to (the new type): the new type still
+	// accepts every value the old one did. Added and Deleted are disjoint, so
+	// to[0] == from[0] cannot occur here, leaving the integer-within-number case.
+	if len(to) == 1 && len(from) == 1 && isSubtype(from[0], to[0]) {
 		return true
 	}
 


### PR DESCRIPTION
Fixes #1003 (the false positive in #989 Gap 2). Rebased on top of #1018.

## Problem

A type-set change in the safe direction is backward compatible but was reported as breaking:

- **Response narrowing** (covariant): the server returns a subset of the value kinds it returned before, so a client prepared for the wider set still handles it. Example reported as ERR on `main`: `type: [string, integer]` -> `type: [string]`, or `[string, integer]` -> `[integer]` under JSON.
- **Request widening** (contravariant): the server accepts every type it did before plus more, so an existing client still works. Example reported as ERR on `main`: `type: [string]` -> `type: [string, integer]`.

Both can fail a CI gate on a non-breaking change.

## Root cause

The breaking check reasons over the added/deleted **type diff**. A multi-type subset change such as `[string, integer]` -> `[string]` produces `deleted: [integer]`, `added: []`; the unchanged `string` is not in the diff, so the containment check cannot tell it is a subset relation and treats it as incompatible. The same blind spot exists in both directions.

## Fix

Work from the full type sets rather than the diff:

- `isRequestTypeWidening`: the base type set is contained in the revision set (request accepts a superset).
- `isResponseTypeNarrowing`: the revision type set is contained in the base set (response returns a subset).

When the change is in the safe direction, `requestTypeFormatBreaking` / `responseTypeFormatBreaking` drop the type axis. Because #1018 made the type and format axes independent, the format axis is still evaluated, so a co-occurring breaking format change is still reported (for example a request widening that also narrows `int64` -> `int32`, or a response narrowing that also widens `int32` -> `int64`).

The two predicates are mirror images and share one `isTypeSetSubset` helper (request checks base subset of revision, response checks revision subset of base). The "no type constraint = any value" cases are left to the existing empty-target-type short-circuit in `typeFormatBreaking`, so the predicates only handle the finite both-non-empty case. The `integer`-within-`number` relation is factored into a single `isSubtype` predicate shared by `isTypeContained` (diff-shaped) and `typeCoveredBy` (set-membership). No new rule IDs, no localization changes.

Still correctly reported as breaking (covered by guard tests, both directions):
- response widening / request narrowing
- removing the type entirely from a response, and constraining a previously untyped request
- a safe-direction type change that co-occurs with a breaking format change

## Tests

Replicate-first tests on both sides: the safe-direction cases (fail without the fix, pass here) and the widening / narrowing / removal / breaking-format guards. Each suppression was verified to be load-bearing (the safe-direction test fails when it is removed). Full suite green.

## Follow-up

The broader suggestion in #989 (dedicated `*-type-generalized` / `-specialized` INFO/ERR rules, and the request-parameter-property consistency in Gap 1) introduces new **public rule IDs**, an output-contract change, so it is left as a separate, deliberate change. This PR closes the user-facing false positives without changing any existing IDs.
