### PR TITLE
Add authenticated review upload to --open

### DIFF
--- a/internal/breaking_changes.go
+++ b/internal/breaking_changes.go
@@ -21,6 +21,7 @@ func getBreakingChangesCmd() *cobra.Command {
 	addCommonBreakingFlags(&cmd)
 	enumWithOptions(&cmd, newEnumValue(GetBreakingLevels(), ""), "fail-on", "o", "exit with return code 1 when output includes errors with this level or higher")
 	cmd.PersistentFlags().Bool("open", false, "after printing the breaking changes, encrypt the comparison and upload it to oasdiff.com, then open the side-by-side review in a browser")
+	addReviewFlags(&cmd)
 
 	return &cmd
 }

--- a/internal/breaking_changes.go
+++ b/internal/breaking_changes.go
@@ -21,7 +21,6 @@ func getBreakingChangesCmd() *cobra.Command {
 	addCommonBreakingFlags(&cmd)
 	enumWithOptions(&cmd, newEnumValue(GetBreakingLevels(), ""), "fail-on", "o", "exit with return code 1 when output includes errors with this level or higher")
 	cmd.PersistentFlags().Bool("open", false, "after printing the breaking changes, encrypt the comparison and upload it to oasdiff.com, then open the side-by-side review in a browser")
-	addReviewFlags(&cmd)
 
 	return &cmd
 }

--- a/internal/breaking_changes.go
+++ b/internal/breaking_changes.go
@@ -20,7 +20,7 @@ func getBreakingChangesCmd() *cobra.Command {
 	addCommonDiffFlags(&cmd)
 	addCommonBreakingFlags(&cmd)
 	enumWithOptions(&cmd, newEnumValue(GetBreakingLevels(), ""), "fail-on", "o", "exit with return code 1 when output includes errors with this level or higher")
-	cmd.PersistentFlags().Bool("open", false, "after printing the breaking changes, encrypt the comparison and upload it to oasdiff.com, then open the side-by-side review in a browser")
+	addOpenFlags(&cmd, "breaking changes")
 
 	return &cmd
 }

--- a/internal/changelog.go
+++ b/internal/changelog.go
@@ -28,6 +28,7 @@ func getChangelogCmd() *cobra.Command {
 	enumWithOptions(&cmd, newEnumValue(GetSupportedLevels(), ""), "fail-on", "o", "exit with return code 1 when output includes errors with this level or higher")
 	enumWithOptions(&cmd, newEnumValue(GetSupportedLevels(), LevelInfo), "level", "", "output errors with this level or higher")
 	cmd.PersistentFlags().Bool("open", false, "after printing the changelog, encrypt the comparison and upload it to oasdiff.com, then open the side-by-side review in a browser")
+	addReviewFlags(&cmd)
 
 	return &cmd
 }

--- a/internal/changelog.go
+++ b/internal/changelog.go
@@ -27,7 +27,7 @@ func getChangelogCmd() *cobra.Command {
 	addCommonBreakingFlags(&cmd)
 	enumWithOptions(&cmd, newEnumValue(GetSupportedLevels(), ""), "fail-on", "o", "exit with return code 1 when output includes errors with this level or higher")
 	enumWithOptions(&cmd, newEnumValue(GetSupportedLevels(), LevelInfo), "level", "", "output errors with this level or higher")
-	cmd.PersistentFlags().Bool("open", false, "after printing the changelog, encrypt the comparison and upload it to oasdiff.com, then open the side-by-side review in a browser")
+	addOpenFlags(&cmd, "changelog")
 
 	return &cmd
 }

--- a/internal/changelog.go
+++ b/internal/changelog.go
@@ -28,7 +28,6 @@ func getChangelogCmd() *cobra.Command {
 	enumWithOptions(&cmd, newEnumValue(GetSupportedLevels(), ""), "fail-on", "o", "exit with return code 1 when output includes errors with this level or higher")
 	enumWithOptions(&cmd, newEnumValue(GetSupportedLevels(), LevelInfo), "level", "", "output errors with this level or higher")
 	cmd.PersistentFlags().Bool("open", false, "after printing the changelog, encrypt the comparison and upload it to oasdiff.com, then open the side-by-side review in a browser")
-	addReviewFlags(&cmd)
 
 	return &cmd
 }

--- a/internal/cmd_flags.go
+++ b/internal/cmd_flags.go
@@ -86,4 +86,12 @@ func addOpenFlags(cmd *cobra.Command, outputName string) {
 	cmd.PersistentFlags().Bool("open", false, fmt.Sprintf("after printing the %s, encrypt the comparison and upload it to oasdiff.com, then open the side-by-side review in a browser", outputName))
 	cmd.PersistentFlags().String("review-token", "", "with --open, upload an authenticated review using this token instead of the free anonymous one")
 	cmd.PersistentFlags().StringSlice("review-meta", nil, "with --open and --review-token, attach repeatable key=value metadata to the authenticated review (opaque; not interpreted by the CLI)")
+
+	// Hide the review-upload flags from --help: the authenticated review is
+	// assembled by the GitHub Action from its environment, not hand-typed, so
+	// these are an automation interface, not a human one. They still parse and
+	// work; a person sees only --open (the free review). Hidden as a pair because
+	// they're only useful together.
+	hideFlag(cmd, "review-token")
+	hideFlag(cmd, "review-meta")
 }

--- a/internal/cmd_flags.go
+++ b/internal/cmd_flags.go
@@ -69,4 +69,11 @@ func addCommonBreakingFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().String("severity-levels", "", "configuration file for custom severity levels")
 	cmd.PersistentFlags().StringSlice("attributes", nil, "OpenAPI Extensions to include in json or yaml output")
 	cmd.PersistentFlags().String("template", "", "path to custom template file for changelog generation")
+
+	// Review-upload flags. Inert without --open; --review-token's presence is the
+	// only switch between the free anonymous upload and the authenticated one.
+	// Deliberately vocabulary-neutral: a token and an opaque key=value metadata
+	// bag the CLI never interprets. getParseArgs rejects them without --open.
+	cmd.PersistentFlags().String("review-token", "", "with --open, upload an authenticated review using this token instead of the free anonymous one")
+	cmd.PersistentFlags().StringSlice("review-meta", nil, "with --open and --review-token, attach repeatable key=value metadata to the authenticated review (opaque; not interpreted by the CLI)")
 }

--- a/internal/cmd_flags.go
+++ b/internal/cmd_flags.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"fmt"
+
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/checker/localizations"
 	"github.com/oasdiff/oasdiff/formatters"
@@ -69,11 +71,19 @@ func addCommonBreakingFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().String("severity-levels", "", "configuration file for custom severity levels")
 	cmd.PersistentFlags().StringSlice("attributes", nil, "OpenAPI Extensions to include in json or yaml output")
 	cmd.PersistentFlags().String("template", "", "path to custom template file for changelog generation")
+}
 
-	// Review-upload flags. Inert without --open; --review-token's presence is the
-	// only switch between the free anonymous upload and the authenticated one.
-	// Deliberately vocabulary-neutral: a token and an opaque key=value metadata
-	// bag the CLI never interprets. getParseArgs rejects them without --open.
+// addOpenFlags registers --open and its companion review-upload flags. They live
+// together, and only on breaking/changelog, because the review flags are inert
+// without --open: --review-token's presence is the only switch between the free
+// anonymous upload and the authenticated one. The review flags are deliberately
+// vocabulary-neutral (a token and an opaque key=value metadata bag the CLI never
+// interprets); getParseArgs rejects them without --open. This is kept out of
+// addCommonBreakingFlags so the git-diff driver (which shares that helper but has
+// no --open) doesn't inherit these. outputName names what was printed before the
+// upload ("breaking changes" or "changelog").
+func addOpenFlags(cmd *cobra.Command, outputName string) {
+	cmd.PersistentFlags().Bool("open", false, fmt.Sprintf("after printing the %s, encrypt the comparison and upload it to oasdiff.com, then open the side-by-side review in a browser", outputName))
 	cmd.PersistentFlags().String("review-token", "", "with --open, upload an authenticated review using this token instead of the free anonymous one")
 	cmd.PersistentFlags().StringSlice("review-meta", nil, "with --open and --review-token, attach repeatable key=value metadata to the authenticated review (opaque; not interpreted by the CLI)")
 }

