### PR TITLE
refactor(checker): rename SCREAMING_SNAKE_CASE stability constants to MixedCaps

### DIFF
--- a/checker/check_api_deprecation_test.go
+++ b/checker/check_api_deprecation_test.go
@@ -120,7 +120,7 @@ func TestBreaking_DeprecationForAlpha(t *testing.T) {
 func TestBreaking_DeprecationForDraft(t *testing.T) {
 	s1, err := open(deprecationFile("base-alpha-stability.yaml"))
 	require.NoError(t, err)
-	draft := toJson(t, checker.STABILITY_DRAFT)
+	draft := toJson(t, checker.StabilityDraft)
 	s1.Spec.Paths.Value("/api/test").Get.Extensions["x-stability-level"] = draft
 
 	s2, err := open(deprecationFile("deprecated-no-sunset-alpha-stability.yaml"))

--- a/checker/check_api_removed.go
+++ b/checker/check_api_removed.go
@@ -39,7 +39,7 @@ func checkRemovedPaths(pathsDiff *diff.PathsDiff, operationsSources *diff.Operat
 		for operation := range pathsDiff.Base.Value(path).Operations() {
 			op := pathsDiff.Base.Value(path).GetOperation(operation)
 			stability, err := getStabilityLevel(op.Extensions)
-			if err != nil || stability == STABILITY_ALPHA || stability == STABILITY_DRAFT {
+			if err != nil || stability == StabilityAlpha || stability == StabilityDraft {
 				continue
 			}
 

--- a/checker/check_api_removed_test.go
+++ b/checker/check_api_removed_test.go
@@ -99,7 +99,7 @@ func TestBreaking_DeprecationNoSunset(t *testing.T) {
 func TestBreaking_RemovedPathForAlpha(t *testing.T) {
 	s1, err := open(deprecationFile("base-alpha-stability.yaml"))
 	require.NoError(t, err)
-	alpha := toJson(t, checker.STABILITY_ALPHA)
+	alpha := toJson(t, checker.StabilityAlpha)
 	s1.Spec.Paths.Value("/api/test").Get.Extensions["x-stability-level"] = alpha
 	s1.Spec.Paths.Value("/api/test").Post.Extensions = map[string]any{"x-stability-level": alpha}
 
@@ -118,7 +118,7 @@ func TestBreaking_RemovedPathForAlpha(t *testing.T) {
 func TestBreaking_RemovedPathForDraft(t *testing.T) {
 	s1, err := open(deprecationFile("base-alpha-stability.yaml"))
 	require.NoError(t, err)
-	draft := toJson(t, checker.STABILITY_DRAFT)
+	draft := toJson(t, checker.StabilityDraft)
 	s1.Spec.Paths.Value("/api/test").Get.Extensions["x-stability-level"] = draft
 	s1.Spec.Paths.Value("/api/test").Post.Extensions = map[string]any{"x-stability-level": draft}
 

--- a/checker/check_api_stability_level.go
+++ b/checker/check_api_stability_level.go
@@ -190,10 +190,10 @@ func filterBelowStabilityThreshold(config *Config, diffReport *diff.Diff) {
 	}
 }
 
-// normalizedStability returns STABILITY_STABLE for an empty label, otherwise the label itself.
+// normalizedStability returns StabilityStable for an empty label, otherwise the label itself.
 func normalizedStability(label string) string {
 	if label == "" {
-		return STABILITY_STABLE
+		return StabilityStable
 	}
 	return label
 }
@@ -229,11 +229,11 @@ func getStabilityLevel(i map[string]any) (string, error) {
 		}
 	}
 
-	if stabilityLevel != STABILITY_DRAFT &&
-		stabilityLevel != STABILITY_ALPHA &&
-		stabilityLevel != STABILITY_BETA &&
-		stabilityLevel != STABILITY_STABLE {
-		return "", fmt.Errorf("value is not one of %s, %s, %s or %s: %q", STABILITY_DRAFT, STABILITY_ALPHA, STABILITY_BETA, STABILITY_STABLE, stabilityLevel)
+	if stabilityLevel != StabilityDraft &&
+		stabilityLevel != StabilityAlpha &&
+		stabilityLevel != StabilityBeta &&
+		stabilityLevel != StabilityStable {
+		return "", fmt.Errorf("value is not one of %s, %s, %s or %s: %q", StabilityDraft, StabilityAlpha, StabilityBeta, StabilityStable, stabilityLevel)
 	}
 
 	return stabilityLevel, nil

--- a/checker/check_api_sunset_changed.go
+++ b/checker/check_api_sunset_changed.go
@@ -97,21 +97,32 @@ func APISunsetChangedCheck(diffReport *diff.Diff, operationsSources *diff.Operat
 }
 
 const (
-	STABILITY_DRAFT  = "draft"
-	STABILITY_ALPHA  = "alpha"
-	STABILITY_BETA   = "beta"
-	STABILITY_STABLE = "stable"
+	StabilityDraft  = "draft"
+	StabilityAlpha  = "alpha"
+	StabilityBeta   = "beta"
+	StabilityStable = "stable"
+)
+
+const (
+	// Deprecated: use StabilityDraft.
+	STABILITY_DRAFT = StabilityDraft
+	// Deprecated: use StabilityAlpha.
+	STABILITY_ALPHA = StabilityAlpha
+	// Deprecated: use StabilityBeta.
+	STABILITY_BETA = StabilityBeta
+	// Deprecated: use StabilityStable.
+	STABILITY_STABLE = StabilityStable
 )
 
 func getDeprecationDays(config *Config, stability string) uint {
 	switch stability {
-	case STABILITY_DRAFT:
+	case StabilityDraft:
 		return 0
-	case STABILITY_ALPHA:
+	case StabilityAlpha:
 		return 0
-	case STABILITY_BETA:
+	case StabilityBeta:
 		return config.MinSunsetBetaDays
-	case STABILITY_STABLE:
+	case StabilityStable:
 		return config.MinSunsetStableDays
 	default:
 		return config.MinSunsetStableDays

--- a/checker/stability_level.go
+++ b/checker/stability_level.go
@@ -24,13 +24,13 @@ const DefaultStabilityLevel = StabilityLevelBeta
 // An empty string is treated as stable (implicit stable).
 func ParseStabilityLevel(s string) StabilityLevel {
 	switch s {
-	case STABILITY_DRAFT:
+	case StabilityDraft:
 		return StabilityLevelDraft
-	case STABILITY_ALPHA:
+	case StabilityAlpha:
 		return StabilityLevelAlpha
-	case STABILITY_BETA:
+	case StabilityBeta:
 		return StabilityLevelBeta
-	case STABILITY_STABLE:
+	case StabilityStable:
 		return StabilityLevelStable
 	default:
 		// empty string or unknown → treat as stable
@@ -48,5 +48,5 @@ func (sl StabilityLevel) IsIncluded(stability string) bool {
 
 // GetSupportedStabilityLevels returns the list of valid stability level strings.
 func GetSupportedStabilityLevels() []string {
-	return []string{STABILITY_DRAFT, STABILITY_ALPHA, STABILITY_BETA, STABILITY_STABLE}
+	return []string{StabilityDraft, StabilityAlpha, StabilityBeta, StabilityStable}
 }


### PR DESCRIPTION
Closes #1031.

`STABILITY_DRAFT` / `STABILITY_ALPHA` / `STABILITY_BETA` / `STABILITY_STABLE` use a C/Python casing convention, not Go (which uses MixedCaps). staticcheck flags this as ST1003.

## Change

- Renamed the canonical constants to `StabilityDraft` / `StabilityAlpha` / `StabilityBeta` / `StabilityStable` and migrated all internal usages.
- The values (`"draft"`, `"alpha"`, `"beta"`, `"stable"`) are unchanged, so there is no CLI or serialized behavior change.
- The old names are kept as `// Deprecated:` aliases, since they are exported and a library consumer may reference them. They can be dropped in a future major release.

## Scope

A repo-wide scan confirmed these four were the only SCREAMING_SNAKE_CASE Go identifiers. Environment-variable name strings (`OASDIFF_CONFIG`, `GITHUB_OUTPUT`, etc.) and `os.O_*` flags are correctly cased and out of scope.

Build, `go vet`, `gofmt`, and the full test suite pass.