### PR TITLE
Suppress duplicate parameter type-changed report for list-of-types transitions

### DIFF
--- a/checker/check_request_parameters_type_changed.go
+++ b/checker/check_request_parameters_type_changed.go
@@ -71,6 +71,11 @@ func RequestParameterTypeChangedCheck(diffReport *diff.Diff, operationsSources *
 
 					if !typeDiff.Empty() || !formatDiff.Empty() {
 
+						// Suppress single<->oneOf/anyOf transitions (handled by the list-of-types checker)
+						if shouldSuppressTypeChangedForListOfTypes(schemaDiff) {
+							continue
+						}
+
 						// Suppress null-only type changes (handled by nullable checkers)
 						if isNullTypeChange(typeDiff) && formatDiff.Empty() {
 							continue
@@ -105,6 +110,11 @@ func RequestParameterTypeChangedCheck(diffReport *diff.Diff, operationsSources *
 							formatDiff := schemaDiff.FormatDiff
 
 							if !typeDiff.Empty() || !formatDiff.Empty() {
+
+								// Suppress single<->oneOf/anyOf transitions (handled by the list-of-types checker)
+								if shouldSuppressPropertyTypeChangedForListOfTypes(schemaDiff) {
+									return
+								}
 
 								// Suppress null-only type changes (handled by nullable checkers)
 								if isNullTypeChange(typeDiff) && formatDiff.Empty() {

--- a/checker/check_request_parameters_type_changed_test.go
+++ b/checker/check_request_parameters_type_changed_test.go
@@ -204,6 +204,36 @@ func TestRequestPathParamTypeIntegerToNumber(t *testing.T) {
 	}, errs[0])
 }
 
+// CL: a query parameter changing from a single type to a oneOf list of types is
+// reported once, by the list-of-types checker. RequestParameterTypeChangedCheck
+// suppresses its own report for the same change so it is not duplicated when both
+// checks run together.
+func TestRequestQueryParamSingleToListOfTypesNotDuplicated(t *testing.T) {
+	s1, err := open("../data/checker/request_parameter_type_changed_base.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/checker/request_parameter_type_changed_base.yaml")
+	require.NoError(t, err)
+
+	queryParam := s2.Spec.Paths.Value("/api/v1.0/groups").Post.Parameters[1].Value
+	queryParam.Schema.Value.Type = nil
+	queryParam.Schema.Value.Format = ""
+	queryParam.Schema.Value.OneOf = openapi3.SchemaRefs{
+		openapi3.NewSchemaRef("", openapi3.NewStringSchema()),
+		openapi3.NewSchemaRef("", openapi3.NewIntegerSchema()),
+	}
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+
+	config := checker.NewConfig(checker.BackwardCompatibilityChecks{
+		checker.RequestParameterTypeChangedCheck,
+		checker.RequestParameterListOfTypesChangedCheck,
+	})
+	errs := checker.CheckBackwardCompatibilityUntilLevel(config, d, osm, checker.INFO)
+	require.Len(t, errs, 1)
+	require.Equal(t, checker.RequestParameterListOfTypesWidenedId, errs[0].GetId())
+}
+
 // BC: changing request's query param property type from number to string is breaking
 func TestBreaking_ReqQueryParamTypeNumberToString(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_property_type_changed_base_num.yaml")


### PR DESCRIPTION
A request parameter changing from a single type to a `oneOf`/`anyOf` list of types (or back) is currently reported twice:

```
request-parameter-list-of-types-widened   (INFO)
request-parameter-type-generalized        (INFO)
```

Both describe the same change. That transition replaces the top-level `type` with `oneOf`/`anyOf`, so it produces a `TypeDiff` alongside the `ListOfTypesDiff`, and two checkers fire for it.

The request-body and response-body type-changed checks already guard against this with `shouldSuppressTypeChangedForListOfTypes` / `shouldSuppressPropertyTypeChangedForListOfTypes`, letting the dedicated list-of-types checker be authoritative. `RequestParameterTypeChangedCheck` was missing that guard, at both the parameter-schema level and the object-parameter-property level. This adds it at both, mirroring the body checks.

Why it was never caught: the existing list-of-types parameter tests run the checker in isolation (`singleCheckConfig`), so the overlap with `RequestParameterTypeChangedCheck` never appeared. The added regression test runs both checks together and asserts a single change; it fails before the fix and passes after.

No other tests changed; the full suite passes.