### PR TITLE
fix: phantom security-scope diff for OR-alternatives sharing one scheme (#1041)

### DIFF
--- a/data/security-requirements/or_alternatives.yaml
+++ b/data/security-requirements/or_alternatives.yaml
@@ -1,0 +1,31 @@
+openapi: 3.0.0
+info:
+  title: Security Requirement Example
+  version: 1.0.0
+paths:
+  /pets/{petId}:
+    get:
+      operationId: getPet
+      # OR of scopes: the caller needs read OR write OR admin (same scheme,
+      # three alternatives, the only way to express an OR of OAuth2 scopes).
+      security:
+      - petstore_auth:
+        - read:pets
+      - petstore_auth:
+        - write:pets
+      - petstore_auth:
+        - admin:pets
+      responses:
+        "200":
+          description: OK
+components:
+  securitySchemes:
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: http://example.org/api/oauth/dialog
+          scopes:
+            read:pets: read your pets
+            write:pets: modify pets in your account
+            admin:pets: administer pets

--- a/data/security-requirements/or_alternatives_scope_added.yaml
+++ b/data/security-requirements/or_alternatives_scope_added.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.0
+info:
+  title: Security Requirement Example
+  version: 1.0.0
+paths:
+  /pets/{petId}:
+    get:
+      operationId: getPet
+      # OR of scopes: the caller needs read OR write OR admin (same scheme,
+      # three alternatives, the only way to express an OR of OAuth2 scopes).
+      security:
+      - petstore_auth:
+        - read:pets
+        - list:pets
+      - petstore_auth:
+        - write:pets
+      - petstore_auth:
+        - admin:pets
+      responses:
+        "200":
+          description: OK
+components:
+  securitySchemes:
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: http://example.org/api/oauth/dialog
+          scopes:
+            read:pets: read your pets
+            list:pets: list your pets
+            write:pets: modify pets in your account
+            admin:pets: administer pets

--- a/data/security-requirements/or_alternatives_two.yaml
+++ b/data/security-requirements/or_alternatives_two.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.0
+info:
+  title: Security Requirement Example
+  version: 1.0.0
+paths:
+  /pets/{petId}:
+    get:
+      operationId: getPet
+      security:
+      - petstore_auth:
+        - read:pets
+      - petstore_auth:
+        - write:pets
+      responses:
+        "200":
+          description: OK
+components:
+  securitySchemes:
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: http://example.org/api/oauth/dialog
+          scopes:
+            read:pets: read your pets
+            write:pets: modify pets in your account
+            admin:pets: administer pets

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -1081,3 +1081,52 @@ func TestGetPathsDiff_WithSinceDate(t *testing.T) {
 	require.Nil(t, d)
 	require.Nil(t, osm)
 }
+
+// Regression for #1041: OR-alternatives that share a security scheme (the only
+// way to express "scope A OR scope B" for one OAuth2 scheme) were matched by
+// scheme name alone, inventing a phantom scope add/remove, even on a spec
+// compared against a copy of itself. A spec must diff clean against itself.
+func TestDiff_SharedSchemeORAlternatives_NoPhantomOnSelf(t *testing.T) {
+	loader := openapi3.NewLoader()
+	s, err := loader.LoadFromFile("../data/security-requirements/or_alternatives.yaml")
+	require.NoError(t, err)
+	d, err := diff.Get(diff.NewConfig(), s, s)
+	require.NoError(t, err)
+	require.Nil(t, d)
+}
+
+// A scope added to one shared-scheme OR-alternative is still reported as a scope
+// modification: the unambiguous case must not regress while the phantom is fixed.
+func TestDiff_SharedSchemeORAlternatives_ScopeAddedStillReported(t *testing.T) {
+	loader := openapi3.NewLoader()
+	base, err := loader.LoadFromFile("../data/security-requirements/or_alternatives.yaml")
+	require.NoError(t, err)
+	added, err := loader.LoadFromFile("../data/security-requirements/or_alternatives_scope_added.yaml")
+	require.NoError(t, err)
+
+	d, err := diff.Get(diff.NewConfig(), base, added)
+	require.NoError(t, err)
+
+	securityDiff := d.PathsDiff.Modified["/pets/{petId}"].OperationsDiff.Modified["GET"].SecurityDiff
+	require.Contains(t, securityDiff.Modified["petstore_auth"]["petstore_auth"].Added, "list:pets")
+	require.Empty(t, securityDiff.Added)
+	require.Empty(t, securityDiff.Deleted)
+}
+
+// Removing a whole shared-scheme OR-alternative is reported as a deleted
+// alternative, with no phantom scope modification on the survivors.
+func TestDiff_SharedSchemeORAlternatives_AlternativeRemoved(t *testing.T) {
+	loader := openapi3.NewLoader()
+	three, err := loader.LoadFromFile("../data/security-requirements/or_alternatives.yaml")
+	require.NoError(t, err)
+	two, err := loader.LoadFromFile("../data/security-requirements/or_alternatives_two.yaml")
+	require.NoError(t, err)
+
+	d, err := diff.Get(diff.NewConfig(), three, two)
+	require.NoError(t, err)
+
+	securityDiff := d.PathsDiff.Modified["/pets/{petId}"].OperationsDiff.Modified["GET"].SecurityDiff
+	require.Contains(t, securityDiff.Deleted, "petstore_auth")
+	require.Empty(t, securityDiff.Modified)
+	require.Empty(t, securityDiff.Added)
+}

--- a/diff/security_requirements_diff.go
+++ b/diff/security_requirements_diff.go
@@ -52,42 +52,108 @@ func getSecurityRequirementsDiffInternal(securityRequirements1, securityRequirem
 
 	result := newSecurityRequirementsDiff()
 
-	if securityRequirements1 != nil {
-		for _, securityRequirement1 := range *securityRequirements1 {
-			if securityRequirement2 := findSecurityRequirement(securityRequirement1, securityRequirements2); securityRequirement2 != nil {
-				if securityScopesDiff := getSecurityScopesDiff(securityRequirement1, securityRequirement2); !securityScopesDiff.Empty() {
-					result.Modified[getSecurityRequirementID(securityRequirement1)] = securityScopesDiff
-				}
-			} else {
-				result.Deleted = append(result.Deleted, getSecurityRequirementID(securityRequirement1))
-			}
+	// A security requirements list is an unordered set of OR-alternatives, and
+	// several alternatives may legitimately share a scheme while differing only
+	// in scopes: because scopes within one requirement are AND-ed, "scope read
+	// OR scope write" can only be written as `- petstore_auth: [read]` /
+	// `- petstore_auth: [write]`. Matching alternatives by scheme name alone
+	// collapses those together and invents a phantom scope add/remove, even when
+	// a spec is compared against itself (#1041). So match alternatives as whole
+	// units (schemes AND scopes) first, and only fall back to a scope diff when
+	// the leftover's scheme set is unambiguous.
+	reqs1 := derefSecurityRequirements(securityRequirements1)
+	reqs2 := derefSecurityRequirements(securityRequirements2)
+	matched1 := make([]bool, len(reqs1))
+	matched2 := make([]bool, len(reqs2))
+
+	// Pass 1: cancel out identical alternatives (same schemes and same scopes),
+	// so they take no part in scope diffing.
+	for i := range reqs1 {
+		if j := findSecurityRequirement(reqs1[i], reqs2, matched2, true); j >= 0 {
+			matched1[i], matched2[j] = true, true
 		}
 	}
 
-	if securityRequirements2 != nil {
-		for _, securityRequirement2 := range *securityRequirements2 {
-			if securityRequirements1 := findSecurityRequirement(securityRequirement2, securityRequirements1); securityRequirements1 == nil {
-				result.Added = append(result.Added, getSecurityRequirementID(securityRequirement2))
-			}
+	// Pass 2: report a leftover as a scope modification only when its scheme set
+	// is unambiguous, i.e. exactly one unmatched alternative carries that scheme
+	// set on each side. Otherwise any pairing would be arbitrary, so leave those
+	// to be reported as a deleted alternative plus an added one in pass 3.
+	for i := range reqs1 {
+		if matched1[i] || !uniqueUnmatchedBySchemes(reqs1, matched1, getSecuritySchemes(reqs1[i])) {
+			continue
+		}
+		j := findSecurityRequirement(reqs1[i], reqs2, matched2, false)
+		if j < 0 || !uniqueUnmatchedBySchemes(reqs2, matched2, getSecuritySchemes(reqs2[j])) {
+			continue
+		}
+		matched1[i], matched2[j] = true, true
+		if securityScopesDiff := getSecurityScopesDiff(reqs1[i], reqs2[j]); !securityScopesDiff.Empty() {
+			result.Modified[getSecurityRequirementID(reqs1[i])] = securityScopesDiff
+		}
+	}
+
+	// Pass 3: whatever is still unmatched was genuinely deleted or added.
+	for i := range reqs1 {
+		if !matched1[i] {
+			result.Deleted = append(result.Deleted, getSecurityRequirementID(reqs1[i]))
+		}
+	}
+	for j := range reqs2 {
+		if !matched2[j] {
+			result.Added = append(result.Added, getSecurityRequirementID(reqs2[j]))
 		}
 	}
 
 	return result
 }
 
-func findSecurityRequirement(securityRequirement1 openapi3.SecurityRequirement, securityRequirements2 *openapi3.SecurityRequirements) openapi3.SecurityRequirement {
-	if securityRequirements2 == nil {
+func derefSecurityRequirements(securityRequirements *openapi3.SecurityRequirements) []openapi3.SecurityRequirement {
+	if securityRequirements == nil {
 		return nil
 	}
+	return *securityRequirements
+}
 
-	securitySchemes1 := getSecuritySchemes(securityRequirement1)
-	for _, securityRequirement2 := range *securityRequirements2 {
-		securitySchemes2 := getSecuritySchemes(securityRequirement2)
-		if securitySchemes1.Equals(securitySchemes2) {
-			return securityRequirement2
+// findSecurityRequirement returns the index of the first unmatched alternative
+// in candidates whose set of scheme names equals that of securityRequirement,
+// or -1 if there is none. When exact is true the scopes must match too, so a
+// match means the two alternatives are identical.
+func findSecurityRequirement(securityRequirement openapi3.SecurityRequirement, candidates []openapi3.SecurityRequirement, matched []bool, exact bool) int {
+	schemes := getSecuritySchemes(securityRequirement)
+	for j, candidate := range candidates {
+		if matched[j] {
+			continue
+		}
+		if !schemes.Equals(getSecuritySchemes(candidate)) {
+			continue
+		}
+		// getSecurityScopesDiff iterates securityRequirement's schemes; the
+		// schemes.Equals check above guarantees both sides share the same scheme
+		// names, so an empty diff here means the scopes are identical too.
+		if exact && !getSecurityScopesDiff(securityRequirement, candidate).Empty() {
+			continue
+		}
+		return j
+	}
+	return -1
+}
+
+// uniqueUnmatchedBySchemes reports whether exactly one unmatched alternative in
+// reqs carries the given set of scheme names.
+func uniqueUnmatchedBySchemes(reqs []openapi3.SecurityRequirement, matched []bool, schemes utils.StringSet) bool {
+	count := 0
+	for i := range reqs {
+		if matched[i] {
+			continue
+		}
+		if schemes.Equals(getSecuritySchemes(reqs[i])) {
+			count++
+			if count > 1 {
+				return false
+			}
 		}
 	}
-	return nil
+	return count == 1
 }
 
 func getSecuritySchemes(securityRequirement openapi3.SecurityRequirement) utils.StringSet {


### PR DESCRIPTION
Fixes #1041.

## The bug
A `security` list is an OR of alternatives, and the only way to express "scope `read` OR scope `write`" for a single OAuth2 scheme is to repeat the scheme across alternatives (`- auth: [read]` / `- auth: [write]`), because scopes within one requirement are AND-ed. The diff matched alternatives by **scheme name alone** (`findSecurityRequirement` / `getSecuritySchemes`), so two alternatives sharing a scheme collided: it paired the wrong ones and emitted a phantom `api-security-scope-added` / `api-security-scope-removed` pair, deterministically, on every diff, **even comparing a spec against a copy of itself**.

## The fix (in `diff/`, where matching belongs)
Match alternatives as whole units rather than by name:

1. **Cancel identical alternatives** (same schemes *and* scopes), so they take no part in scope diffing. Identical specs now cancel completely.
2. **Scope-diff a leftover only when its scheme set is unambiguous** (exactly one unmatched alternative carries that scheme set on each side). This preserves the legitimate granular reporting (a scope added to a single alternative is still reported) without inventing a pairing when several alternatives share a scheme.
3. **Remaining unmatched** alternatives are reported as deleted / added.

## Tests
- `TestDiff_SharedSchemeORAlternatives_NoPhantomOnSelf` (the repro: identical spec diffs clean)
- `TestDiff_SharedSchemeORAlternatives_ScopeAddedStillReported` (the unambiguous scope change is still reported, i.e. no regression)
- `TestDiff_SharedSchemeORAlternatives_AlternativeRemoved` (a removed OR-alternative is reported, with no phantom scope change)

`go test ./...` passes, including the existing security checker tests (`checker/check_api_security_updated_test.go`), so the granular scope add/remove behavior is unchanged. CLI before: 2 phantom info changes on identical specs; after: `No changes detected`.

## Credit
The two-pass approach is based on the reference PR #1042 by @siem-moneybird, who reported the issue with a clear root-cause analysis and a working example. This PR adapts it to the codebase conventions and adds the regression test matrix.