### PR TITLE
ci: add github-actions ecosystem to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Dependabot was configured for `gomod` only, so GitHub Actions versions drifted (e.g. `actions/checkout` behind latest). Adds a `github-actions` update (weekly, grouped).