### PR TITLE
refactor(checker): unify and decouple the type/format breaking check

### DIFF
--- a/checker/check_not_breaking_test.go
+++ b/checker/check_not_breaking_test.go
@@ -166,19 +166,27 @@ func TestBreaking_NewRequiredResponseHeader(t *testing.T) {
 // BC: changing operation ID is not breaking
 func TestBreaking_OperationID(t *testing.T) {
 	r := d(t, diff.NewConfig(), 3, 1)
-	require.Len(t, r, 3)
+	require.Len(t, r, 4)
 	require.Equal(t, checker.RequestParameterMaxLengthDecreasedId, r[0].GetId())
 	require.Equal(t, checker.RequestParameterPatternAddedId, r[1].GetId())
-	require.Equal(t, checker.RequestParameterEnumValueRemovedId, r[2].GetId())
+	// the image query parameter gains a "general string" format; adding a format
+	// constraint to a request is breaking and was previously masked because the
+	// type also changed (the type/format check now evaluates the axes independently)
+	require.Equal(t, checker.RequestParameterTypeChangedId, r[2].GetId())
+	require.Equal(t, checker.RequestParameterEnumValueRemovedId, r[3].GetId())
 }
 
 // BC: changing a link to operation ID is not breaking
 func TestBreaking_LinkOperationID(t *testing.T) {
 	r := d(t, diff.NewConfig(), 3, 1)
-	require.Len(t, r, 3)
+	require.Len(t, r, 4)
 	require.Equal(t, checker.RequestParameterMaxLengthDecreasedId, r[0].GetId())
 	require.Equal(t, checker.RequestParameterPatternAddedId, r[1].GetId())
-	require.Equal(t, checker.RequestParameterEnumValueRemovedId, r[2].GetId())
+	// the image query parameter gains a "general string" format; adding a format
+	// constraint to a request is breaking and was previously masked because the
+	// type also changed (the type/format check now evaluates the axes independently)
+	require.Equal(t, checker.RequestParameterTypeChangedId, r[2].GetId())
+	require.Equal(t, checker.RequestParameterEnumValueRemovedId, r[3].GetId())
 }
 
 // BC: adding a media-type to response is not breaking

--- a/checker/check_not_breaking_test.go
+++ b/checker/check_not_breaking_test.go
@@ -163,30 +163,31 @@ func TestBreaking_NewRequiredResponseHeader(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: changing operation ID is not breaking
+// BC: changing an operation's operationId is not breaking
 func TestBreaking_OperationID(t *testing.T) {
-	r := d(t, diff.NewConfig(), 3, 1)
-	require.Len(t, r, 4)
-	require.Equal(t, checker.RequestParameterMaxLengthDecreasedId, r[0].GetId())
-	require.Equal(t, checker.RequestParameterPatternAddedId, r[1].GetId())
-	// the image query parameter gains a "general string" format; adding a format
-	// constraint to a request is breaking and was previously masked because the
-	// type also changed (the type/format check now evaluates the axes independently)
-	require.Equal(t, checker.RequestParameterTypeChangedId, r[2].GetId())
-	require.Equal(t, checker.RequestParameterEnumValueRemovedId, r[3].GetId())
+	s1 := l(t, 1)
+	s2 := l(t, 1)
+
+	s2.Spec.Paths.Value(securityScorePath).Get.OperationID = "GetSecurityScoresRenamed"
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibility(allChecksConfig(), d, osm)
+	require.Empty(t, errs)
 }
 
-// BC: changing a link to operation ID is not breaking
+// BC: changing a link's operationId is not breaking
 func TestBreaking_LinkOperationID(t *testing.T) {
-	r := d(t, diff.NewConfig(), 3, 1)
-	require.Len(t, r, 4)
-	require.Equal(t, checker.RequestParameterMaxLengthDecreasedId, r[0].GetId())
-	require.Equal(t, checker.RequestParameterPatternAddedId, r[1].GetId())
-	// the image query parameter gains a "general string" format; adding a format
-	// constraint to a request is breaking and was previously masked because the
-	// type also changed (the type/format check now evaluates the axes independently)
-	require.Equal(t, checker.RequestParameterTypeChangedId, r[2].GetId())
-	require.Equal(t, checker.RequestParameterEnumValueRemovedId, r[3].GetId())
+	s1 := l(t, 1)
+	s2 := l(t, 1)
+
+	link := s2.Spec.Paths.Value("/subscribe").Post.Callbacks["myEvent"].Value.Map()["hi"].Post.Responses.Value("200").Value.Links["test"].Value
+	link.OperationID = "GetSecurityScoresRenamed"
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibility(allChecksConfig(), d, osm)
+	require.Empty(t, errs)
 }
 
 // BC: adding a media-type to response is not breaking

--- a/checker/check_request_parameters_type_changed.go
+++ b/checker/check_request_parameters_type_changed.go
@@ -78,7 +78,7 @@ func RequestParameterTypeChangedCheck(diffReport *diff.Diff, operationsSources *
 
 						id := RequestParameterTypeGeneralizedId
 
-						if breakingTypeFormatChangedInRequest(typeDiff, formatDiff, false, schemaDiff) &&
+						if typeOrFormatBreaking(typeDiff, formatDiff, false, schemaDiff) &&
 							!isParameterScalarToFormExplodeArray(paramDiff, typeDiff) {
 							id = RequestParameterTypeChangedId
 						}

--- a/checker/check_request_parameters_type_changed.go
+++ b/checker/check_request_parameters_type_changed.go
@@ -78,6 +78,11 @@ func RequestParameterTypeChangedCheck(diffReport *diff.Diff, operationsSources *
 
 						id := RequestParameterTypeGeneralizedId
 
+						// The parameter's own value is serialized as a string on the wire
+						// (query/path/header/cookie), so it is non-strongly-typed: a binary
+						// generalized/changed verdict with stronglyTyped=false. This differs
+						// on purpose from the property-level check below, which cannot tell
+						// how an object parameter is serialized and therefore forks three ways.
 						if typeOrFormatBreaking(typeDiff, formatDiff, false, schemaDiff) &&
 							!isParameterScalarToFormExplodeArray(paramDiff, typeDiff) {
 							id = RequestParameterTypeChangedId

--- a/checker/check_request_parameters_type_changed.go
+++ b/checker/check_request_parameters_type_changed.go
@@ -83,7 +83,7 @@ func RequestParameterTypeChangedCheck(diffReport *diff.Diff, operationsSources *
 						// generalized/changed verdict with stronglyTyped=false. This differs
 						// on purpose from the property-level check below, which cannot tell
 						// how an object parameter is serialized and therefore forks three ways.
-						if typeOrFormatBreaking(typeDiff, formatDiff, false, schemaDiff) &&
+						if typeOrFormatBreaking(typeDiff, formatDiff, false, schemaDiff.Revision.Type) &&
 							!isParameterScalarToFormExplodeArray(paramDiff, typeDiff) {
 							id = RequestParameterTypeChangedId
 						}

--- a/checker/check_request_property_type_changed.go
+++ b/checker/check_request_property_type_changed.go
@@ -21,8 +21,7 @@ func RequestPropertyTypeChangedCheck(diffReport *diff.Diff, operationsSources *d
 
 		if !typeDiff.Empty() || !formatDiff.Empty() {
 			// Body-level suppression also skips the property walk for this
-			// media type (the pre-migration code used a `continue` in the
-			// media-type for-loop, which had that effect). Preserved.
+			// media type.
 			if shouldSuppressTypeChangedForListOfTypes(schemaDiff) {
 				return
 			}

--- a/checker/check_request_property_type_changed.go
+++ b/checker/check_request_property_type_changed.go
@@ -32,7 +32,7 @@ func RequestPropertyTypeChangedCheck(diffReport *diff.Diff, operationsSources *d
 			}
 
 			id := RequestBodyTypeGeneralizedId
-			if !isRequestTypeGeneralization(typeDiff, schemaDiff) && breakingTypeFormatChangedInRequestProperty(typeDiff, formatDiff, info.mediaType, schemaDiff) {
+			if requestTypeFormatBreaking(typeDiff, formatDiff, info.mediaType, schemaDiff) {
 				id = RequestBodyTypeChangedId
 			}
 			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, schemaDiff, "type")
@@ -64,7 +64,7 @@ func RequestPropertyTypeChangedCheck(diffReport *diff.Diff, operationsSources *d
 
 			if !propTypeDiff.Empty() || !propFormatDiff.Empty() {
 				id := RequestPropertyTypeGeneralizedId
-				if !isRequestTypeGeneralization(propTypeDiff, propSchemaDiff) && breakingTypeFormatChangedInRequestProperty(propTypeDiff, propFormatDiff, info.mediaType, propSchemaDiff) {
+				if requestTypeFormatBreaking(propTypeDiff, propFormatDiff, info.mediaType, propSchemaDiff) {
 					id = RequestPropertyTypeChangedId
 				}
 

--- a/checker/check_response_property_type_changed.go
+++ b/checker/check_response_property_type_changed.go
@@ -16,8 +16,7 @@ func ResponsePropertyTypeChangedCheck(diffReport *diff.Diff, operationsSources *
 		schemaDiff := info.schemaDiff
 
 		// Body-level suppression also skips the property walk for this
-		// media type (the pre-migration code used `continue` in the
-		// media-type for-loop, which had that effect). Preserved.
+		// media type.
 		if shouldSuppressTypeChangedForListOfTypes(schemaDiff) {
 			return
 		}

--- a/checker/check_response_property_type_changed.go
+++ b/checker/check_response_property_type_changed.go
@@ -30,7 +30,7 @@ func ResponsePropertyTypeChangedCheck(diffReport *diff.Diff, operationsSources *
 			return
 		}
 
-		if breakingTypeFormatChangedInResponseProperty(typeDiff, formatDiff, info.mediaType, schemaDiff) {
+		if responseTypeFormatBreaking(typeDiff, formatDiff, info.mediaType, schemaDiff) {
 			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, schemaDiff, "type")
 			result = append(result, info.newChange(
 				ResponseBodyTypeChangedId,
@@ -55,7 +55,7 @@ func ResponsePropertyTypeChangedCheck(diffReport *diff.Diff, operationsSources *
 			propTypeDiff := propSchemaDiff.TypeDiff
 			propFormatDiff := propSchemaDiff.FormatDiff
 
-			if breakingTypeFormatChangedInResponseProperty(propTypeDiff, propFormatDiff, info.mediaType, propSchemaDiff) {
+			if responseTypeFormatBreaking(propTypeDiff, propFormatDiff, info.mediaType, propSchemaDiff) {
 				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "type")
 				result = append(result, p.newChange(
 					ResponsePropertyTypeChangedId,

--- a/checker/check_types.go
+++ b/checker/check_types.go
@@ -81,6 +81,15 @@ The "params" object has two properties: "id" and "color", both with type "string
 Imagine that the OpenAPI type of property "id" was changed from "number" to "string".
 In the first example, the change is non-breaking, because the PHP format for numbers and strings is the same: we refer to this as non-strongly-typed.
 But in the second example, the change is breaking, because the JSON format requires quotes for strings: we refer to this as strongly-typed.
+
+This is intentionally the only request type location that forks three ways
+(generalized / specialized / changed-as-a-warning). The other request type
+locations resolve strong-vs-non-strong definitively (the body and body
+properties from a known media type; a scalar parameter is always a string on
+the wire), so a binary generalized/changed verdict is correct there. Only an
+object parameter's serialization is unknown here, so when the two verdicts
+disagree we can't be sure it's breaking and report a warning. Do not unify this
+with the binary paths; see oasdiff/oasdiff#989.
 */
 func checkRequestParameterPropertyTypeChanged(typeDiff *diff.StringsDiff, formatDiff *diff.ValueDiff, schemaDiff *diff.SchemaDiff) (string, string) {
 

--- a/checker/check_types.go
+++ b/checker/check_types.go
@@ -8,56 +8,43 @@ import (
 )
 
 // requestTypeFormatBreaking reports whether a request type/format change is
-// breaking. Removing the type constraint entirely is a non-breaking
-// generalization (the server then accepts any value); otherwise defer to the
-// direction-agnostic core.
+// breaking. Requests are contravariant, so the change is evaluated toward the
+// revision type.
 func requestTypeFormatBreaking(typeDiff *diff.StringsDiff, formatDiff *diff.ValueDiff, mediaType string, schemaDiff *diff.SchemaDiff) bool {
-	if isTypeConstraintRemoved(typeDiff, schemaDiff) {
-		return false
-	}
-	return typeOrFormatBreaking(typeDiff, formatDiff, isStronglyTyped(mediaType), schemaDiff)
+	return typeFormatBreaking(typeDiff, formatDiff, isStronglyTyped(mediaType), schemaDiff.Revision.Type)
 }
 
 // responseTypeFormatBreaking reports whether a response type/format change is
-// breaking. Responses are covariant, so it is the same core check with the
-// base/revision direction reversed. Adding a type constraint where there was
-// none narrows what the server returns, so it is a non-breaking specialization
-// (the mirror of removing the constraint on the request side).
+// breaking. Responses are covariant, so it is the same check with the
+// base/revision direction reversed: the diffs are reversed and the change is
+// evaluated toward the base type.
 func responseTypeFormatBreaking(typeDiff *diff.StringsDiff, formatDiff *diff.ValueDiff, mediaType string, schemaDiff *diff.SchemaDiff) bool {
-	if isTypeConstraintAdded(typeDiff, schemaDiff) {
-		return false
-	}
-	return typeOrFormatBreaking(typeDiff.Reverse(), formatDiff.Reverse(), isStronglyTyped(mediaType), schemaDiff)
+	return typeFormatBreaking(typeDiff.Reverse(), formatDiff.Reverse(), isStronglyTyped(mediaType), schemaDiff.Base.Type)
 }
 
-// isTypeConstraintRemoved reports whether the type changed and the revision has
-// no type, i.e. the type constraint was removed entirely.
-func isTypeConstraintRemoved(typeDiff *diff.StringsDiff, schemaDiff *diff.SchemaDiff) bool {
-	if typeDiff == nil {
+// typeFormatBreaking reports whether a type/format change toward toType is
+// breaking. An empty toType means the type constraint is gone: removing it on
+// the request side (the server then accepts any value), or, in the reversed
+// response frame, adding one (the server then returns a subset). Both are
+// non-breaking generalizations. Otherwise the two axes are evaluated by the
+// direction-agnostic core.
+func typeFormatBreaking(typeDiff *diff.StringsDiff, formatDiff *diff.ValueDiff, stronglyTyped bool, toType *openapi3.Types) bool {
+	if typeDiff != nil && len(toType.Slice()) == 0 {
 		return false
 	}
-	rev := schemaDiff.Revision.Type
-	return rev == nil || len(*rev) == 0
-}
-
-// isTypeConstraintAdded reports whether the type changed and the base had no
-// type, i.e. a type constraint was added where there was none.
-func isTypeConstraintAdded(typeDiff *diff.StringsDiff, schemaDiff *diff.SchemaDiff) bool {
-	if typeDiff == nil {
-		return false
-	}
-	base := schemaDiff.Base.Type
-	return base == nil || len(*base) == 0
+	return typeOrFormatBreaking(typeDiff, formatDiff, stronglyTyped, toType)
 }
 
 // typeOrFormatBreaking reports whether a type change or a format change is
-// breaking. The two axes are evaluated independently: the change is breaking if
-// either the type or the format is breaking on its own.
+// breaking, evaluating the two axes independently toward toType: the change is
+// breaking if either the type or the format is breaking on its own. It does not
+// treat a removed type constraint specially; callers that need that go through
+// typeFormatBreaking.
 // stronglyTyped reflects the media type (see isStronglyTyped); callers that
 // can't resolve it (request parameters) pass it explicitly.
-func typeOrFormatBreaking(typeDiff *diff.StringsDiff, formatDiff *diff.ValueDiff, stronglyTyped bool, schemaDiff *diff.SchemaDiff) bool {
+func typeOrFormatBreaking(typeDiff *diff.StringsDiff, formatDiff *diff.ValueDiff, stronglyTyped bool, toType *openapi3.Types) bool {
 	typeBreaking := typeDiff != nil && !isTypeContained(typeDiff.Added, typeDiff.Deleted, stronglyTyped)
-	formatBreaking := formatDiff != nil && !isFormatContained(schemaDiff.Revision.Type, formatDiff.To, formatDiff.From)
+	formatBreaking := formatDiff != nil && !isFormatContained(toType, formatDiff.To, formatDiff.From)
 	return typeBreaking || formatBreaking
 }
 
@@ -102,8 +89,8 @@ disagree we can't be sure it's breaking and report a warning.
 func checkRequestParameterPropertyTypeChanged(typeDiff *diff.StringsDiff, formatDiff *diff.ValueDiff, schemaDiff *diff.SchemaDiff) (string, string) {
 
 	// since we don't know if the object is strogly-typed or not, we check both
-	stronglyTyped := typeOrFormatBreaking(typeDiff, formatDiff, true, schemaDiff)
-	nonStronglyTyped := typeOrFormatBreaking(typeDiff, formatDiff, false, schemaDiff)
+	stronglyTyped := typeOrFormatBreaking(typeDiff, formatDiff, true, schemaDiff.Revision.Type)
+	nonStronglyTyped := typeOrFormatBreaking(typeDiff, formatDiff, false, schemaDiff.Revision.Type)
 
 	// if strongly-typed and non-strongly-typed don't agree, it's a warning since we can't be sure that it's breaking
 	if stronglyTyped != nonStronglyTyped {

--- a/checker/check_types.go
+++ b/checker/check_types.go
@@ -20,8 +20,13 @@ func requestTypeFormatBreaking(typeDiff *diff.StringsDiff, formatDiff *diff.Valu
 
 // responseTypeFormatBreaking reports whether a response type/format change is
 // breaking. Responses are covariant, so it is the same core check with the
-// base/revision direction reversed.
+// base/revision direction reversed. Adding a type constraint where there was
+// none narrows what the server returns, so it is a non-breaking specialization
+// (the mirror of removing the constraint on the request side).
 func responseTypeFormatBreaking(typeDiff *diff.StringsDiff, formatDiff *diff.ValueDiff, mediaType string, schemaDiff *diff.SchemaDiff) bool {
+	if isTypeConstraintAdded(typeDiff, schemaDiff) {
+		return false
+	}
 	return typeOrFormatBreaking(typeDiff.Reverse(), formatDiff.Reverse(), isStronglyTyped(mediaType), schemaDiff)
 }
 
@@ -33,6 +38,16 @@ func isTypeConstraintRemoved(typeDiff *diff.StringsDiff, schemaDiff *diff.Schema
 	}
 	rev := schemaDiff.Revision.Type
 	return rev == nil || len(*rev) == 0
+}
+
+// isTypeConstraintAdded reports whether the type changed and the base had no
+// type, i.e. a type constraint was added where there was none.
+func isTypeConstraintAdded(typeDiff *diff.StringsDiff, schemaDiff *diff.SchemaDiff) bool {
+	if typeDiff == nil {
+		return false
+	}
+	base := schemaDiff.Base.Type
+	return base == nil || len(*base) == 0
 }
 
 // typeOrFormatBreaking reports whether a type change or a format change is

--- a/checker/check_types.go
+++ b/checker/check_types.go
@@ -12,7 +12,7 @@ import (
 // generalization (the server then accepts any value); otherwise defer to the
 // direction-agnostic core.
 func requestTypeFormatBreaking(typeDiff *diff.StringsDiff, formatDiff *diff.ValueDiff, mediaType string, schemaDiff *diff.SchemaDiff) bool {
-	if isRequestTypeGeneralization(typeDiff, schemaDiff) {
+	if isTypeConstraintRemoved(typeDiff, schemaDiff) {
 		return false
 	}
 	return typeOrFormatBreaking(typeDiff, formatDiff, isStronglyTyped(mediaType), schemaDiff)
@@ -31,8 +31,9 @@ func responseTypeFormatBreaking(typeDiff *diff.StringsDiff, formatDiff *diff.Val
 	return typeOrFormatBreaking(typeDiff, formatDiff, isStronglyTyped(mediaType), schemaDiff)
 }
 
-// isRequestTypeGeneralization checks if a type diff represents a complete removal of the type constraint
-func isRequestTypeGeneralization(typeDiff *diff.StringsDiff, schemaDiff *diff.SchemaDiff) bool {
+// isTypeConstraintRemoved reports whether the type changed and the revision has
+// no type, i.e. the type constraint was removed entirely.
+func isTypeConstraintRemoved(typeDiff *diff.StringsDiff, schemaDiff *diff.SchemaDiff) bool {
 	if typeDiff == nil {
 		return false
 	}

--- a/checker/check_types.go
+++ b/checker/check_types.go
@@ -22,21 +22,25 @@ func requestTypeFormatBreaking(typeDiff *diff.StringsDiff, formatDiff *diff.Valu
 // breaking. Responses are covariant, so it is the same core check with the
 // base/revision direction reversed.
 func responseTypeFormatBreaking(typeDiff *diff.StringsDiff, formatDiff *diff.ValueDiff, mediaType string, schemaDiff *diff.SchemaDiff) bool {
-	typeDiff, formatDiff = reversed(typeDiff, formatDiff)
-	return typeOrFormatBreaking(typeDiff, formatDiff, isStronglyTyped(mediaType), schemaDiff)
+	return typeOrFormatBreaking(reverseStringsDiff(typeDiff), reverseValueDiff(formatDiff), isStronglyTyped(mediaType), schemaDiff)
 }
 
-// reversed swaps the base/revision direction of the type and format diffs
-// (Added<->Deleted, From<->To). A nil diff has no direction to reverse and is
-// returned unchanged.
-func reversed(typeDiff *diff.StringsDiff, formatDiff *diff.ValueDiff) (*diff.StringsDiff, *diff.ValueDiff) {
-	if typeDiff != nil {
-		typeDiff = &diff.StringsDiff{Added: typeDiff.Deleted, Deleted: typeDiff.Added}
+// reverseStringsDiff swaps the base/revision direction of a strings diff
+// (Added<->Deleted). A nil diff has no direction to reverse and is returned nil.
+func reverseStringsDiff(d *diff.StringsDiff) *diff.StringsDiff {
+	if d == nil {
+		return nil
 	}
-	if formatDiff != nil {
-		formatDiff = &diff.ValueDiff{From: formatDiff.To, To: formatDiff.From}
+	return &diff.StringsDiff{Added: d.Deleted, Deleted: d.Added}
+}
+
+// reverseValueDiff swaps the base/revision direction of a value diff
+// (From<->To). A nil diff has no direction to reverse and is returned nil.
+func reverseValueDiff(d *diff.ValueDiff) *diff.ValueDiff {
+	if d == nil {
+		return nil
 	}
-	return typeDiff, formatDiff
+	return &diff.ValueDiff{From: d.To, To: d.From}
 }
 
 // isTypeConstraintRemoved reports whether the type changed and the revision has

--- a/checker/check_types.go
+++ b/checker/check_types.go
@@ -41,9 +41,8 @@ func isRequestTypeGeneralization(typeDiff *diff.StringsDiff, schemaDiff *diff.Sc
 }
 
 // typeOrFormatBreaking reports whether a type change or a format change is
-// breaking, with the two axes evaluated independently and combined. A breaking
-// format change is reported even when the type also changed (previously the type
-// took precedence and a co-occurring breaking format change was dropped).
+// breaking. The two axes are evaluated independently: the change is breaking if
+// either the type or the format is breaking on its own.
 // stronglyTyped reflects the media type (see isStronglyTyped); callers that
 // can't resolve it (request parameters) pass it explicitly.
 func typeOrFormatBreaking(typeDiff *diff.StringsDiff, formatDiff *diff.ValueDiff, stronglyTyped bool, schemaDiff *diff.SchemaDiff) bool {
@@ -82,14 +81,13 @@ Imagine that the OpenAPI type of property "id" was changed from "number" to "str
 In the first example, the change is non-breaking, because the PHP format for numbers and strings is the same: we refer to this as non-strongly-typed.
 But in the second example, the change is breaking, because the JSON format requires quotes for strings: we refer to this as strongly-typed.
 
-This is intentionally the only request type location that forks three ways
+This is the only request type location that forks three ways
 (generalized / specialized / changed-as-a-warning). The other request type
 locations resolve strong-vs-non-strong definitively (the body and body
 properties from a known media type; a scalar parameter is always a string on
 the wire), so a binary generalized/changed verdict is correct there. Only an
 object parameter's serialization is unknown here, so when the two verdicts
-disagree we can't be sure it's breaking and report a warning. Do not unify this
-with the binary paths; see oasdiff/oasdiff#989.
+disagree we can't be sure it's breaking and report a warning.
 */
 func checkRequestParameterPropertyTypeChanged(typeDiff *diff.StringsDiff, formatDiff *diff.ValueDiff, schemaDiff *diff.SchemaDiff) (string, string) {
 
@@ -130,7 +128,7 @@ func isFormatContained(revisionType *openapi3.Types, to, from any) bool {
 
 	// Removing a format constraint is a generalization (non-breaking), whatever
 	// the type, including when the type was removed too (revisionType is nil).
-	// Hoisted above the type switch so it isn't skipped by the nil/multi guard.
+	// Checked before the type switch so it applies for any revision type.
 	if to == "" {
 		return true
 	}

--- a/checker/check_types.go
+++ b/checker/check_types.go
@@ -22,25 +22,7 @@ func requestTypeFormatBreaking(typeDiff *diff.StringsDiff, formatDiff *diff.Valu
 // breaking. Responses are covariant, so it is the same core check with the
 // base/revision direction reversed.
 func responseTypeFormatBreaking(typeDiff *diff.StringsDiff, formatDiff *diff.ValueDiff, mediaType string, schemaDiff *diff.SchemaDiff) bool {
-	return typeOrFormatBreaking(reverseStringsDiff(typeDiff), reverseValueDiff(formatDiff), isStronglyTyped(mediaType), schemaDiff)
-}
-
-// reverseStringsDiff swaps the base/revision direction of a strings diff
-// (Added<->Deleted). A nil diff has no direction to reverse and is returned nil.
-func reverseStringsDiff(d *diff.StringsDiff) *diff.StringsDiff {
-	if d == nil {
-		return nil
-	}
-	return &diff.StringsDiff{Added: d.Deleted, Deleted: d.Added}
-}
-
-// reverseValueDiff swaps the base/revision direction of a value diff
-// (From<->To). A nil diff has no direction to reverse and is returned nil.
-func reverseValueDiff(d *diff.ValueDiff) *diff.ValueDiff {
-	if d == nil {
-		return nil
-	}
-	return &diff.ValueDiff{From: d.To, To: d.From}
+	return typeOrFormatBreaking(typeDiff.Reverse(), formatDiff.Reverse(), isStronglyTyped(mediaType), schemaDiff)
 }
 
 // isTypeConstraintRemoved reports whether the type changed and the revision has

--- a/checker/check_types.go
+++ b/checker/check_types.go
@@ -7,29 +7,28 @@ import (
 	"github.com/oasdiff/oasdiff/diff"
 )
 
-// breakingTypeFormatChangedInResponseProperty checks if the type or format of a response property was changed in a breaking way
-func breakingTypeFormatChangedInResponseProperty(typeDiff *diff.StringsDiff, formatDiff *diff.ValueDiff, mediaType string, schemaDiff *diff.SchemaDiff) bool {
-
-	if typeDiff != nil {
-		typeDiff = &diff.StringsDiff{
-			Added:   typeDiff.Deleted,
-			Deleted: typeDiff.Added,
-		}
+// requestTypeFormatBreaking reports whether a request type/format change is
+// breaking. Removing the type constraint entirely is a non-breaking
+// generalization (the server then accepts any value); otherwise defer to the
+// direction-agnostic core.
+func requestTypeFormatBreaking(typeDiff *diff.StringsDiff, formatDiff *diff.ValueDiff, mediaType string, schemaDiff *diff.SchemaDiff) bool {
+	if isRequestTypeGeneralization(typeDiff, schemaDiff) {
+		return false
 	}
-
-	if formatDiff != nil {
-		formatDiff = &diff.ValueDiff{
-			From: formatDiff.To,
-			To:   formatDiff.From,
-		}
-	}
-
-	return breakingTypeFormatChangedInRequestProperty(typeDiff, formatDiff, mediaType, schemaDiff)
+	return typeOrFormatBreaking(typeDiff, formatDiff, isStronglyTyped(mediaType), schemaDiff)
 }
 
-// breakingTypeFormatChangedInRequestProperty checks if the type or format of a request property was changed in a breaking way
-func breakingTypeFormatChangedInRequestProperty(typeDiff *diff.StringsDiff, formatDiff *diff.ValueDiff, mediaType string, schemaDiff *diff.SchemaDiff) bool {
-	return breakingTypeFormatChangedInRequest(typeDiff, formatDiff, isStronglyTyped(mediaType), schemaDiff)
+// responseTypeFormatBreaking reports whether a response type/format change is
+// breaking. Responses are covariant, so it is the same core check with the
+// base/revision direction reversed (Added<->Deleted, From<->To).
+func responseTypeFormatBreaking(typeDiff *diff.StringsDiff, formatDiff *diff.ValueDiff, mediaType string, schemaDiff *diff.SchemaDiff) bool {
+	if typeDiff != nil {
+		typeDiff = &diff.StringsDiff{Added: typeDiff.Deleted, Deleted: typeDiff.Added}
+	}
+	if formatDiff != nil {
+		formatDiff = &diff.ValueDiff{From: formatDiff.To, To: formatDiff.From}
+	}
+	return typeOrFormatBreaking(typeDiff, formatDiff, isStronglyTyped(mediaType), schemaDiff)
 }
 
 // isRequestTypeGeneralization checks if a type diff represents a complete removal of the type constraint
@@ -41,18 +40,16 @@ func isRequestTypeGeneralization(typeDiff *diff.StringsDiff, schemaDiff *diff.Sc
 	return rev == nil || len(*rev) == 0
 }
 
-// breakingTypeFormatChangedInRequest checks if the type or format of a request was changed in a breaking way
-func breakingTypeFormatChangedInRequest(typeDiff *diff.StringsDiff, formatDiff *diff.ValueDiff, stronglyTyped bool, schemaDiff *diff.SchemaDiff) bool {
-
-	if typeDiff != nil {
-		return !isTypeContained(typeDiff.Added, typeDiff.Deleted, stronglyTyped)
-	}
-
-	if formatDiff != nil {
-		return !isFormatContained(schemaDiff.Revision.Type, formatDiff.To, formatDiff.From)
-	}
-
-	return false
+// typeOrFormatBreaking reports whether a type change or a format change is
+// breaking, with the two axes evaluated independently and combined. A breaking
+// format change is reported even when the type also changed (previously the type
+// took precedence and a co-occurring breaking format change was dropped).
+// stronglyTyped reflects the media type (see isStronglyTyped); callers that
+// can't resolve it (request parameters) pass it explicitly.
+func typeOrFormatBreaking(typeDiff *diff.StringsDiff, formatDiff *diff.ValueDiff, stronglyTyped bool, schemaDiff *diff.SchemaDiff) bool {
+	typeBreaking := typeDiff != nil && !isTypeContained(typeDiff.Added, typeDiff.Deleted, stronglyTyped)
+	formatBreaking := formatDiff != nil && !isFormatContained(schemaDiff.Revision.Type, formatDiff.To, formatDiff.From)
+	return typeBreaking || formatBreaking
 }
 
 /*
@@ -88,8 +85,8 @@ But in the second example, the change is breaking, because the JSON format requi
 func checkRequestParameterPropertyTypeChanged(typeDiff *diff.StringsDiff, formatDiff *diff.ValueDiff, schemaDiff *diff.SchemaDiff) (string, string) {
 
 	// since we don't know if the object is strogly-typed or not, we check both
-	stronglyTyped := breakingTypeFormatChangedInRequest(typeDiff, formatDiff, true, schemaDiff)
-	nonStronglyTyped := breakingTypeFormatChangedInRequest(typeDiff, formatDiff, false, schemaDiff)
+	stronglyTyped := typeOrFormatBreaking(typeDiff, formatDiff, true, schemaDiff)
+	nonStronglyTyped := typeOrFormatBreaking(typeDiff, formatDiff, false, schemaDiff)
 
 	// if strongly-typed and non-strongly-typed don't agree, it's a warning since we can't be sure that it's breaking
 	if stronglyTyped != nonStronglyTyped {
@@ -122,6 +119,13 @@ func isJsonMediaType(mediaType string) bool {
 // isFormatContained checks if from is contained in to
 func isFormatContained(revisionType *openapi3.Types, to, from any) bool {
 
+	// Removing a format constraint is a generalization (non-breaking), whatever
+	// the type, including when the type was removed too (revisionType is nil).
+	// Hoisted above the type switch so it isn't skipped by the nil/multi guard.
+	if to == "" {
+		return true
+	}
+
 	if revisionType == nil || len(*revisionType) > 1 {
 		return false
 	}
@@ -129,16 +133,13 @@ func isFormatContained(revisionType *openapi3.Types, to, from any) bool {
 	// we don't support multiple types currenty, so just take the first one
 	switch getSingleType(revisionType) {
 	case "number":
-		return to == "" ||
-			(to == "double" && from == "float")
+		return to == "double" && from == "float"
 	case "integer":
-		return to == "" ||
-			(to == "int64" && from == "int32") ||
+		return (to == "int64" && from == "int32") ||
 			(to == "bigint" && from == "int32") ||
 			(to == "bigint" && from == "int64")
 	case "string":
-		return to == "" || // removing a format constraint is a generalization
-			(to == "date-time" && from == "date") ||
+		return (to == "date-time" && from == "date") ||
 			(to == "date-time" && from == "time")
 	}
 

--- a/checker/check_types.go
+++ b/checker/check_types.go
@@ -20,15 +20,23 @@ func requestTypeFormatBreaking(typeDiff *diff.StringsDiff, formatDiff *diff.Valu
 
 // responseTypeFormatBreaking reports whether a response type/format change is
 // breaking. Responses are covariant, so it is the same core check with the
-// base/revision direction reversed (Added<->Deleted, From<->To).
+// base/revision direction reversed.
 func responseTypeFormatBreaking(typeDiff *diff.StringsDiff, formatDiff *diff.ValueDiff, mediaType string, schemaDiff *diff.SchemaDiff) bool {
+	typeDiff, formatDiff = reversed(typeDiff, formatDiff)
+	return typeOrFormatBreaking(typeDiff, formatDiff, isStronglyTyped(mediaType), schemaDiff)
+}
+
+// reversed swaps the base/revision direction of the type and format diffs
+// (Added<->Deleted, From<->To). A nil diff has no direction to reverse and is
+// returned unchanged.
+func reversed(typeDiff *diff.StringsDiff, formatDiff *diff.ValueDiff) (*diff.StringsDiff, *diff.ValueDiff) {
 	if typeDiff != nil {
 		typeDiff = &diff.StringsDiff{Added: typeDiff.Deleted, Deleted: typeDiff.Added}
 	}
 	if formatDiff != nil {
 		formatDiff = &diff.ValueDiff{From: formatDiff.To, To: formatDiff.From}
 	}
-	return typeOrFormatBreaking(typeDiff, formatDiff, isStronglyTyped(mediaType), schemaDiff)
+	return typeDiff, formatDiff
 }
 
 // isTypeConstraintRemoved reports whether the type changed and the revision has

--- a/checker/check_types_test.go
+++ b/checker/check_types_test.go
@@ -135,20 +135,21 @@ func TestFormatAdded(t *testing.T) {
 
 // The type axis and the format axis are breaking independently: a breaking
 // format change makes the overall change breaking even when the type change on
-// its own is not. Here the type change (integer -> number) is a non-breaking
-// generalization, but adding a format constraint (none -> float) restricts the
-// accepted values and is breaking, so the overall change is breaking.
+// its own is not. Here the parameter type changes integer -> string, which is
+// not breaking on its own (the value is a string on the wire either way), but
+// the added date-time format rejects values that were previously accepted (e.g.
+// "123"), so the overall change is breaking.
 func TestBreakingFormatNotMaskedByTypeChange(t *testing.T) {
 	typeDiff := &diff.StringsDiff{
 		Deleted: []string{"integer"},
-		Added:   []string{"number"},
+		Added:   []string{"string"},
 	}
 	formatDiff := &diff.ValueDiff{
 		From: nil,
-		To:   "float",
+		To:   "date-time",
 	}
 	revisionType := &openapi3.Types{
-		"number",
+		"string",
 	}
 	breaking(t, typeDiff, formatDiff, false, revisionType)
 }

--- a/checker/check_types_test.go
+++ b/checker/check_types_test.go
@@ -136,15 +136,15 @@ func TestFormatAdded(t *testing.T) {
 // The type axis and the format axis are breaking independently: a breaking
 // format change makes the overall change breaking even when the type change on
 // its own is not. Here the type change (integer -> number) is a non-breaking
-// generalization, but the format narrows (double -> float), so the overall
-// change is breaking.
+// generalization, but adding a format constraint (none -> float) restricts the
+// accepted values and is breaking, so the overall change is breaking.
 func TestBreakingFormatNotMaskedByTypeChange(t *testing.T) {
 	typeDiff := &diff.StringsDiff{
 		Deleted: []string{"integer"},
 		Added:   []string{"number"},
 	}
 	formatDiff := &diff.ValueDiff{
-		From: "double",
+		From: nil,
 		To:   "float",
 	}
 	revisionType := &openapi3.Types{

--- a/checker/check_types_test.go
+++ b/checker/check_types_test.go
@@ -133,12 +133,11 @@ func TestFormatAdded(t *testing.T) {
 	breaking(t, typeDiff, formatDiff, false, revisionType)
 }
 
-// The type axis and the format axis are evaluated independently and combined
-// (#1018). A breaking format change is reported even when the type also changed.
-// Here the type change (integer -> number) is a non-breaking generalization, but
-// the format narrows (double -> float), so the overall change is breaking. Before
-// #1018 the type took precedence and the co-occurring breaking format change was
-// dropped, so this case was incorrectly reported as non-breaking.
+// The type axis and the format axis are breaking independently: a breaking
+// format change makes the overall change breaking even when the type change on
+// its own is not. Here the type change (integer -> number) is a non-breaking
+// generalization, but the format narrows (double -> float), so the overall
+// change is breaking.
 func TestBreakingFormatNotMaskedByTypeChange(t *testing.T) {
 	typeDiff := &diff.StringsDiff{
 		Deleted: []string{"integer"},
@@ -154,11 +153,10 @@ func TestBreakingFormatNotMaskedByTypeChange(t *testing.T) {
 	breaking(t, typeDiff, formatDiff, false, revisionType)
 }
 
-// Removing a format constraint is a non-breaking generalization even when the
-// type also changes (#1018). The format-removal rule is hoisted above the
-// per-type switch in isFormatContained, so it applies regardless of the revision
-// type. Here the type generalizes (integer -> number) and the format is removed
-// (int64 -> ""), so the overall change is non-breaking.
+// Removing a format constraint is a non-breaking generalization for any revision
+// type, and it stays non-breaking when the type also changes. Here the type
+// generalizes (integer -> number) and the format is removed (int64 -> ""), so
+// the overall change is non-breaking.
 func TestFormatRemovedWithTypeChangeNotBreaking(t *testing.T) {
 	typeDiff := &diff.StringsDiff{
 		Deleted: []string{"integer"},

--- a/checker/check_types_test.go
+++ b/checker/check_types_test.go
@@ -173,6 +173,38 @@ func TestFormatRemovedWithTypeChangeNotBreaking(t *testing.T) {
 	notBreaking(t, typeDiff, formatDiff, false, revisionType)
 }
 
+// Removing the type constraint from a request body is a non-breaking
+// generalization: the server then accepts any value. This holds even for a
+// strongly-typed (JSON) media type, where isTypeContained alone would not grant
+// it.
+func TestRequestTypeConstraintRemovedNotBreaking(t *testing.T) {
+	typeDiff := &diff.StringsDiff{
+		Deleted: []string{"object"},
+	}
+	schemaDiff := &diff.SchemaDiff{
+		Base:     &openapi3.Schema{Type: &openapi3.Types{"object"}},
+		Revision: &openapi3.Schema{},
+		TypeDiff: typeDiff,
+	}
+	require.False(t, requestTypeFormatBreaking(typeDiff, nil, "application/json", schemaDiff))
+}
+
+// Adding a type constraint to a response body where there was none is a
+// non-breaking specialization: the server then returns a subset of what it
+// could before. This is the covariant mirror of removing the constraint on the
+// request side, and likewise holds for a strongly-typed (JSON) media type.
+func TestResponseTypeConstraintAddedNotBreaking(t *testing.T) {
+	typeDiff := &diff.StringsDiff{
+		Added: []string{"object"},
+	}
+	schemaDiff := &diff.SchemaDiff{
+		Base:     &openapi3.Schema{},
+		Revision: &openapi3.Schema{Type: &openapi3.Types{"object"}},
+		TypeDiff: typeDiff,
+	}
+	require.False(t, responseTypeFormatBreaking(typeDiff, nil, "application/json", schemaDiff))
+}
+
 func TestIsJsonMediaType(t *testing.T) {
 	require.True(t, isJsonMediaType("application/json"))
 	require.True(t, isJsonMediaType("application/problem+json"))

--- a/checker/check_types_test.go
+++ b/checker/check_types_test.go
@@ -133,6 +133,47 @@ func TestFormatAdded(t *testing.T) {
 	breaking(t, typeDiff, formatDiff, false, revisionType)
 }
 
+// The type axis and the format axis are evaluated independently and combined
+// (#1018). A breaking format change is reported even when the type also changed.
+// Here the type change (integer -> number) is a non-breaking generalization, but
+// the format narrows (double -> float), so the overall change is breaking. Before
+// #1018 the type took precedence and the co-occurring breaking format change was
+// dropped, so this case was incorrectly reported as non-breaking.
+func TestBreakingFormatNotMaskedByTypeChange(t *testing.T) {
+	typeDiff := &diff.StringsDiff{
+		Deleted: []string{"integer"},
+		Added:   []string{"number"},
+	}
+	formatDiff := &diff.ValueDiff{
+		From: "double",
+		To:   "float",
+	}
+	revisionType := &openapi3.Types{
+		"number",
+	}
+	breaking(t, typeDiff, formatDiff, false, revisionType)
+}
+
+// Removing a format constraint is a non-breaking generalization even when the
+// type also changes (#1018). The format-removal rule is hoisted above the
+// per-type switch in isFormatContained, so it applies regardless of the revision
+// type. Here the type generalizes (integer -> number) and the format is removed
+// (int64 -> ""), so the overall change is non-breaking.
+func TestFormatRemovedWithTypeChangeNotBreaking(t *testing.T) {
+	typeDiff := &diff.StringsDiff{
+		Deleted: []string{"integer"},
+		Added:   []string{"number"},
+	}
+	formatDiff := &diff.ValueDiff{
+		From: "int64",
+		To:   "",
+	}
+	revisionType := &openapi3.Types{
+		"number",
+	}
+	notBreaking(t, typeDiff, formatDiff, false, revisionType)
+}
+
 func TestIsJsonMediaType(t *testing.T) {
 	require.True(t, isJsonMediaType("application/json"))
 	require.True(t, isJsonMediaType("application/problem+json"))

--- a/checker/check_types_test.go
+++ b/checker/check_types_test.go
@@ -22,7 +22,7 @@ func breaking(t *testing.T, typeDiff *diff.StringsDiff, formatDiff *diff.ValueDi
 		mediaType = "application/json"
 	}
 
-	require.True(t, breakingTypeFormatChangedInRequestProperty(typeDiff, formatDiff, mediaType, schemaDiff), "breakingTypeFormatChangedInRequestProperty failed")
+	require.True(t, typeOrFormatBreaking(typeDiff, formatDiff, isStronglyTyped(mediaType), schemaDiff), "typeOrFormatBreaking failed")
 }
 
 func notBreaking(t *testing.T, typeDiff *diff.StringsDiff, formatDiff *diff.ValueDiff, isJson bool, revisionTypes *openapi3.Types) {
@@ -37,7 +37,7 @@ func notBreaking(t *testing.T, typeDiff *diff.StringsDiff, formatDiff *diff.Valu
 	if isJson {
 		mediaType = "application/json"
 	}
-	require.False(t, breakingTypeFormatChangedInRequestProperty(typeDiff, formatDiff, mediaType, schemaDiff), "breakingTypeFormatChangedInRequestProperty failed")
+	require.False(t, typeOrFormatBreaking(typeDiff, formatDiff, isStronglyTyped(mediaType), schemaDiff), "typeOrFormatBreaking failed")
 }
 
 func TestStringtoInt(t *testing.T) {

--- a/checker/check_types_test.go
+++ b/checker/check_types_test.go
@@ -11,33 +11,22 @@ import (
 func breaking(t *testing.T, typeDiff *diff.StringsDiff, formatDiff *diff.ValueDiff, isJson bool, revisionTypes *openapi3.Types) {
 	t.Helper()
 
-	schemaDiff := &diff.SchemaDiff{
-		Revision: &openapi3.Schema{
-			Type: revisionTypes,
-		},
-	}
-
 	mediaType := ""
 	if isJson {
 		mediaType = "application/json"
 	}
 
-	require.True(t, typeOrFormatBreaking(typeDiff, formatDiff, isStronglyTyped(mediaType), schemaDiff), "typeOrFormatBreaking failed")
+	require.True(t, typeOrFormatBreaking(typeDiff, formatDiff, isStronglyTyped(mediaType), revisionTypes), "typeOrFormatBreaking failed")
 }
 
 func notBreaking(t *testing.T, typeDiff *diff.StringsDiff, formatDiff *diff.ValueDiff, isJson bool, revisionTypes *openapi3.Types) {
-
-	schemaDiff := &diff.SchemaDiff{
-		Revision: &openapi3.Schema{
-			Type: revisionTypes,
-		},
-	}
+	t.Helper()
 
 	mediaType := ""
 	if isJson {
 		mediaType = "application/json"
 	}
-	require.False(t, typeOrFormatBreaking(typeDiff, formatDiff, isStronglyTyped(mediaType), schemaDiff), "typeOrFormatBreaking failed")
+	require.False(t, typeOrFormatBreaking(typeDiff, formatDiff, isStronglyTyped(mediaType), revisionTypes), "typeOrFormatBreaking failed")
 }
 
 func TestStringtoInt(t *testing.T) {

--- a/diff/string_list_diff.go
+++ b/diff/string_list_diff.go
@@ -25,6 +25,19 @@ func (stringsDiff *StringsDiff) Empty() bool {
 		len(stringsDiff.Deleted) == 0
 }
 
+// Reverse returns the diff with base and revision swapped (Added<->Deleted).
+// A nil diff has no direction to reverse and is returned nil.
+func (stringsDiff *StringsDiff) Reverse() *StringsDiff {
+	if stringsDiff == nil {
+		return nil
+	}
+
+	return &StringsDiff{
+		Added:   stringsDiff.Deleted,
+		Deleted: stringsDiff.Added,
+	}
+}
+
 func getStringsDiff(strings1, strings2 []string) *StringsDiff {
 	diff := getStringsDiffInternal(strings1, strings2)
 

--- a/diff/string_list_diff_test.go
+++ b/diff/string_list_diff_test.go
@@ -1,0 +1,25 @@
+package diff_test
+
+import (
+	"testing"
+
+	"github.com/oasdiff/oasdiff/diff"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringsDiff_Reverse(t *testing.T) {
+	d := &diff.StringsDiff{
+		Added:   []string{"a"},
+		Deleted: []string{"b", "c"},
+	}
+
+	require.Equal(t, &diff.StringsDiff{
+		Added:   []string{"b", "c"},
+		Deleted: []string{"a"},
+	}, d.Reverse())
+}
+
+func TestStringsDiff_ReverseNil(t *testing.T) {
+	var d *diff.StringsDiff
+	require.Nil(t, d.Reverse())
+}

--- a/diff/value_diff.go
+++ b/diff/value_diff.go
@@ -15,6 +15,19 @@ func (diff *ValueDiff) Empty() bool {
 	return diff == nil
 }
 
+// Reverse returns the diff with base and revision swapped (From<->To).
+// A nil diff has no direction to reverse and is returned nil.
+func (diff *ValueDiff) Reverse() *ValueDiff {
+	if diff == nil {
+		return nil
+	}
+
+	return &ValueDiff{
+		From: diff.To,
+		To:   diff.From,
+	}
+}
+
 func getValueDiff(value1, value2 any) *ValueDiff {
 
 	diff := getValueDiffInternal(value1, value2)

--- a/diff/value_diff_test.go
+++ b/diff/value_diff_test.go
@@ -1,0 +1,25 @@
+package diff_test
+
+import (
+	"testing"
+
+	"github.com/oasdiff/oasdiff/diff"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValueDiff_Reverse(t *testing.T) {
+	d := &diff.ValueDiff{
+		From: "a",
+		To:   "b",
+	}
+
+	require.Equal(t, &diff.ValueDiff{
+		From: "b",
+		To:   "a",
+	}, d.Reverse())
+}
+
+func TestValueDiff_ReverseNil(t *testing.T) {
+	var d *diff.ValueDiff
+	require.Nil(t, d.Reverse())
+}


### PR DESCRIPTION
Refactor of the `breakingTypeFormatChangedInResponseProperty -> ...InRequestProperty -> ...InRequest` chain into a flatter, symmetric shape, plus two correctness fixes the flattening exposes.

## Structure

The four-function wrapper chain becomes a small set of single-purpose functions:

- `typeOrFormatBreaking(typeDiff, formatDiff, stronglyTyped, toType)`: the two-axis core. It evaluates the type axis and the format axis independently and reports breaking if either is. It takes the target type directly rather than the whole schema diff, so it has no built-in direction. The request parameter checkers call this directly with an explicit `stronglyTyped` (they try both `true` and `false` to resolve the PHP-vs-JSON object serialization ambiguity).
- `typeFormatBreaking(typeDiff, formatDiff, stronglyTyped, toType)`: adds the generalization short-circuit on top of the core. An empty target type means the type constraint is gone, a non-breaking generalization, after which it defers to the core.
- `requestTypeFormatBreaking(..., mediaType, schemaDiff)`: contravariant entry, evaluates toward the revision type.
- `responseTypeFormatBreaking(..., mediaType, schemaDiff)`: covariant entry, reverses the diffs and evaluates toward the base type.

Direction reversal is now a nil-safe `Reverse()` method on `StringsDiff` and `ValueDiff` (alongside the existing `Empty()`), so the covariant path reads as one named operation rather than two inline nil-guarded swaps. Request and response are now exact mirrors: request evaluates toward the revision type, response reverses and evaluates toward the base type.

## Behavior changes (deliberate)

Two, both surfaced by making the paths symmetric:

1. The type and format axes are independent. The core used to be "type wins, format ignored whenever the type also changed". It now reports breaking if either axis breaks, so a breaking format change is no longer masked by a co-occurring type change. The "removing a format is a generalization" rule is also evaluated before the per-type switch in `isFormatContained`, so a format removal is not mis-flagged as breaking when the type was removed too.

2. Adding a type constraint to a response is non-breaking. The request side treats removing the type constraint as a generalization (the server then accepts any value), even for a strongly-typed (JSON) body. The response side had no covariant mirror, so adding a type constraint to a JSON response (base had no type, revision constrains it) was reported breaking even though it narrows what the server returns and is safe for clients. The response path now treats it as a non-breaking specialization, mirroring the request side.

## Tests

- The two operationId tests (`TestBreaking_OperationID`, `TestBreaking_LinkOperationID`) were only coincidentally asserting the full `openapi-test3 -> openapi-test1` fixture diff. They are rewritten to mutate just an operationId (and a link's operationId) on a single spec and assert no breaking change, so they demonstrate what they are named for.
- Dedicated white-box tests cover the decoupling (a breaking format change reported despite a non-breaking type change, and a format removal staying non-breaking across a type change) and the request/response symmetry (constraint removed on a request and constraint added on a response, both non-breaking under JSON).
- Full module suite, `vet`, and `gofmt` are clean. No existing test encoded the old response behavior, so the constraint-added fix is a pure correctness gain.

## Note

This does not include the response type-narrowing fix (#1016), which will rebase on top of this and gets simpler: it can drop its `nil`-typeDiff format-isolation workaround now that the axes are independent.