--- a/internal/cmd_flags.go
+++ b/internal/cmd_flags.go
@@ -73,25 +73,16 @@ func addCommonBreakingFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().String("template", "", "path to custom template file for changelog generation")
 }
 
-// addOpenFlags registers --open and its companion review-upload flags. They live
-// together, and only on breaking/changelog, because the review flags are inert
-// without --open: --review-token's presence is the only switch between the free
-// anonymous upload and the authenticated one. The review flags are deliberately
-// vocabulary-neutral (a token and an opaque key=value metadata bag the CLI never
-// interprets); getParseArgs rejects them without --open. This is kept out of
-// addCommonBreakingFlags so the git-diff driver (which shares that helper but has
-// no --open) doesn't inherit these. outputName names what was printed before the
-// upload ("breaking changes" or "changelog").
+// addOpenFlags registers --open and its companion review-upload flags. Kept out
+// of addCommonBreakingFlags so the git-diff driver (which shares that helper but
+// has no --open) doesn't inherit them.
 func addOpenFlags(cmd *cobra.Command, outputName string) {
 	cmd.PersistentFlags().Bool("open", false, fmt.Sprintf("after printing the %s, encrypt the comparison and upload it to oasdiff.com, then open the side-by-side review in a browser", outputName))
 	cmd.PersistentFlags().String("review-token", "", "with --open, upload an authenticated review using this token instead of the free anonymous one")
 	cmd.PersistentFlags().StringSlice("review-meta", nil, "with --open and --review-token, attach repeatable key=value metadata to the authenticated review (opaque; not interpreted by the CLI)")
 
-	// Hide the review-upload flags from --help: the authenticated review is
-	// assembled by the GitHub Action from its environment, not hand-typed, so
-	// these are an automation interface, not a human one. They still parse and
-	// work; a person sees only --open (the free review). Hidden as a pair because
-	// they're only useful together.
+	// Hidden from --help: the authenticated review is assembled by the Action,
+	// not hand-typed, so these are an automation interface. They still work.
 	hideFlag(cmd, "review-token")
 	hideFlag(cmd, "review-meta")
 }

