### PR TITLE
test(checker): add rule-symmetry guard over the taxonomy

### DIFF
--- a/checker/rule_symmetry_test.go
+++ b/checker/rule_symmetry_test.go
@@ -1,0 +1,209 @@
+package checker_test
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/oasdiff/oasdiff/checker"
+)
+
+// This file audits the rule registry (GetAllRules) for broken symmetries on
+// the Direction/Area/Kind/Action taxonomy: a coordinate populated on one side
+// of a symmetry axis but empty on the mirror. Each such absence is either a
+// real missing check or an intentional asymmetry (the mirror is not a
+// wire-contract change, e.g. by request/response contravariance).
+//
+// TestRuleSymmetry is the guard: every absence must be listed in symmetryWaivers
+// with a reason, otherwise the test fails. A new rule that breaks symmetry, or a
+// waiver that no longer applies, both fail the build, so the waiver list stays an
+// honest, reviewed record of every intentional asymmetry.
+//
+// TestRuleSymmetryReport is informational (count mismatches that contravariance
+// makes legitimate); run with: go test ./checker -run RuleSymmetryReport -v
+
+// symmetryWaivers records every intentional asymmetry. Key is the canonical
+// absence string emitted by symmetryAbsences; value is why it is acceptable.
+// Removing a real check, or adding one that fills a gap, must update this map.
+var symmetryWaivers = map[string]string{
+	// --- request <-> response (bidirectional areas only) ---
+	"request<->response schema/type/generalize missing-response":        "response type generalization is the breaking direction (a wider returned type can break clients); it is reported by response-property-type-changed (ERR). The safe response direction is specialization. Granularity asymmetry tracked in #1034.",
+	"request<->response schema/constraints/generalize missing-response": "response pattern generalization is breaking and reported by response-property-pattern-changed; the safe response direction is specialization. Tracked in #1034.",
+	"request<->response schema/constraints/set missing-response":        "setting a constraint on a response narrows the server's output, which is non-breaking for clients, so it is request-only by contravariance (request reports the constraint as newly enforced).",
+
+	// --- add <-> remove (same direction/area/kind) ---
+	"add<->remove none/paths/lifecycle missing-add": "a sunset date being added is part of the deprecation flow and is reported by the deprecation rules; only its removal (sunset-deleted) is a standalone change.",
+
+	// --- generalize <-> specialize (same direction/area/kind) ---
+	"generalize<->specialize request/schema/type missing-specialize":            "narrowing a request type is breaking and already reported by request-*-type-changed (ERR); the generalize rule exists only to carve out the safe widening as INFO.",
+	"generalize<->specialize request/schema/constraints missing-specialize":     "tightening a request pattern is reported by request-*-pattern-changed; the generalize rule carves out the safe loosening.",
+	"generalize<->specialize request/parameters/constraints missing-specialize": "same as request schema pattern: tightening is covered by request-parameter-pattern-changed; generalize carves out the safe loosening.",
+
+	// --- KNOWN GAP, tracked (not intentional) ---
+	"add<->remove response/headers/existence missing-add": "GAP tracked in #1033: adding a response header has no rule, only removal. Remove this waiver when response-header-added lands.",
+}
+
+// symmetryAbsences returns the canonical key for every coordinate that is
+// populated on one side of a symmetry axis but completely empty on the mirror.
+// Count mismatches (both sides populated) are intentionally excluded: by
+// request/response contravariance the counts legitimately differ.
+func symmetryAbsences(rules checker.BackwardCompatibilityRules) []string {
+	var out []string
+
+	// Axis 1: request <-> response, restricted to Areas that appear in both
+	// directions (parameters/request-body are request-only, responses/headers
+	// response-only, so their missing mirror is structural, not a gap).
+	reqAreas, respAreas := map[checker.Area]bool{}, map[checker.Area]bool{}
+	for _, r := range rules {
+		switch r.Direction {
+		case checker.DirectionRequest:
+			reqAreas[r.Area] = true
+		case checker.DirectionResponse:
+			respAreas[r.Area] = true
+		}
+	}
+	type aka struct {
+		Area   checker.Area
+		Kind   checker.Kind
+		Action checker.Action
+	}
+	req, resp := map[aka]bool{}, map[aka]bool{}
+	for _, r := range rules {
+		if !(reqAreas[r.Area] && respAreas[r.Area]) {
+			continue
+		}
+		k := aka{r.Area, r.Kind, r.Action}
+		switch r.Direction {
+		case checker.DirectionRequest:
+			req[k] = true
+		case checker.DirectionResponse:
+			resp[k] = true
+		}
+	}
+	for k := range req {
+		if !resp[k] {
+			out = append(out, fmt.Sprintf("request<->response %s/%s/%s missing-response", k.Area.String(), k.Kind.String(), k.Action.String()))
+		}
+	}
+	for k := range resp {
+		if !req[k] {
+			out = append(out, fmt.Sprintf("request<->response %s/%s/%s missing-request", k.Area.String(), k.Kind.String(), k.Action.String()))
+		}
+	}
+
+	// Axis 2: dual action pairs within the same Direction/Area/Kind.
+	pairs := [][2]checker.Action{
+		{checker.ActionAdd, checker.ActionRemove},
+		{checker.ActionIncrease, checker.ActionDecrease},
+		{checker.ActionGeneralize, checker.ActionSpecialize},
+	}
+	type dak struct {
+		Direction checker.Direction
+		Area      checker.Area
+		Kind      checker.Kind
+		Action    checker.Action
+	}
+	present := map[dak]bool{}
+	for _, r := range rules {
+		present[dak{r.Direction, r.Area, r.Kind, r.Action}] = true
+	}
+	for _, p := range pairs {
+		coords := map[dak]bool{}
+		for k := range present {
+			if k.Action == p[0] || k.Action == p[1] {
+				coords[dak{k.Direction, k.Area, k.Kind, 0}] = true
+			}
+		}
+		for c := range coords {
+			has0 := present[dak{c.Direction, c.Area, c.Kind, p[0]}]
+			has1 := present[dak{c.Direction, c.Area, c.Kind, p[1]}]
+			coord := fmt.Sprintf("%s/%s/%s", c.Direction.String(), c.Area.String(), c.Kind.String())
+			if has0 && !has1 {
+				out = append(out, fmt.Sprintf("%s<->%s %s missing-%s", p[0].String(), p[1].String(), coord, p[1].String()))
+			} else if has1 && !has0 {
+				out = append(out, fmt.Sprintf("%s<->%s %s missing-%s", p[0].String(), p[1].String(), coord, p[0].String()))
+			}
+		}
+	}
+
+	sort.Strings(out)
+	return out
+}
+
+func TestRuleSymmetry(t *testing.T) {
+	absences := symmetryAbsences(checker.GetAllRules())
+
+	absent := map[string]bool{}
+	for _, a := range absences {
+		absent[a] = true
+		if _, ok := symmetryWaivers[a]; !ok {
+			t.Errorf("unwaived rule asymmetry: %q\n  fix it by adding the mirror rule, or document it in symmetryWaivers with a reason", a)
+		}
+	}
+	for w := range symmetryWaivers {
+		if !absent[w] {
+			t.Errorf("stale symmetry waiver: %q\n  this asymmetry no longer exists; remove the waiver", w)
+		}
+	}
+}
+
+// --- informational report (not asserted) ---
+
+func TestRuleSymmetryReport(t *testing.T) {
+	rules := checker.GetAllRules()
+	t.Logf("total rules: %d", len(rules))
+
+	reqAreas, respAreas := map[checker.Area]bool{}, map[checker.Area]bool{}
+	for _, r := range rules {
+		switch r.Direction {
+		case checker.DirectionRequest:
+			reqAreas[r.Area] = true
+		case checker.DirectionResponse:
+			respAreas[r.Area] = true
+		}
+	}
+	type key struct {
+		Area   checker.Area
+		Kind   checker.Kind
+		Action checker.Action
+	}
+	req, resp := map[key][]string{}, map[key][]string{}
+	for _, r := range rules {
+		if !(reqAreas[r.Area] && respAreas[r.Area]) {
+			continue
+		}
+		k := key{r.Area, r.Kind, r.Action}
+		switch r.Direction {
+		case checker.DirectionRequest:
+			req[k] = append(req[k], r.Id)
+		case checker.DirectionResponse:
+			resp[k] = append(resp[k], r.Id)
+		}
+	}
+	seen := map[key]bool{}
+	var keys []key
+	for k := range req {
+		keys, seen[k] = append(keys, k), true
+	}
+	for k := range resp {
+		if !seen[k] {
+			keys = append(keys, k)
+		}
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		a, b := keys[i], keys[j]
+		if a.Area != b.Area {
+			return a.Area < b.Area
+		}
+		if a.Kind != b.Kind {
+			return a.Kind < b.Kind
+		}
+		return a.Action < b.Action
+	})
+	t.Log("=== request vs response count mismatches (contravariance expected) ===")
+	for _, k := range keys {
+		if len(req[k]) > 0 && len(resp[k]) > 0 && len(req[k]) != len(resp[k]) {
+			t.Logf("  %d req / %d resp [%s/%s/%s]", len(req[k]), len(resp[k]), k.Area.String(), k.Kind.String(), k.Action.String())
+		}
+	}
+}

