### PR TITLE
Guard list-of-types suppression when checks run together

### DIFF
--- a/checker/list_of_types_core_test.go
+++ b/checker/list_of_types_core_test.go
@@ -123,64 +123,6 @@ func TestListOfTypesIntegration_EdgeCases(t *testing.T) {
 	require.NotEmpty(t, listOfTypesChanges, "Expected some list-of-types changes in edge cases")
 }
 
-func TestListOfTypesIntegration_SuppressionBehavior(t *testing.T) {
-	// Test that list-of-types checker suppresses oneOf/anyOf changes
-	s1, err := open("../data/list-of-types/single-to-list-base.yaml")
-	require.NoError(t, err)
-
-	s2, err := open("../data/list-of-types/single-to-list-revision.yaml")
-	require.NoError(t, err)
-
-	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
-	require.NoError(t, err)
-
-	// Run with all checkers including oneOf/anyOf checkers
-	allChecksConfig := checker.NewConfig(checker.GetAllChecks())
-	errs := checker.CheckBackwardCompatibilityUntilLevel(allChecksConfig, d, osm, checker.INFO)
-
-	// Count different types of changes
-	var listOfTypesChanges, oneOfAnyOfChanges []checker.ApiChange
-
-	for _, err := range errs {
-		if containsString([]string{
-			checker.RequestPropertyListOfTypesNarrowedId,
-			checker.RequestPropertyListOfTypesWidenedId,
-			checker.ResponsePropertyListOfTypesNarrowedId,
-			checker.ResponsePropertyListOfTypesWidenedId,
-			checker.RequestBodyListOfTypesNarrowedId,
-			checker.RequestBodyListOfTypesWidenedId,
-			checker.ResponseBodyListOfTypesNarrowedId,
-			checker.ResponseBodyListOfTypesWidenedId,
-		}, err.GetId()) {
-			listOfTypesChanges = append(listOfTypesChanges, err.(checker.ApiChange))
-		}
-
-		if containsString([]string{
-			checker.RequestPropertyOneOfAddedId,
-			checker.RequestPropertyOneOfRemovedId,
-			checker.RequestPropertyAnyOfAddedId,
-			checker.RequestPropertyAnyOfRemovedId,
-		}, err.GetId()) {
-			oneOfAnyOfChanges = append(oneOfAnyOfChanges, err.(checker.ApiChange))
-		}
-	}
-
-	// Should have ListOfTypes changes detected
-	require.NotEmpty(t, listOfTypesChanges, "Expected ListOfTypes changes to be detected")
-
-	// OneOf/anyOf changes should be suppressed where ListOfTypes applies
-	// When ListOfTypes changes are detected, the corresponding oneOf/anyOf changes should be suppressed
-	// This is the core behavior we're testing: suppression of redundant change detection
-	if len(listOfTypesChanges) > 0 {
-		// We expect fewer or no oneOf/anyOf changes due to suppression
-		// The exact behavior depends on the implementation, but the important thing is that
-		// both types of changes shouldn't be reported for the same schema modifications
-		t.Logf("ListOfTypes changes found: %d, OneOf/AnyOf changes found: %d",
-			len(listOfTypesChanges), len(oneOfAnyOfChanges))
-		// Note: The specific assertion depends on the suppression logic implementation
-	}
-}
-
 func TestListOfTypesIntegration_ParameterChanges(t *testing.T) {
 	// Create a simple test using existing parameter test data structure
 	s1, err := open("../data/checker/request_parameter_type_changed_base.yaml")

--- a/checker/list_of_types_core_test.go
+++ b/checker/list_of_types_core_test.go
@@ -210,6 +210,62 @@ func TestListOfTypesIntegration_ParameterChanges(t *testing.T) {
 	require.Empty(t, paramChanges, "No parameter changes expected for identical files")
 }
 
+// TestListOfTypes_SuppressionWhenRunWithTypeAndOneOfChecks is a strict
+// regression guard: a single<->oneOf/anyOf transition on a body property must be
+// reported only by the list-of-types checker, even when the type-changed and
+// oneOf/anyOf-updated checkers run alongside it. Those checkers each suppress
+// their own report for this transition; without the suppression the same change
+// is reported two or three times. The other list-of-types tests run a single
+// checker in isolation, so they would not catch the suppression regressing.
+func TestListOfTypes_SuppressionWhenRunWithTypeAndOneOfChecks(t *testing.T) {
+	config := checker.NewConfig(checker.BackwardCompatibilityChecks{
+		checker.RequestPropertyTypeChangedCheck,
+		checker.ResponsePropertyTypeChangedCheck,
+		checker.RequestPropertyOneOfUpdatedCheck,
+		checker.ResponsePropertyOneOfUpdated,
+		checker.RequestPropertyAnyOfUpdatedCheck,
+		checker.ResponsePropertyAnyOfUpdatedCheck,
+		checker.RequestPropertyListOfTypesChangedCheck,
+		checker.ResponsePropertyListOfTypesChangedCheck,
+	})
+
+	for _, tc := range []struct {
+		name       string
+		base, rev  string
+		expectedId string
+	}{
+		{
+			"single-to-list reports only response-property-list-of-types-widened",
+			"../data/list-of-types/single-to-list-base.yaml",
+			"../data/list-of-types/single-to-list-revision.yaml",
+			checker.ResponsePropertyListOfTypesWidenedId,
+		},
+		{
+			"list-to-single reports only request-property-list-of-types-narrowed",
+			"../data/list-of-types/list-to-single-base.yaml",
+			"../data/list-of-types/list-to-single-revision.yaml",
+			checker.RequestPropertyListOfTypesNarrowedId,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s1, err := open(tc.base)
+			require.NoError(t, err)
+			s2, err := open(tc.rev)
+			require.NoError(t, err)
+
+			d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+			require.NoError(t, err)
+
+			errs := checker.CheckBackwardCompatibilityUntilLevel(config, d, osm, checker.INFO)
+			require.NotEmpty(t, errs)
+			for _, e := range errs {
+				require.Equal(t, tc.expectedId, e.GetId(),
+					"only the list-of-types checker should report a single<->list transition; got a duplicate from another checker")
+			}
+		})
+	}
+}
+
 func TestListOfTypesIntegration_CoreFunctionsExecution(t *testing.T) {
 	// Test that covers the core internal functions by creating scenarios that exercise them
 	s1, err := open("../data/list-of-types/list-to-single-base.yaml")


### PR DESCRIPTION
Pure test hardening, no behavior change.

The type-changed and `oneOf`/`anyOf`-updated body/property checkers each suppress their own report for a single<->`oneOf`/`anyOf` transition, so the list-of-types checker is the single authoritative source for that change. That suppression works today, but every existing list-of-types test runs one checker in isolation (`singleCheckConfig`), so a regression that reintroduced a cross-checker duplicate would not be caught.

This adds a strict regression test that runs the type-changed, `oneOf`/`anyOf`-updated, and list-of-types property checkers together over the `single-to-list` and `list-to-single` fixtures and asserts every emitted change is a list-of-types change (no duplicate from another checker leaks through).

Verified the test fails if a suppression guard is removed and passes once restored. Full suite passes.

Companion to #1020, which fixes and guards the same issue on the request-parameter path (that path had an actual duplicate bug; the body/property paths are already correct and this just locks them in).