### PR TITLE
handlers: guard checkStdinWithComposed against an unregistered composed flag

### DIFF
--- a/internal/handlers.go
+++ b/internal/handlers.go
@@ -122,6 +122,14 @@ func checkOpenWithComposed(cmd *cobra.Command) error {
 
 func checkStdinWithComposed(cmd *cobra.Command, args []string) error {
 
+	// Every command using getParseArgs registers composed (via addCommonDiffFlags),
+	// but guard with Lookup so this check degrades gracefully instead of erroring
+	// with "failed to get composed flag" if it's ever run on a command without it.
+	// Same pattern as checkOpenWithComposed.
+	if cmd.Flags().Lookup("composed") == nil {
+		return nil
+	}
+
 	composed, err := cmd.Flags().GetBool("composed")
 	if err != nil {
 		return errors.New("failed to get composed flag")


### PR DESCRIPTION
`checkStdinWithComposed` reads `composed` via `GetBool` with no Lookup guard. `GetBool` returns an error for a flag that isn't registered, so the check is safe only because every command using `getParseArgs` (breaking, changelog, diff, summary) happens to register `composed` via `addCommonDiffFlags`. That's an implicit invariant, not a guarantee.

This adds a `Lookup("composed") == nil -> return nil` guard so the check degrades gracefully instead of failing with a confusing `failed to get composed flag` if `getParseArgs` is ever added to a command without `composed`. It mirrors the existing guard in `checkOpenWithComposed` (which guards the non-universal `open` flag the same way).

Defense-in-depth, no behavior change today. (`checkColor` already handles this gracefully by leading with `Changed`, which returns false for unregistered flags rather than erroring.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)