--- a/checker/rules.go
+++ b/checker/rules.go
@@ -59,6 +59,88 @@ const (
 	ActionNone
 )
 
+func (d Direction) String() string {
+	switch d {
+	case DirectionRequest:
+		return "request"
+	case DirectionResponse:
+		return "response"
+	default:
+		return "none"
+	}
+}
+
+func (a Area) String() string {
+	switch a {
+	case AreaSchema:
+		return "schema"
+	case AreaParameters:
+		return "parameters"
+	case AreaRequestBody:
+		return "requestBody"
+	case AreaResponses:
+		return "responses"
+	case AreaPaths:
+		return "paths"
+	case AreaHeaders:
+		return "headers"
+	case AreaSecurity:
+		return "security"
+	case AreaTags:
+		return "tags"
+	case AreaComponents:
+		return "components"
+	default:
+		return "none"
+	}
+}
+
+func (k Kind) String() string {
+	switch k {
+	case KindExistence:
+		return "existence"
+	case KindRequiredness:
+		return "requiredness"
+	case KindMutability:
+		return "mutability"
+	case KindType:
+		return "type"
+	case KindConstraints:
+		return "constraints"
+	case KindValues:
+		return "values"
+	case KindStructure:
+		return "structure"
+	case KindLifecycle:
+		return "lifecycle"
+	default:
+		return "none"
+	}
+}
+
+func (a Action) String() string {
+	switch a {
+	case ActionAdd:
+		return "add"
+	case ActionRemove:
+		return "remove"
+	case ActionChange:
+		return "change"
+	case ActionGeneralize:
+		return "generalize"
+	case ActionSpecialize:
+		return "specialize"
+	case ActionIncrease:
+		return "increase"
+	case ActionDecrease:
+		return "decrease"
+	case ActionSet:
+		return "set"
+	default:
+		return "none"
+	}
+}
+
 type BackwardCompatibilityRule struct {
 	Id          string
 	Level       Level

--- a/internal/checks.go
+++ b/internal/checks.go
@@ -36,88 +36,6 @@ func runChecks(flags *Flags, stdout io.Writer) (bool, *ReturnError) {
 	return false, outputChecks(stdout, flags, checker.GetAllRules())
 }
 
-func directionString(d checker.Direction) string {
-	switch d {
-	case checker.DirectionRequest:
-		return "request"
-	case checker.DirectionResponse:
-		return "response"
-	default:
-		return "none"
-	}
-}
-
-func areaString(a checker.Area) string {
-	switch a {
-	case checker.AreaSchema:
-		return "schema"
-	case checker.AreaParameters:
-		return "parameters"
-	case checker.AreaRequestBody:
-		return "requestBody"
-	case checker.AreaResponses:
-		return "responses"
-	case checker.AreaPaths:
-		return "paths"
-	case checker.AreaHeaders:
-		return "headers"
-	case checker.AreaSecurity:
-		return "security"
-	case checker.AreaTags:
-		return "tags"
-	case checker.AreaComponents:
-		return "components"
-	default:
-		return "none"
-	}
-}
-
-func kindString(k checker.Kind) string {
-	switch k {
-	case checker.KindExistence:
-		return "existence"
-	case checker.KindRequiredness:
-		return "requiredness"
-	case checker.KindMutability:
-		return "mutability"
-	case checker.KindType:
-		return "type"
-	case checker.KindConstraints:
-		return "constraints"
-	case checker.KindValues:
-		return "values"
-	case checker.KindStructure:
-		return "structure"
-	case checker.KindLifecycle:
-		return "lifecycle"
-	default:
-		return "none"
-	}
-}
-
-func actionString(a checker.Action) string {
-	switch a {
-	case checker.ActionAdd:
-		return "add"
-	case checker.ActionRemove:
-		return "remove"
-	case checker.ActionChange:
-		return "change"
-	case checker.ActionGeneralize:
-		return "generalize"
-	case checker.ActionSpecialize:
-		return "specialize"
-	case checker.ActionIncrease:
-		return "increase"
-	case checker.ActionDecrease:
-		return "decrease"
-	case checker.ActionSet:
-		return "set"
-	default:
-		return "none"
-	}
-}
-
 func outputChecks(stdout io.Writer, flags *Flags, rules []checker.BackwardCompatibilityRule) *ReturnError {
 
 	format := flags.getFormat()
@@ -163,10 +81,10 @@ func outputChecks(stdout io.Writer, flags *Flags, rules []checker.BackwardCompat
 		checks = append(checks, formatters.Check{
 			Id:          rule.Id,
 			Level:       rule.Level.String(),
-			Direction:   directionString(rule.Direction),
-			Area:        areaString(rule.Area),
-			Kind:        kindString(rule.Kind),
-			Action:      actionString(rule.Action),
+			Direction:   rule.Direction.String(),
+			Area:        rule.Area.String(),
+			Kind:        rule.Kind.String(),
+			Action:      rule.Action.String(),
 			Description: localizer(rule.Description),
 			Mitigation:  mitigation,
 		})


### PR DESCRIPTION
Adds `TestRuleSymmetry`, a guard that audits `GetAllRules()` for broken symmetries on the Direction/Area/Kind/Action taxonomy: a coordinate populated on one side of a symmetry axis but empty on the mirror.

## Axes checked

- **request ↔ response**, restricted to Areas present in both directions (parameters/request-body are request-only, responses/headers response-only, so their missing mirror is structural).
- **action duals** within the same Direction/Area/Kind: add/remove, increase/decrease, generalize/specialize.

## How it stays honest

Every absence must appear in `symmetryWaivers` with a reason. An unwaived asymmetry (a new rule that breaks symmetry) **and** a stale waiver (an asymmetry that no longer exists) both fail the test. So the waiver list is a reviewed, self-cleaning record of every intentional asymmetry, most of which are request/response contravariance: each side implements its breaking direction and omits the non-breaking mirror.

Count mismatches (both sides populated, different counts) are reported informationally (`TestRuleSymmetryReport`, run with `-v`) rather than asserted, since contravariance makes the counts legitimately differ.

## Taxonomy String() consolidation

The mapping from Direction/Area/Kind/Action to strings previously lived as four unexported functions in `internal/checks.go`. This moves it onto the types as `String()` methods (consistent with the existing `Level.String()`), so it lives once where the types are defined. `internal/checks.go` now calls them and the guard uses them too. The `checks` command output is unchanged.

## Gaps surfaced

The audit found two genuine candidates, filed separately:
- #1033: adding a response header is not reported (only removal is).
- #1034: response property type/pattern changes lack the generalize/specialize granularity that request and response media-type have.

The waiver for #1033 is marked as a tracked gap (not intentional) and should be removed when `response-header-added` lands.