--- a/internal/config_coverage_test.go
+++ b/internal/config_coverage_test.go
@@ -14,13 +14,20 @@ import (
 //   - open: an interactive one-shot action (encrypt the comparison, upload it,
 //     and open a browser). Persisting it in a committed config would upload and
 //     open a review on every run, so it is command-line only.
+//   - review-token / review-meta: per-invocation parameters of the --open upload
+//     (the auth token and its opaque metadata bag). They are meaningless without
+//     --open, which is itself command-line only, and the token is a credential
+//     that should never be committed to a config file. So they are command-line
+//     only too.
 //   - config: the path to the config file itself.
 //
 // Hidden (deprecated) flags are skipped separately via flag.Hidden, so they
 // don't need to be listed here.
 var flagsNotInConfigFile = map[string]bool{
-	"open":   true,
-	"config": true,
+	"open":         true,
+	"review-token": true,
+	"review-meta":  true,
+	"config":       true,
 }
 
 // Test_ConfigFileCoversAllFlags guards against config drift.

--- a/internal/flags.go
+++ b/internal/flags.go
@@ -92,6 +92,20 @@ func (flags *Flags) getOpen() bool {
 	return flags.v.GetBool("open")
 }
 
+// getReviewToken returns the opaque auth token supplied via --review-token. Its
+// presence (non-empty) is the only switch that makes --open do an authenticated
+// upload instead of the free anonymous one.
+func (flags *Flags) getReviewToken() string {
+	return flags.v.GetString("review-token")
+}
+
+// getReviewMeta returns the raw --review-meta entries (repeatable key=value
+// strings). The values are an opaque bag the CLI does not interpret; parsing
+// into a map happens in the authenticated upload path.
+func (flags *Flags) getReviewMeta() []string {
+	return fixViperStringSlice(flags.v.GetStringSlice("review-meta"))
+}
+
 func (flags *Flags) getIncludeChecks() []string {
 	return fixViperStringSlice(flags.v.GetStringSlice("include-checks"))
 }

--- a/internal/handlers.go
+++ b/internal/handlers.go
@@ -125,16 +125,13 @@ func checkOpenWithComposed(cmd *cobra.Command) error {
 
 func checkReviewFlagsRequireOpen(cmd *cobra.Command) error {
 
-	// The review flags exist only on breaking and changelog, added by
-	// addOpenFlags. Commands that share getParseArgs but not addOpenFlags (diff,
-	// summary) don't define them, so there's nothing to check.
+	// Only breaking/changelog define these (via addOpenFlags); skip elsewhere.
 	if cmd.Flags().Lookup("review-token") == nil {
 		return nil
 	}
 
-	// addOpenFlags registers --open together with the review flags, so wherever
-	// review-token exists --open does too. The Lookup guard is belt-and-suspenders
-	// for that invariant: if --open were ever absent, treat it as not set.
+	// --open is registered alongside the review flags; the Lookup is defensive
+	// in case it ever isn't.
 	open := false
 	if cmd.Flags().Lookup("open") != nil {
 		var err error

--- a/internal/handlers.go
+++ b/internal/handlers.go
@@ -125,16 +125,16 @@ func checkOpenWithComposed(cmd *cobra.Command) error {
 
 func checkReviewFlagsRequireOpen(cmd *cobra.Command) error {
 
-	// review flags exist only on breaking and changelog (added by
-	// addCommonBreakingFlags); diff and summary share getParseArgs but don't
-	// define them.
+	// The review flags exist only on breaking and changelog, added by
+	// addOpenFlags. Commands that share getParseArgs but not addOpenFlags (diff,
+	// summary) don't define them, so there's nothing to check.
 	if cmd.Flags().Lookup("review-token") == nil {
 		return nil
 	}
 
-	// --open is registered alongside the review flags on breaking and changelog,
-	// so where review-token exists, open does too. If it somehow doesn't, treat
-	// that as "open not set".
+	// addOpenFlags registers --open together with the review flags, so wherever
+	// review-token exists --open does too. The Lookup guard is belt-and-suspenders
+	// for that invariant: if --open were ever absent, treat it as not set.
 	open := false
 	if cmd.Flags().Lookup("open") != nil {
 		var err error

--- a/internal/handlers.go
+++ b/internal/handlers.go
@@ -26,6 +26,9 @@ func getParseArgs() cobra.PositionalArgs {
 		if err := checkOpenWithComposed(cmd); err != nil {
 			return err
 		}
+		if err := checkReviewFlagsRequireOpen(cmd); err != nil {
+			return err
+		}
 		if err := checkColor(cmd); err != nil {
 			return err
 		}
@@ -115,6 +118,36 @@ func checkOpenWithComposed(cmd *cobra.Command) error {
 		// mode (-c) diffs a glob of many files, which the review can't
 		// represent.
 		return errors.New("--open cannot be used with composed mode (-c): the side-by-side review compares exactly two specs")
+	}
+
+	return nil
+}
+
+func checkReviewFlagsRequireOpen(cmd *cobra.Command) error {
+
+	// review flags exist only on breaking and changelog (added by
+	// addCommonBreakingFlags); diff and summary share getParseArgs but don't
+	// define them.
+	if cmd.Flags().Lookup("review-token") == nil {
+		return nil
+	}
+
+	// --open is registered alongside the review flags on breaking and changelog,
+	// so where review-token exists, open does too. If it somehow doesn't, treat
+	// that as "open not set".
+	open := false
+	if cmd.Flags().Lookup("open") != nil {
+		var err error
+		if open, err = cmd.Flags().GetBool("open"); err != nil {
+			return errors.New("failed to get open flag")
+		}
+	}
+	if open {
+		return nil
+	}
+
+	if cmd.Flags().Changed("review-token") || cmd.Flags().Changed("review-meta") {
+		return errors.New("--review-token and --review-meta require --open")
 	}
 
 	return nil

--- a/internal/open_review.go
+++ b/internal/open_review.go
@@ -392,7 +392,10 @@ func readSpecSource(source *load.Source) ([]byte, string, error) {
 // manually. Notable absence: a CI / headless detection. CI users wouldn't
 // run --open in the first place; if they do, they get a non-fatal error
 // and the printed URL.
-func openBrowser(targetURL string) error {
+//
+// A var so tests can stub it: the upload path's tests exercise the upload, not
+// an actual browser launch.
+var openBrowser = func(targetURL string) error {
 	if _, err := url.Parse(targetURL); err != nil {
 		return fmt.Errorf("invalid URL: %w", err)
 	}

--- a/internal/open_review.go
+++ b/internal/open_review.go
@@ -38,11 +38,9 @@ func oasdiffSiteURL() string {
 	return "https://www.oasdiff.com"
 }
 
-// oasdiffAPIBaseURL is the base URL of the backend API service. It is used only
-// by the authenticated review upload (--review-token); the free anonymous path
-// posts to the web product instead (see oasdiffSiteURL). Defaults to
-// api.oasdiff.com; set the OASDIFF_API_URL env var to point the authenticated
-// upload at a different deployment (a local dev service, or a self-hosted one).
+// oasdiffAPIBaseURL is the backend API base, used only by the authenticated
+// review upload (the free path posts to oasdiffSiteURL). Override with
+// OASDIFF_API_URL; defaults to api.oasdiff.com.
 func oasdiffAPIBaseURL() string {
 	if u := os.Getenv("OASDIFF_API_URL"); u != "" {
 		return strings.TrimRight(u, "/")
@@ -135,9 +133,8 @@ func uploadAndOpen(flags *Flags, stderr io.Writer, isBreaking bool, errs checker
 		return fmt.Errorf("encrypt review: %w", err)
 	}
 
-	// When a token is supplied, --open does the authenticated upload instead of
-	// the free anonymous one. The encrypted bundle and key are identical; only
-	// the endpoint, the request shape, and the response differ.
+	// A token switches --open to the authenticated upload; the bundle and key
+	// are the same as the free path.
 	if token := flags.getReviewToken(); token != "" {
 		return uploadAuthenticatedReview(token, flags.getReviewMeta(), blob, key, errs, stderr)
 	}
@@ -260,7 +257,6 @@ func parseReviewMeta(entries []string) (map[string]string, error) {
 	for _, e := range entries {
 		i := strings.IndexByte(e, '=')
 		if i <= 0 {
-			// i == -1: no '=' separator. i == 0: empty key.
 			return nil, fmt.Errorf("invalid --review-meta entry %q: expected key=value", e)
 		}
 		key := e[:i]
@@ -272,21 +268,16 @@ func parseReviewMeta(entries []string) (map[string]string, error) {
 	return meta, nil
 }
 
-// reviewChange is one entry in the change manifest sent alongside the encrypted
-// bundle on the authenticated path. The fingerprint matches a logical change
-// across spec versions (see formatters.ComputeFingerprint); the level is the
-// change's severity as an int.
+// reviewChange is one manifest entry sent alongside the encrypted bundle: a
+// change's fingerprint (see formatters.ComputeFingerprint) and its level.
 type reviewChange struct {
 	Fingerprint string `json:"fingerprint" yaml:"fingerprint"`
 	Level       int    `json:"level" yaml:"level"`
 }
 
-// reviewManifest extracts the change manifest from the computed changes: one
-// entry per change carrying its fingerprint and level. The fingerprint is
-// computed exactly as the JSON formatter computes it (formatters.ComputeFingerprint),
-// so the manifest matches the fingerprints embedded in the encrypted changelog.
-// A fingerprint is the only handle the server has on a change; ComputeFingerprint
-// always returns a non-empty 12-char hash, so an entry is emitted for every change.
+// reviewManifest builds the {fingerprint, level} manifest. Fingerprints are
+// computed as the JSON formatter does, so they match the ones in the encrypted
+// changelog the page renders.
 func reviewManifest(errs checker.Changes) []reviewChange {
 	manifest := make([]reviewChange, 0, len(errs))
 	for _, change := range errs {
@@ -298,11 +289,9 @@ func reviewManifest(errs checker.Changes) []reviewChange {
 	return manifest
 }
 
-// uploadAuthenticatedReview posts the encrypted bundle to the token-authenticated
-// endpoint, builds the final review URL with the key in its #fragment (encoded
-// identically to the free path), prints it, and prints the returned status
-// verbatim. It mirrors the free path's additive error model: any failure warns
-// and returns non-fatally so --open never changes the command's exit code.
+// uploadAuthenticatedReview posts the encrypted bundle to the token endpoint and
+// prints the returned review URL (key in its #fragment) plus the status. Errors
+// are returned for the caller to demote to a warning, like the free path.
 func uploadAuthenticatedReview(token string, metaEntries []string, blob, key []byte, errs checker.Changes, stderr io.Writer) error {
 	metadata, err := parseReviewMeta(metaEntries)
 	if err != nil {
@@ -314,8 +303,6 @@ func uploadAuthenticatedReview(token string, metaEntries []string, blob, key []b
 		Metadata   map[string]string `json:"metadata" yaml:"metadata"`
 		Changes    []reviewChange    `json:"changes" yaml:"changes"`
 	}{
-		// encoding/json base64-encodes a []byte field automatically, matching
-		// the raw-blob handling of the free path.
 		Ciphertext: blob,
 		Metadata:   metadata,
 		Changes:    reviewManifest(errs),

--- a/internal/open_review.go
+++ b/internal/open_review.go
@@ -251,14 +251,10 @@ func postEncryptedReview(blob []byte) (string, time.Time, error) {
 	return parsed.ReviewID, time.Unix(parsed.ExpiresAt, 0).UTC(), nil
 }
 
-// parseReviewMeta splits each "key=value" entry on the first '=' into a map.
-// The bag is opaque: the CLI assigns no meaning to any key. Anything that would
-// silently lose or override caller intent is an error rather than swallowed:
-//   - an entry that isn't a key=value pair (no '=', or an empty key);
-//   - a duplicate key (the server's metadata is single-valued, so a repeat is a
-//     caller mistake, not a multi-value, and last-wins would discard the first).
-//
-// An empty value is allowed.
+// parseReviewMeta splits each "key=value" entry on the first '=' into an opaque
+// map (the CLI assigns no meaning to any key). It rejects entries that would
+// silently lose or override caller intent rather than swallowing them; see
+// TestParseReviewMeta for the exact cases.
 func parseReviewMeta(entries []string) (map[string]string, error) {
 	meta := make(map[string]string, len(entries))
 	for _, e := range entries {

--- a/internal/open_review.go
+++ b/internal/open_review.go
@@ -23,7 +23,6 @@ import (
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/formatters"
 	"github.com/oasdiff/oasdiff/load"
-	"github.com/spf13/cobra"
 )
 
 // oasdiffSiteURL is the base URL of the web product. Defaults to the canonical
@@ -49,16 +48,6 @@ func oasdiffAPIBaseURL() string {
 		return strings.TrimRight(u, "/")
 	}
 	return "https://api.oasdiff.com"
-}
-
-// addReviewFlags registers the flags that turn the additive --open upload into
-// an authenticated one. They are inert without --open; --review-token's presence
-// is the only switch between the free anonymous upload and the authenticated
-// one. The flags are deliberately vocabulary-neutral: a token and an opaque
-// key=value metadata bag the CLI never interprets.
-func addReviewFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().String("review-token", "", "with --open, upload an authenticated review using this token instead of the free anonymous one")
-	cmd.PersistentFlags().StringSlice("review-meta", nil, "with --open and --review-token, attach repeatable key=value metadata to the authenticated review (opaque; not interpreted by the CLI)")
 }
 
 // encryptedReviewBlobVersion is the first byte of the uploaded blob. It lets

--- a/internal/open_review.go
+++ b/internal/open_review.go
@@ -252,21 +252,22 @@ func postEncryptedReview(blob []byte) (string, time.Time, error) {
 }
 
 // parseReviewMeta splits each "key=value" entry on the first '=' into a map.
-// The bag is opaque: the CLI assigns no meaning to any key. An entry with no
-// '=' has no value and is skipped (there is nothing to attach); an empty key is
-// likewise skipped. Later entries with the same key win.
-func parseReviewMeta(entries []string) map[string]string {
+// The bag is opaque: the CLI assigns no meaning to any key. An entry that isn't
+// a key=value pair (no '=', or an empty key) is an error rather than silently
+// dropped: dropping it would lose metadata the caller meant to send and surface
+// later as a confusing server-side rejection. An empty value is allowed. Later
+// entries with the same key win.
+func parseReviewMeta(entries []string) (map[string]string, error) {
 	meta := make(map[string]string, len(entries))
 	for _, e := range entries {
 		i := strings.IndexByte(e, '=')
 		if i <= 0 {
-			// No '=' (i == -1): no value to attach. Leading '=' (i == 0):
-			// empty key. Skip both.
-			continue
+			// i == -1: no '=' separator. i == 0: empty key.
+			return nil, fmt.Errorf("invalid --review-meta entry %q: expected key=value", e)
 		}
 		meta[e[:i]] = e[i+1:]
 	}
-	return meta
+	return meta, nil
 }
 
 // reviewChange is one entry in the change manifest sent alongside the encrypted
@@ -301,6 +302,11 @@ func reviewManifest(errs checker.Changes) []reviewChange {
 // verbatim. It mirrors the free path's additive error model: any failure warns
 // and returns non-fatally so --open never changes the command's exit code.
 func uploadAuthenticatedReview(token string, metaEntries []string, blob, key []byte, errs checker.Changes, stderr io.Writer) error {
+	metadata, err := parseReviewMeta(metaEntries)
+	if err != nil {
+		return err
+	}
+
 	body, err := json.Marshal(struct {
 		Ciphertext []byte            `json:"ciphertext" yaml:"ciphertext"`
 		Metadata   map[string]string `json:"metadata" yaml:"metadata"`
@@ -309,7 +315,7 @@ func uploadAuthenticatedReview(token string, metaEntries []string, blob, key []b
 		// encoding/json base64-encodes a []byte field automatically, matching
 		// the raw-blob handling of the free path.
 		Ciphertext: blob,
-		Metadata:   parseReviewMeta(metaEntries),
+		Metadata:   metadata,
 		Changes:    reviewManifest(errs),
 	})
 	if err != nil {

--- a/internal/open_review.go
+++ b/internal/open_review.go
@@ -23,6 +23,7 @@ import (
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/formatters"
 	"github.com/oasdiff/oasdiff/load"
+	"github.com/spf13/cobra"
 )
 
 // oasdiffSiteURL is the base URL of the web product. Defaults to the canonical
@@ -36,6 +37,28 @@ func oasdiffSiteURL() string {
 		return strings.TrimRight(u, "/")
 	}
 	return "https://www.oasdiff.com"
+}
+
+// oasdiffAPIBaseURL is the base URL of the backend API service. It is used only
+// by the authenticated review upload (--review-token); the free anonymous path
+// posts to the web product instead (see oasdiffSiteURL). Defaults to
+// api.oasdiff.com; set the OASDIFF_API_URL env var to point the authenticated
+// upload at a different deployment (a local dev service, or a self-hosted one).
+func oasdiffAPIBaseURL() string {
+	if u := os.Getenv("OASDIFF_API_URL"); u != "" {
+		return strings.TrimRight(u, "/")
+	}
+	return "https://api.oasdiff.com"
+}
+
+// addReviewFlags registers the flags that turn the additive --open upload into
+// an authenticated one. They are inert without --open; --review-token's presence
+// is the only switch between the free anonymous upload and the authenticated
+// one. The flags are deliberately vocabulary-neutral: a token and an opaque
+// key=value metadata bag the CLI never interprets.
+func addReviewFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().String("review-token", "", "with --open, upload an authenticated review using this token instead of the free anonymous one")
+	cmd.PersistentFlags().StringSlice("review-meta", nil, "with --open and --review-token, attach repeatable key=value metadata to the authenticated review (opaque; not interpreted by the CLI)")
 }
 
 // encryptedReviewBlobVersion is the first byte of the uploaded blob. It lets
@@ -121,6 +144,13 @@ func uploadAndOpen(flags *Flags, stderr io.Writer, isBreaking bool, errs checker
 	blob, key, err := encryptReviewPayload(plaintext)
 	if err != nil {
 		return fmt.Errorf("encrypt review: %w", err)
+	}
+
+	// When a token is supplied, --open does the authenticated upload instead of
+	// the free anonymous one. The encrypted bundle and key are identical; only
+	// the endpoint, the request shape, and the response differ.
+	if token := flags.getReviewToken(); token != "" {
+		return uploadAuthenticatedReview(token, flags.getReviewMeta(), blob, key, errs, stderr)
 	}
 
 	reviewID, expiresAt, err := postEncryptedReview(blob)
@@ -230,6 +260,122 @@ func postEncryptedReview(blob []byte) (string, time.Time, error) {
 		return "", time.Time{}, fmt.Errorf("response missing review_id: %s", string(respBody))
 	}
 	return parsed.ReviewID, time.Unix(parsed.ExpiresAt, 0).UTC(), nil
+}
+
+// parseReviewMeta splits each "key=value" entry on the first '=' into a map.
+// The bag is opaque: the CLI assigns no meaning to any key. An entry with no
+// '=' has no value and is skipped (there is nothing to attach); an empty key is
+// likewise skipped. Later entries with the same key win.
+func parseReviewMeta(entries []string) map[string]string {
+	meta := make(map[string]string, len(entries))
+	for _, e := range entries {
+		i := strings.IndexByte(e, '=')
+		if i <= 0 {
+			// No '=' (i == -1): no value to attach. Leading '=' (i == 0):
+			// empty key. Skip both.
+			continue
+		}
+		meta[e[:i]] = e[i+1:]
+	}
+	return meta
+}
+
+// reviewChange is one entry in the change manifest sent alongside the encrypted
+// bundle on the authenticated path. The fingerprint matches a logical change
+// across spec versions (see formatters.ComputeFingerprint); the level is the
+// change's severity as an int.
+type reviewChange struct {
+	Fingerprint string `json:"fingerprint" yaml:"fingerprint"`
+	Level       int    `json:"level" yaml:"level"`
+}
+
+// reviewManifest extracts the change manifest from the computed changes: one
+// entry per change carrying its fingerprint and level. The fingerprint is
+// computed exactly as the JSON formatter computes it (formatters.ComputeFingerprint),
+// so the manifest matches the fingerprints embedded in the encrypted changelog.
+// A fingerprint is the only handle the server has on a change; ComputeFingerprint
+// always returns a non-empty 12-char hash, so an entry is emitted for every change.
+func reviewManifest(errs checker.Changes) []reviewChange {
+	manifest := make([]reviewChange, 0, len(errs))
+	for _, change := range errs {
+		manifest = append(manifest, reviewChange{
+			Fingerprint: formatters.ComputeFingerprint(change.GetId(), change.GetOperation(), change.GetPath(), change.GetArgs()),
+			Level:       int(change.GetLevel()),
+		})
+	}
+	return manifest
+}
+
+// uploadAuthenticatedReview posts the encrypted bundle to the token-authenticated
+// endpoint, builds the final review URL with the key in its #fragment (encoded
+// identically to the free path), prints it, and prints the returned status
+// verbatim. It mirrors the free path's additive error model: any failure warns
+// and returns non-fatally so --open never changes the command's exit code.
+func uploadAuthenticatedReview(token string, metaEntries []string, blob, key []byte, errs checker.Changes, stderr io.Writer) error {
+	body, err := json.Marshal(struct {
+		Ciphertext []byte            `json:"ciphertext" yaml:"ciphertext"`
+		Metadata   map[string]string `json:"metadata" yaml:"metadata"`
+		Changes    []reviewChange    `json:"changes" yaml:"changes"`
+	}{
+		// encoding/json base64-encodes a []byte field automatically, matching
+		// the raw-blob handling of the free path.
+		Ciphertext: blob,
+		Metadata:   parseReviewMeta(metaEntries),
+		Changes:    reviewManifest(errs),
+	})
+	if err != nil {
+		return fmt.Errorf("marshal authenticated review: %w", err)
+	}
+
+	endpoint := fmt.Sprintf("%s/tenants/%s/encrypted-pr-review", oasdiffAPIBaseURL(), url.PathEscape(token))
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "oasdiff-cli")
+
+	client := &http.Client{Timeout: 5 * time.Minute}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("upload to %s: %w", endpoint, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("upload failed (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+
+	var parsed struct {
+		ReviewToken string `json:"review_token" yaml:"review_token"`
+		ReviewURL   string `json:"review_url" yaml:"review_url"`
+		Gate        struct {
+			State            string `json:"state" yaml:"state"`
+			BreakingTotal    int    `json:"breaking_total" yaml:"breaking_total"`
+			BreakingApproved int    `json:"breaking_approved" yaml:"breaking_approved"`
+		} `json:"gate" yaml:"gate"`
+	}
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return fmt.Errorf("parse response: %w", err)
+	}
+	if parsed.ReviewURL == "" {
+		return fmt.Errorf("response missing review_url: %s", string(respBody))
+	}
+
+	// The key rides in the URL #fragment exactly as the free path encodes it:
+	// browsers never transmit the fragment, so the server stores ciphertext it
+	// cannot read.
+	reviewURL := parsed.ReviewURL + "#k=" + base64.RawURLEncoding.EncodeToString(key)
+
+	fmt.Fprintf(stderr, "\nOpening %s\n", reviewURL)
+	// The status is printed verbatim, on its own grep-friendly line. The CLI
+	// does not interpret or branch on it; the caller acts on it.
+	fmt.Fprintf(stderr, "oasdiff: review status: %s\n", parsed.Gate.State)
+	if err := openBrowser(reviewURL); err != nil {
+		fmt.Fprintf(stderr, "Could not open browser automatically: %v\nOpen this URL manually: %s\n", err, reviewURL)
+	}
+	return nil
 }
 
 // readSpecSource returns the raw bytes of a spec source and a display

--- a/internal/open_review.go
+++ b/internal/open_review.go
@@ -252,11 +252,13 @@ func postEncryptedReview(blob []byte) (string, time.Time, error) {
 }
 
 // parseReviewMeta splits each "key=value" entry on the first '=' into a map.
-// The bag is opaque: the CLI assigns no meaning to any key. An entry that isn't
-// a key=value pair (no '=', or an empty key) is an error rather than silently
-// dropped: dropping it would lose metadata the caller meant to send and surface
-// later as a confusing server-side rejection. An empty value is allowed. Later
-// entries with the same key win.
+// The bag is opaque: the CLI assigns no meaning to any key. Anything that would
+// silently lose or override caller intent is an error rather than swallowed:
+//   - an entry that isn't a key=value pair (no '=', or an empty key);
+//   - a duplicate key (the server's metadata is single-valued, so a repeat is a
+//     caller mistake, not a multi-value, and last-wins would discard the first).
+//
+// An empty value is allowed.
 func parseReviewMeta(entries []string) (map[string]string, error) {
 	meta := make(map[string]string, len(entries))
 	for _, e := range entries {
@@ -265,7 +267,11 @@ func parseReviewMeta(entries []string) (map[string]string, error) {
 			// i == -1: no '=' separator. i == 0: empty key.
 			return nil, fmt.Errorf("invalid --review-meta entry %q: expected key=value", e)
 		}
-		meta[e[:i]] = e[i+1:]
+		key := e[:i]
+		if _, dup := meta[key]; dup {
+			return nil, fmt.Errorf("duplicate --review-meta key %q", key)
+		}
+		meta[key] = e[i+1:]
 	}
 	return meta, nil
 }

--- a/internal/open_review_unix_test.go
+++ b/internal/open_review_unix_test.go
@@ -239,11 +239,11 @@ func TestParseReviewMeta(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, want, got)
 	}
-	bad := func(t *testing.T, entries ...string) {
+	bad := func(t *testing.T, wantMsg string, entries ...string) {
 		t.Helper()
 		_, err := parseReviewMeta(entries)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "expected key=value")
+		require.Contains(t, err.Error(), wantMsg)
 	}
 
 	t.Run("simple key=value", func(t *testing.T) {
@@ -261,14 +261,14 @@ func TestParseReviewMeta(t *testing.T) {
 	t.Run("nil input yields empty map", func(t *testing.T) {
 		ok(t, map[string]string{})
 	})
-	t.Run("later entry wins for duplicate key", func(t *testing.T) {
-		ok(t, map[string]string{"a": "second"}, "a=first", "a=second")
-	})
 	t.Run("entry without = is an error, not silently dropped", func(t *testing.T) {
-		bad(t, "a=b", "noequals")
+		bad(t, "expected key=value", "a=b", "noequals")
 	})
 	t.Run("leading = (empty key) is an error", func(t *testing.T) {
-		bad(t, "=value")
+		bad(t, "expected key=value", "=value")
+	})
+	t.Run("duplicate key is an error, not last-wins", func(t *testing.T) {
+		bad(t, "duplicate", "a=first", "a=second")
 	})
 }
 

--- a/internal/open_review_unix_test.go
+++ b/internal/open_review_unix_test.go
@@ -233,30 +233,53 @@ func TestUploadAndOpen_BreakingSetsModeBreaking(t *testing.T) {
 }
 
 func TestParseReviewMeta(t *testing.T) {
+	ok := func(t *testing.T, want map[string]string, entries ...string) {
+		t.Helper()
+		got, err := parseReviewMeta(entries)
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	}
+	bad := func(t *testing.T, entries ...string) {
+		t.Helper()
+		_, err := parseReviewMeta(entries)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "expected key=value")
+	}
+
 	t.Run("simple key=value", func(t *testing.T) {
-		require.Equal(t, map[string]string{"a": "b"}, parseReviewMeta([]string{"a=b"}))
+		ok(t, map[string]string{"a": "b"}, "a=b")
 	})
 	t.Run("value containing = splits on the first only", func(t *testing.T) {
-		require.Equal(t, map[string]string{"k": "a=b=c"}, parseReviewMeta([]string{"k=a=b=c"}))
+		ok(t, map[string]string{"k": "a=b=c"}, "k=a=b=c")
 	})
 	t.Run("multiple entries", func(t *testing.T) {
-		require.Equal(t, map[string]string{"a": "1", "b": "2"}, parseReviewMeta([]string{"a=1", "b=2"}))
+		ok(t, map[string]string{"a": "1", "b": "2"}, "a=1", "b=2")
 	})
 	t.Run("empty value is allowed", func(t *testing.T) {
-		require.Equal(t, map[string]string{"a": ""}, parseReviewMeta([]string{"a="}))
-	})
-	t.Run("malformed entry without = is skipped", func(t *testing.T) {
-		require.Equal(t, map[string]string{"a": "b"}, parseReviewMeta([]string{"noequals", "a=b"}))
-	})
-	t.Run("leading = (empty key) is skipped", func(t *testing.T) {
-		require.Equal(t, map[string]string{}, parseReviewMeta([]string{"=value"}))
+		ok(t, map[string]string{"a": ""}, "a=")
 	})
 	t.Run("nil input yields empty map", func(t *testing.T) {
-		require.Equal(t, map[string]string{}, parseReviewMeta(nil))
+		ok(t, map[string]string{})
 	})
 	t.Run("later entry wins for duplicate key", func(t *testing.T) {
-		require.Equal(t, map[string]string{"a": "second"}, parseReviewMeta([]string{"a=first", "a=second"}))
+		ok(t, map[string]string{"a": "second"}, "a=first", "a=second")
 	})
+	t.Run("entry without = is an error, not silently dropped", func(t *testing.T) {
+		bad(t, "a=b", "noequals")
+	})
+	t.Run("leading = (empty key) is an error", func(t *testing.T) {
+		bad(t, "=value")
+	})
+}
+
+func TestUploadAuthenticatedReview_InvalidMetaIsError(t *testing.T) {
+	// A malformed --review-meta entry must surface (the caller demotes it to a
+	// warning), not be silently dropped. Fails during parsing, before any HTTP
+	// call, so no server is needed.
+	var out bytes.Buffer
+	err := uploadAuthenticatedReview("tok", []string{"noequals"}, []byte{encryptedReviewBlobVersion, 1}, make([]byte, 32), checker.Changes{}, &out)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expected key=value")
 }
 
 // writeSpecPair writes two minimal specs to fresh temp dirs and returns a Flags

--- a/internal/open_review_unix_test.go
+++ b/internal/open_review_unix_test.go
@@ -231,3 +231,176 @@ func TestUploadAndOpen_BreakingSetsModeBreaking(t *testing.T) {
 	require.NoError(t, json.Unmarshal(decryptBlob(t, uploadedBlob, key), &payload))
 	require.Equal(t, "breaking", payload.Mode, "isBreaking=true must propagate as mode=breaking")
 }
+
+func TestParseReviewMeta(t *testing.T) {
+	t.Run("simple key=value", func(t *testing.T) {
+		require.Equal(t, map[string]string{"a": "b"}, parseReviewMeta([]string{"a=b"}))
+	})
+	t.Run("value containing = splits on the first only", func(t *testing.T) {
+		require.Equal(t, map[string]string{"k": "a=b=c"}, parseReviewMeta([]string{"k=a=b=c"}))
+	})
+	t.Run("multiple entries", func(t *testing.T) {
+		require.Equal(t, map[string]string{"a": "1", "b": "2"}, parseReviewMeta([]string{"a=1", "b=2"}))
+	})
+	t.Run("empty value is allowed", func(t *testing.T) {
+		require.Equal(t, map[string]string{"a": ""}, parseReviewMeta([]string{"a="}))
+	})
+	t.Run("malformed entry without = is skipped", func(t *testing.T) {
+		require.Equal(t, map[string]string{"a": "b"}, parseReviewMeta([]string{"noequals", "a=b"}))
+	})
+	t.Run("leading = (empty key) is skipped", func(t *testing.T) {
+		require.Equal(t, map[string]string{}, parseReviewMeta([]string{"=value"}))
+	})
+	t.Run("nil input yields empty map", func(t *testing.T) {
+		require.Equal(t, map[string]string{}, parseReviewMeta(nil))
+	})
+	t.Run("later entry wins for duplicate key", func(t *testing.T) {
+		require.Equal(t, map[string]string{"a": "second"}, parseReviewMeta([]string{"a=first", "a=second"}))
+	})
+}
+
+// writeSpecPair writes two minimal specs to fresh temp dirs and returns a Flags
+// pointed at them. The two dirs keep the basenames identical (openapi.yaml)
+// without colliding, mirroring the existing --open tests.
+func writeSpecPair(t *testing.T) *Flags {
+	t.Helper()
+	baseDir := t.TempDir()
+	basePath := filepath.Join(baseDir, "openapi.yaml")
+	require.NoError(t, os.WriteFile(basePath, []byte("openapi: 3.0.0\nbase\n"), 0644))
+	revDir := t.TempDir()
+	revPath := filepath.Join(revDir, "openapi.yaml")
+	require.NoError(t, os.WriteFile(revPath, []byte("openapi: 3.0.0\nrev\n"), 0644))
+
+	flags := NewFlags()
+	flags.setBase(load.NewSource(basePath))
+	flags.setRevision(load.NewSource(revPath))
+	return flags
+}
+
+func TestReviewManifest(t *testing.T) {
+	changes := checker.Changes{
+		checker.ApiChange{Id: "id-a", Operation: "GET", Path: "/a", Level: checker.ERR},
+		checker.ApiChange{Id: "id-b", Operation: "POST", Path: "/b", Level: checker.INFO},
+	}
+	manifest := reviewManifest(changes)
+	require.Len(t, manifest, 2)
+	for _, m := range manifest {
+		require.NotEmpty(t, m.Fingerprint, "every entry must carry a fingerprint")
+		require.Len(t, m.Fingerprint, 12, "fingerprint is the 12-char ComputeFingerprint output")
+	}
+	require.Equal(t, int(checker.ERR), manifest[0].Level, "level is the change's severity as an int")
+	require.Equal(t, int(checker.INFO), manifest[1].Level)
+	require.NotEqual(t, manifest[0].Fingerprint, manifest[1].Fingerprint, "distinct changes must have distinct fingerprints")
+}
+
+func TestUploadAndOpen_AuthenticatedPath(t *testing.T) {
+	var (
+		gotPath        string
+		gotMethod      string
+		gotContentType string
+		gotBody        []byte
+	)
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		gotContentType = r.Header.Get("Content-Type")
+		gotBody, _ = io.ReadAll(r.Body)
+		_, _ = w.Write([]byte(`{"review_token":"rt-1","review_url":"https://www.oasdiff.com/review/e/auth-1","gate":{"state":"approved","breaking_total":3,"breaking_approved":3}}`))
+	}))
+	defer stub.Close()
+	// The authenticated upload targets the API base, not the site base.
+	t.Setenv("OASDIFF_API_URL", stub.URL)
+	// Point the site env elsewhere to prove the auth path does not use it.
+	t.Setenv("OASDIFF_URL", "https://should-not-be-used.example.com")
+
+	flags := writeSpecPair(t)
+	flags.v.Set("review-token", "tok-123")
+	flags.v.Set("review-meta", []string{"owner=acme", "pr=42"})
+
+	var out bytes.Buffer
+	require.NoError(t, uploadAndOpen(flags, &out, true, checker.Changes{}, nil, true))
+
+	require.Equal(t, http.MethodPost, gotMethod)
+	require.Equal(t, "/tenants/tok-123/encrypted-pr-review", gotPath, "the token is path-authenticated")
+	require.Equal(t, "application/json", gotContentType)
+
+	var body struct {
+		Ciphertext []byte            `json:"ciphertext"`
+		Metadata   map[string]string `json:"metadata"`
+		Changes    []reviewChange    `json:"changes"`
+	}
+	require.NoError(t, json.Unmarshal(gotBody, &body))
+	require.NotEmpty(t, body.Ciphertext, "the encrypted bundle must ride in ciphertext")
+	require.Equal(t, byte(encryptedReviewBlobVersion), body.Ciphertext[0], "ciphertext is the same blob layout as the free path")
+	require.Equal(t, map[string]string{"owner": "acme", "pr": "42"}, body.Metadata, "the opaque metadata bag is forwarded verbatim")
+
+	// The output carries the returned URL with the key in its #fragment and the
+	// gate state printed verbatim.
+	require.Contains(t, out.String(), "https://www.oasdiff.com/review/e/auth-1#k=")
+	require.Contains(t, out.String(), "oasdiff: review status: approved")
+	require.NotContains(t, out.String(), "should-not-be-used", "the authenticated path must not use the site base URL")
+
+	m := keyFragmentRe.FindStringSubmatch(out.String())
+	require.Len(t, m, 2, "the URL must contain a #k= fragment")
+	key, err := base64.RawURLEncoding.DecodeString(m[1])
+	require.NoError(t, err)
+	require.Len(t, key, 32)
+
+	// The fragment key must decrypt the uploaded ciphertext: same zero-knowledge
+	// contract as the free path.
+	var payload reviewPayload
+	require.NoError(t, json.Unmarshal(decryptBlob(t, body.Ciphertext, key), &payload))
+	require.Equal(t, "openapi: 3.0.0\nbase\n", payload.BaseSpec)
+	require.Equal(t, "openapi: 3.0.0\nrev\n", payload.RevisionSpec)
+}
+
+func TestUploadAndOpen_FreePathWhenNoToken(t *testing.T) {
+	// With no token, --open must hit the free endpoint on the site base, not the
+	// authenticated one. Fail loudly if the authenticated endpoint is touched.
+	var freeHit bool
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/encrypted-review", r.URL.Path, "no token means the free anonymous endpoint")
+		freeHit = true
+		_, _ = w.Write([]byte(`{"review_id":"free-1","expires_at":0}`))
+	}))
+	defer stub.Close()
+	t.Setenv("OASDIFF_URL", stub.URL)
+	// If the auth path were wrongly taken, this base would be used; point it at a
+	// dead address so the test would error rather than silently pass.
+	t.Setenv("OASDIFF_API_URL", "http://127.0.0.1:0")
+
+	flags := writeSpecPair(t)
+
+	var out bytes.Buffer
+	require.NoError(t, uploadAndOpen(flags, &out, false, checker.Changes{}, nil, true))
+	require.True(t, freeHit, "the free endpoint must be used when --review-token is empty")
+	require.Contains(t, out.String(), "/review/e/free-1#k=")
+}
+
+func TestUploadAuthenticatedReview_ServerErrorIsNonFatal(t *testing.T) {
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"tenant not found"}`))
+	}))
+	defer stub.Close()
+	t.Setenv("OASDIFF_API_URL", stub.URL)
+
+	blob := []byte{encryptedReviewBlobVersion, 1, 2, 3}
+	key := make([]byte, 32)
+	var out bytes.Buffer
+	err := uploadAuthenticatedReview("tok", nil, blob, key, checker.Changes{}, &out)
+	require.Error(t, err, "the function returns the error; the caller (getChangelog) demotes it to a warning")
+	require.Contains(t, err.Error(), "403")
+	require.Contains(t, err.Error(), "tenant not found", "the server's error body must surface in the warning")
+}
+
+func TestUploadAuthenticatedReview_UnreachableIsNonFatal(t *testing.T) {
+	// Port 0 is not connectable; the upload must return an error (which the
+	// caller demotes to a warning) rather than panicking.
+	t.Setenv("OASDIFF_API_URL", "http://127.0.0.1:0")
+	blob := []byte{encryptedReviewBlobVersion, 1, 2, 3}
+	var out bytes.Buffer
+	err := uploadAuthenticatedReview("tok", nil, blob, make([]byte, 32), checker.Changes{}, &out)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "upload to")
+}

--- a/internal/open_review_unix_test.go
+++ b/internal/open_review_unix_test.go
@@ -148,6 +148,7 @@ func TestPostEncryptedReview_ServerError(t *testing.T) {
 var keyFragmentRe = regexp.MustCompile(`#k=([A-Za-z0-9_-]+)`)
 
 func TestUploadAndOpen_EncryptsSpecsAndEmitsFragmentURL(t *testing.T) {
+	stubBrowser(t)
 	// End-to-end: stand up a stub /api/encrypted-review, run uploadAndOpen
 	// against two real spec files, capture the uploaded blob, pull the key
 	// out of the emitted #fragment, decrypt, and assert the payload carries
@@ -203,6 +204,7 @@ func TestUploadAndOpen_EncryptsSpecsAndEmitsFragmentURL(t *testing.T) {
 }
 
 func TestUploadAndOpen_BreakingSetsModeBreaking(t *testing.T) {
+	stubBrowser(t)
 	var uploadedBlob []byte
 	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		uploadedBlob, _ = io.ReadAll(r.Body)
@@ -282,6 +284,15 @@ func TestUploadAuthenticatedReview_InvalidMetaIsError(t *testing.T) {
 	require.Contains(t, err.Error(), "expected key=value")
 }
 
+// stubBrowser replaces openBrowser with a no-op for the test, so the upload
+// tests don't actually launch a browser on the dev machine.
+func stubBrowser(t *testing.T) {
+	t.Helper()
+	orig := openBrowser
+	openBrowser = func(string) error { return nil }
+	t.Cleanup(func() { openBrowser = orig })
+}
+
 // writeSpecPair writes two minimal specs to fresh temp dirs and returns a Flags
 // pointed at them. The two dirs keep the basenames identical (openapi.yaml)
 // without colliding, mirroring the existing --open tests.
@@ -317,6 +328,7 @@ func TestReviewManifest(t *testing.T) {
 }
 
 func TestUploadAndOpen_AuthenticatedPath(t *testing.T) {
+	stubBrowser(t)
 	var (
 		gotPath        string
 		gotMethod      string
@@ -378,6 +390,7 @@ func TestUploadAndOpen_AuthenticatedPath(t *testing.T) {
 }
 
 func TestUploadAndOpen_FreePathWhenNoToken(t *testing.T) {
+	stubBrowser(t)
 	// With no token, --open must hit the free endpoint on the site base, not the
 	// authenticated one. Fail loudly if the authenticated endpoint is touched.
 	var freeHit bool

--- a/internal/open_review_unix_test.go
+++ b/internal/open_review_unix_test.go
@@ -340,7 +340,9 @@ func TestUploadAndOpen_AuthenticatedPath(t *testing.T) {
 		gotMethod = r.Method
 		gotContentType = r.Header.Get("Content-Type")
 		gotBody, _ = io.ReadAll(r.Body)
-		_, _ = w.Write([]byte(`{"review_token":"rt-1","review_url":"https://www.oasdiff.com/review/e/auth-1","gate":{"state":"approved","breaking_total":3,"breaking_approved":3}}`))
+		// A deliberately distinct host + the Pro /review/ep route: it proves the
+		// CLI echoes the server-returned review_url verbatim, not OASDIFF_URL.
+		_, _ = w.Write([]byte(`{"review_token":"rt-1","review_url":"https://review.example.test/review/ep/auth-1","gate":{"state":"approved","breaking_total":3,"breaking_approved":3}}`))
 	}))
 	defer stub.Close()
 	// The authenticated upload targets the API base, not the site base.
@@ -371,7 +373,7 @@ func TestUploadAndOpen_AuthenticatedPath(t *testing.T) {
 
 	// The output carries the returned URL with the key in its #fragment and the
 	// gate state printed verbatim.
-	require.Contains(t, out.String(), "https://www.oasdiff.com/review/e/auth-1#k=")
+	require.Contains(t, out.String(), "https://review.example.test/review/ep/auth-1#k=", "the CLI appends #k= to the server-returned review_url verbatim")
 	require.Contains(t, out.String(), "oasdiff: review status: approved")
 	require.NotContains(t, out.String(), "should-not-be-used", "the authenticated path must not use the site base URL")
 

--- a/internal/open_review_unix_test.go
+++ b/internal/open_review_unix_test.go
@@ -404,3 +404,62 @@ func TestUploadAuthenticatedReview_UnreachableIsNonFatal(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "upload to")
 }
+
+func TestUploadAuthenticatedReview_InvalidJSONResponse(t *testing.T) {
+	// A 2xx whose body isn't the expected JSON must surface a parse error, not a
+	// bogus review URL.
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer stub.Close()
+	t.Setenv("OASDIFF_API_URL", stub.URL)
+
+	var out bytes.Buffer
+	err := uploadAuthenticatedReview("tok", nil, []byte{encryptedReviewBlobVersion, 1}, make([]byte, 32), checker.Changes{}, &out)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "parse response")
+	require.NotContains(t, out.String(), "Opening", "no URL is emitted when the response can't be parsed")
+}
+
+func TestUploadAuthenticatedReview_MissingReviewURL(t *testing.T) {
+	// A 2xx that omits review_url can't produce a usable link, so it must error
+	// rather than print a keyless or malformed URL.
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"review_token":"rt","gate":{"state":"pending"}}`))
+	}))
+	defer stub.Close()
+	t.Setenv("OASDIFF_API_URL", stub.URL)
+
+	var out bytes.Buffer
+	err := uploadAuthenticatedReview("tok", nil, []byte{encryptedReviewBlobVersion, 1}, make([]byte, 32), checker.Changes{}, &out)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "review_url")
+}
+
+func TestUploadAndOpen_ReadBaseSpecError(t *testing.T) {
+	// A missing base spec fails before any upload; the error must name the base.
+	flags := NewFlags()
+	flags.setBase(load.NewSource(filepath.Join(t.TempDir(), "does-not-exist.yaml")))
+	flags.setRevision(load.NewSource(filepath.Join(t.TempDir(), "also-missing.yaml")))
+
+	var out bytes.Buffer
+	err := uploadAndOpen(flags, &out, false, checker.Changes{}, nil, true)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "read base spec")
+}
+
+func TestUploadAndOpen_ReadRevisionSpecError(t *testing.T) {
+	// Base reads fine but the revision is missing: the error must name the revision.
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "openapi.yaml")
+	require.NoError(t, os.WriteFile(basePath, []byte("openapi: 3.0.0\n"), 0644))
+
+	flags := NewFlags()
+	flags.setBase(load.NewSource(basePath))
+	flags.setRevision(load.NewSource(filepath.Join(t.TempDir(), "missing.yaml")))
+
+	var out bytes.Buffer
+	err := uploadAndOpen(flags, &out, false, checker.Changes{}, nil, true)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "read revision spec")
+}

--- a/internal/run_test.go
+++ b/internal/run_test.go
@@ -56,6 +56,31 @@ func Test_OpenWithComposedRejected(t *testing.T) {
 	}
 }
 
+func Test_ReviewFlagsRequireOpen(t *testing.T) {
+	// --review-token / --review-meta only make sense with --open; using either
+	// without --open is rejected at argument validation before any diff runs.
+	for _, cmd := range []string{
+		"oasdiff changelog ../data/openapi-test1.yaml ../data/openapi-test1.yaml --review-token tok",
+		"oasdiff breaking ../data/openapi-test1.yaml ../data/openapi-test1.yaml --review-meta owner=acme",
+	} {
+		var stderr bytes.Buffer
+		require.Equal(t, 100, internal.Run(cmdToArgs(cmd), io.Discard, &stderr), cmd)
+		require.Contains(t, stderr.String(), "--review-token and --review-meta require --open", cmd)
+	}
+}
+
+func Test_ReviewFlagsAllowedWithOpen(t *testing.T) {
+	// With --open the review flags pass argument validation. Point the upload at a
+	// non-connectable API so no real network call happens; --open upload errors
+	// are additive (warned, non-fatal), so the exit code is the changelog result
+	// (0 for identical specs), never the 100 arg-validation code.
+	t.Setenv("OASDIFF_API_URL", "http://127.0.0.1:0")
+	var stderr bytes.Buffer
+	code := internal.Run(cmdToArgs("oasdiff changelog ../data/openapi-test1.yaml ../data/openapi-test1.yaml --open --review-token tok"), io.Discard, &stderr)
+	require.NotEqual(t, 100, code, "review flags with --open must pass argument validation")
+	require.NotContains(t, stderr.String(), "require --open")
+}
+
 func Test_BasicDiff(t *testing.T) {
 	var stdout bytes.Buffer
 	require.Zero(t, internal.Run(cmdToArgs("oasdiff diff ../data/openapi-test1.yaml ../data/openapi-test3.yaml --exclude-elements endpoints"), &stdout, io.Discard))


### PR DESCRIPTION
## What

Extends the existing `--open` flag so that when an auth token is supplied, oasdiff does an **authenticated** review upload instead of the free anonymous one. Same feature (`--open` shares a side-by-side review on oasdiff.com), richer when authenticated.

The free path is unchanged when no token is supplied: same endpoint, same zero-knowledge encrypted bundle, same key-in-`#fragment` URL.

## New flags (on `changelog` and `breaking`)

- `--review-token <string>` — an opaque auth token. **Its presence is the only switch**: with it, `--open` does the authenticated upload; without it, `--open` is unchanged.
- `--review-meta <key=value>` — repeatable. An opaque metadata bag, parsed by splitting each entry on the first `=` into a map. The CLI does not interpret any key names.

Both flags are command-line only (not config-file settable), consistent with `--open` itself, and the token is a credential that should never be committed.

## Behaviour when `--review-token` is set

1. Builds the **same** AES-256-GCM encrypted bundle and key as the free path.
2. Extracts a change manifest from the computed changes: one `{fingerprint, level}` per change, where fingerprint matches the value already embedded in the JSON changelog and level is the change severity as an int.
3. POSTs JSON `{ciphertext, metadata, changes}` to `<api-base>/tenants/<review-token>/encrypted-pr-review`. `ciphertext` is the raw blob (base64-encoded by `encoding/json`'s `[]byte` handling, same as the free path). The API base defaults to `https://api.oasdiff.com` and is overridable via `OASDIFF_API_URL` (mirroring the existing `OASDIFF_URL` override for the site base).
4. Parses `{review_token, review_url, gate}` and prints the final URL = `review_url` + the `#k=<key>` fragment (encoded identically to the free path).
5. Prints the returned status verbatim on a grep-friendly line: `oasdiff: review status: <state>`. The CLI does not branch on it.
6. Any non-2xx response or transport error warns and returns non-fatally, surfacing the server's error body, exactly mirroring the free path's additive error model.

## Tests

- `--review-meta` parsing (first-`=` split, malformed/empty-key handling, duplicates).
- `reviewManifest` produces a fingerprint + level per change.
- Authenticated upload against an `httptest.Server`: asserts method/path, JSON body shape (non-empty ciphertext, metadata map, changes), and that the printed output carries `review_url` + `#k=` fragment and the status; the fragment key decrypts the uploaded ciphertext.
- Free path still posts to the free endpoint when the token is empty (no regression).
- Server 4xx and unreachable host both warn non-fatally.

`go build ./...`, `go vet ./...`, and `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)