### PR TITLE
Fix phantom security-scope diff for OR-alternatives sharing one scheme

### DIFF
--- a/data/security-requirements/or_alternatives.yaml
+++ b/data/security-requirements/or_alternatives.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.0
+info:
+  title: Security Requirement Example
+  version: 1.0.0
+paths:
+  /pets/{petId}:
+    get:
+      operationId: getPet
+      security:
+      - petstore_auth:
+        - read:pets
+      - petstore_auth:
+        - write:pets
+      - petstore_auth:
+        - admin:pets
+      responses:
+        "200":
+          description: OK
+components:
+  securitySchemes:
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: http://example.org/api/oauth/dialog
+          scopes:
+            read:pets: read your pets
+            write:pets: modify pets in your account
+            admin:pets: administer pets

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -1081,3 +1081,66 @@ func TestGetPathsDiff_WithSinceDate(t *testing.T) {
 	require.Nil(t, d)
 	require.Nil(t, osm)
 }
+
+// Regression test: OR-alternatives that share a security scheme (e.g.
+// `- petstore_auth: [read:pets]` / `- petstore_auth: [write:pets]`) must not
+// produce a phantom diff when a spec is compared against itself.
+func TestDiff_SharedSchemeORAlternativesNoPhantomDiff(t *testing.T) {
+	loader := openapi3.NewLoader()
+	s, err := loader.LoadFromFile("../data/security-requirements/or_alternatives.yaml")
+	require.NoError(t, err)
+	d, err := diff.Get(diff.NewConfig(), s, s)
+	require.NoError(t, err)
+	require.Nil(t, d)
+}
+
+// An in-place scope change to a single OR-alternative is reported as a scope modification.
+func TestDiff_SharedSchemeORAlternativesScopeModified(t *testing.T) {
+	// Separate loaders: a single loader caches by file path and returns the same
+	// *openapi3.T for both calls, so mutating s2 would also mutate s1.
+	s1, err := openapi3.NewLoader().LoadFromFile("../data/security-requirements/or_alternatives.yaml")
+	require.NoError(t, err)
+	s2, err := openapi3.NewLoader().LoadFromFile("../data/security-requirements/or_alternatives.yaml")
+	require.NoError(t, err)
+
+	security := *s2.Paths.Find("/pets/{petId}").Get.Security
+	last := len(security) - 1
+	security[last]["petstore_auth"] = append(security[last]["petstore_auth"], "list:pets")
+
+	d, err := diff.Get(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	require.NotNil(t, d)
+	securityDiff := d.PathsDiff.Modified["/pets/{petId}"].OperationsDiff.Modified["GET"].SecurityDiff
+	require.NotNil(t, securityDiff)
+	scopesDiff := securityDiff.Modified["petstore_auth"]
+	require.NotNil(t, scopesDiff["petstore_auth"])
+	require.Equal(t, []string{"list:pets"}, scopesDiff["petstore_auth"].Added)
+	require.Empty(t, scopesDiff["petstore_auth"].Deleted)
+}
+
+// When more than one same-scheme alternative changes, pairing is ambiguous, so the
+// changes are reported as deleted/added alternatives rather than silently dropped.
+func TestDiff_SharedSchemeAmbiguousModificationNotDropped(t *testing.T) {
+	s1, err := openapi3.NewLoader().LoadFromFile("../data/security-requirements/or_alternatives.yaml")
+	require.NoError(t, err)
+	s1.Paths.Find("/pets/{petId}").Get.Security = &openapi3.SecurityRequirements{
+		{"petstore_auth": []string{"read:pets"}},
+		{"petstore_auth": []string{"write:pets"}},
+	}
+
+	s2, err := openapi3.NewLoader().LoadFromFile("../data/security-requirements/or_alternatives.yaml")
+	require.NoError(t, err)
+	s2.Paths.Find("/pets/{petId}").Get.Security = &openapi3.SecurityRequirements{
+		{"petstore_auth": []string{"read:pets", "list:pets"}},
+		{"petstore_auth": []string{"write:pets", "delete:pets"}},
+	}
+
+	d, err := diff.Get(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	require.NotNil(t, d)
+	securityDiff := d.PathsDiff.Modified["/pets/{petId}"].OperationsDiff.Modified["GET"].SecurityDiff
+	require.NotNil(t, securityDiff)
+	require.Len(t, securityDiff.Deleted, 2)
+	require.Len(t, securityDiff.Added, 2)
+	require.Empty(t, securityDiff.Modified)
+}

--- a/diff/security_requirements_diff.go
+++ b/diff/security_requirements_diff.go
@@ -52,42 +52,98 @@ func getSecurityRequirementsDiffInternal(securityRequirements1, securityRequirem
 
 	result := newSecurityRequirementsDiff()
 
-	if securityRequirements1 != nil {
-		for _, securityRequirement1 := range *securityRequirements1 {
-			if securityRequirement2 := findSecurityRequirement(securityRequirement1, securityRequirements2); securityRequirement2 != nil {
-				if securityScopesDiff := getSecurityScopesDiff(securityRequirement1, securityRequirement2); !securityScopesDiff.Empty() {
-					result.Modified[getSecurityRequirementID(securityRequirement1)] = securityScopesDiff
-				}
-			} else {
-				result.Deleted = append(result.Deleted, getSecurityRequirementID(securityRequirement1))
-			}
+	// Security requirements are an unordered set of OR-alternatives, and several
+	// alternatives may share a scheme (e.g. `- petstore_auth: [read:pets]` /
+	// `- petstore_auth: [write:pets]`), so they cannot be matched by scheme name alone.
+	reqs1 := derefSecurityRequirements(securityRequirements1)
+	reqs2 := derefSecurityRequirements(securityRequirements2)
+	matched1 := make([]bool, len(reqs1))
+	matched2 := make([]bool, len(reqs2))
+
+	// Match unchanged alternatives (same schemes and scopes) so they don't participate in scope diffing.
+	for i := range reqs1 {
+		if j := findSecurityRequirementIndex(reqs1[i], reqs2, matched2, true); j >= 0 {
+			matched1[i] = true
+			matched2[j] = true
 		}
 	}
 
-	if securityRequirements2 != nil {
-		for _, securityRequirement2 := range *securityRequirements2 {
-			if securityRequirements1 := findSecurityRequirement(securityRequirement2, securityRequirements1); securityRequirements1 == nil {
-				result.Added = append(result.Added, getSecurityRequirementID(securityRequirement2))
-			}
+	// Report a leftover as a scope modification only when its scheme set is unambiguous:
+	// exactly one unmatched alternative with that scheme set on each side. Otherwise any
+	// pairing is arbitrary, so the alternatives fall through to deleted/added below.
+	for i := range reqs1 {
+		if matched1[i] || !uniqueUnmatchedBySchemes(reqs1, matched1, getSecuritySchemes(reqs1[i])) {
+			continue
+		}
+		j := findSecurityRequirementIndex(reqs1[i], reqs2, matched2, false)
+		if j < 0 || !uniqueUnmatchedBySchemes(reqs2, matched2, getSecuritySchemes(reqs2[j])) {
+			continue
+		}
+		matched1[i] = true
+		matched2[j] = true
+		if securityScopesDiff := getSecurityScopesDiff(reqs1[i], reqs2[j]); !securityScopesDiff.Empty() {
+			result.Modified[getSecurityRequirementID(reqs1[i])] = securityScopesDiff
+		}
+	}
+
+	for i := range reqs1 {
+		if !matched1[i] {
+			result.Deleted = append(result.Deleted, getSecurityRequirementID(reqs1[i]))
+		}
+	}
+	for j := range reqs2 {
+		if !matched2[j] {
+			result.Added = append(result.Added, getSecurityRequirementID(reqs2[j]))
 		}
 	}
 
 	return result
 }
 
-func findSecurityRequirement(securityRequirement1 openapi3.SecurityRequirement, securityRequirements2 *openapi3.SecurityRequirements) openapi3.SecurityRequirement {
-	if securityRequirements2 == nil {
+func derefSecurityRequirements(securityRequirements *openapi3.SecurityRequirements) []openapi3.SecurityRequirement {
+	if securityRequirements == nil {
 		return nil
 	}
+	return *securityRequirements
+}
 
-	securitySchemes1 := getSecuritySchemes(securityRequirement1)
-	for _, securityRequirement2 := range *securityRequirements2 {
-		securitySchemes2 := getSecuritySchemes(securityRequirement2)
-		if securitySchemes1.Equals(securitySchemes2) {
-			return securityRequirement2
+// findSecurityRequirementIndex returns the index of the first unmatched
+// requirement in candidates that matches securityRequirement, or -1 if none.
+// When exact is true the scopes must match too; otherwise only the set of
+// scheme names must match.
+func findSecurityRequirementIndex(securityRequirement openapi3.SecurityRequirement, candidates []openapi3.SecurityRequirement, matched []bool, exact bool) int {
+	schemes := getSecuritySchemes(securityRequirement)
+	for j, candidate := range candidates {
+		if matched[j] {
+			continue
+		}
+		if !schemes.Equals(getSecuritySchemes(candidate)) {
+			continue
+		}
+		if exact && !getSecurityScopesDiff(securityRequirement, candidate).Empty() {
+			continue
+		}
+		return j
+	}
+	return -1
+}
+
+// uniqueUnmatchedBySchemes reports whether exactly one unmatched requirement in
+// reqs has the given set of scheme names.
+func uniqueUnmatchedBySchemes(reqs []openapi3.SecurityRequirement, matched []bool, schemes utils.StringSet) bool {
+	count := 0
+	for i := range reqs {
+		if matched[i] {
+			continue
+		}
+		if schemes.Equals(getSecuritySchemes(reqs[i])) {
+			count++
+			if count > 1 {
+				return false
+			}
 		}
 	}
-	return nil
+	return count == 1
 }
 
 func getSecuritySchemes(securityRequirement openapi3.SecurityRequirement) utils.StringSet {
@@ -99,7 +155,7 @@ func getSecuritySchemes(securityRequirement openapi3.SecurityRequirement) utils.
 }
 
 func getSecurityRequirementID(securityRequirement openapi3.SecurityRequirement) string {
-	return strings.Join(slices.Collect(maps.Keys(securityRequirement)), " AND ")
+	return strings.Join(slices.Sorted(maps.Keys(securityRequirement)), " AND ")
 }
 
 func (diff *SecurityRequirementsDiff) getSummary() *SummaryDetails {


### PR DESCRIPTION
> [!IMPORTANT]
> **Note:** This PR was generated with AI assistance.
>
> I'm not familiar with this codebase and don't write Go, so this isn't intended to be merged as-is. It's meant as a **working, tested example** that demonstrates the bug and one possible fix, please treat it as a starting point rather than a merge candidate. I mainly want to surface the issue and the reproduction; the maintainers will know the right way to solve it.

Fixes #1041

## Problem

When an operation expresses "any one of these scopes grants access" by listing the **same security scheme** in multiple OR-alternatives, `oasdiff` reports a phantom `api-security-scope-added` / `api-security-scope-removed` pair — **even when diffing a spec against an identical copy of itself**. The result is deterministic and appears on every diff, polluting changelogs.

A list of Security Requirement Objects is an **OR**. Per [the OpenAPI Specification](https://spec.openapis.org/oas/v3.1.0#fixed-fields-7):

> A declaration of which security mechanisms can be used for this operation. The list of values includes **alternative** security requirement objects that can be used. **Only one of the security requirement objects need to be satisfied to authorize a request.**

Because the scopes listed together *within a single* requirement are AND-ed, the only way to express "scope `read:pets` OR scope `write:pets`" is to repeat the scheme across alternatives — exactly the pattern that triggers this bug.

### Reproduction

`spec.yaml`:

```yaml
openapi: 3.0.0
info:
  title: Repro
  version: 1.0.0
paths:
  /pets/{petId}:
    get:
      operationId: getPet
      security:
        - petstore_auth: [read:pets]
        - petstore_auth: [write:pets]
      responses:
        '200':
          description: OK
components:
  securitySchemes:
    petstore_auth:
      type: oauth2
      flows:
        implicit:
          authorizationUrl: http://example.org/api/oauth/dialog
          scopes:
            read:pets: read your pets
            write:pets: modify pets in your account
```

```console
$ cp spec.yaml spec_copy.yaml
$ oasdiff changelog spec.yaml spec_copy.yaml
2 changes: 0 error, 0 warning, 2 info
info	[api-security-scope-added] at spec_copy.yaml
	in API GET /pets/{petId}
		the security scope `read:pets` was added to the endpoint's security scheme `petstore_auth`

info	[api-security-scope-removed] at spec_copy.yaml
	in API GET /pets/{petId}
		the security scope `write:pets` was removed from the endpoint's security scheme `petstore_auth`
```

Expected: `No changes detected`.

## Root cause

In `diff/security_requirements_diff.go`, security requirements were matched **by the set of scheme names only** (returning the first match), and the per-scheme scope diff was stored in `Modified` keyed by scheme name. When several alternatives share a scheme (`petstore_auth`), every alternative matched the *first* `petstore_auth` entry and they all collapsed onto a single `Modified` key — the last write winning. The reported diff was effectively `getStringsDiff(lastScopeOf(base), firstScopeOf(revision))`, which is non-empty whenever the alternatives differ, including for identical specs.

## Fix

Treat the security requirements list as an unordered set of OR-alternatives:

1. Match unchanged alternatives by full content (scheme **and** scopes) first, so shared-scheme alternatives are not mis-paired.
2. Report a leftover as a scope **modification** only when its scheme set is unambiguous — exactly one unmatched alternative with that scheme set on each side. Otherwise the pairing would be arbitrary, so report whole alternatives as added/deleted instead of silently collapsing onto one scheme-keyed entry.

Also sorts the scheme names in the requirement ID so multi-scheme (AND) identifiers are deterministic.

## Tests

Added regression tests in `diff/diff_test.go` (fixture `data/security-requirements/or_alternatives.yaml`):

- shared-scheme OR-alternatives diffed against themselves report no changes;
- an in-place scope change to a single alternative is still reported as a scope modification;
- when multiple same-scheme alternatives change, the changes are reported as added/deleted alternatives rather than silently dropped.

The full existing suite passes.
