### PR TITLE
diff: model security requirement alternatives as structured, index-keyed values

### DIFF
--- a/checker/check_api_security_updated.go
+++ b/checker/check_api_security_updated.go
@@ -25,7 +25,7 @@ func checkGlobalSecurity(diffReport *diff.Diff) Changes {
 		result = append(result, SecurityChange{
 			Id:    APIGlobalSecurityAddedCheckId,
 			Level: INFO,
-			Args:  []any{addedSecurity},
+			Args:  []any{addedSecurity.String()},
 		})
 	}
 
@@ -33,12 +33,12 @@ func checkGlobalSecurity(diffReport *diff.Diff) Changes {
 		result = append(result, SecurityChange{
 			Id:    APIGlobalSecurityRemovedCheckId,
 			Level: INFO,
-			Args:  []any{removedSecurity},
+			Args:  []any{removedSecurity.String()},
 		})
 	}
 
 	for _, updatedSecurity := range diffReport.SecurityDiff.Modified {
-		for securitySchemeName, updatedSecuritySchemeScopes := range updatedSecurity {
+		for securitySchemeName, updatedSecuritySchemeScopes := range updatedSecurity.Scopes {
 			for _, addedScope := range updatedSecuritySchemeScopes.Added {
 				result = append(result, SecurityChange{
 					Id:    APIGlobalSecurityScopeAddedId,
@@ -79,14 +79,14 @@ func APISecurityUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.Oper
 			}
 
 			for _, addedSecurity := range operationItem.SecurityDiff.Added {
-				if addedSecurity == "" {
+				if len(addedSecurity.Schemes) == 0 {
 					continue
 				}
 
 				result = append(result, NewApiChange(
 					APISecurityAddedCheckId,
 					config,
-					[]any{addedSecurity},
+					[]any{addedSecurity.String()},
 					"",
 					operationsSources,
 					operationItem.Revision,
@@ -96,14 +96,14 @@ func APISecurityUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.Oper
 			}
 
 			for _, deletedSecurity := range operationItem.SecurityDiff.Deleted {
-				if deletedSecurity == "" {
+				if len(deletedSecurity.Schemes) == 0 {
 					continue
 				}
 
 				result = append(result, NewApiChange(
 					APISecurityRemovedCheckId,
 					config,
-					[]any{deletedSecurity},
+					[]any{deletedSecurity.String()},
 					"",
 					operationsSources,
 					operationItem.Revision,
@@ -113,10 +113,10 @@ func APISecurityUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.Oper
 			}
 
 			for _, updatedSecurity := range operationItem.SecurityDiff.Modified {
-				if updatedSecurity.Empty() {
+				if updatedSecurity.Scopes.Empty() {
 					continue
 				}
-				for securitySchemeName, updatedSecuritySchemeScopes := range updatedSecurity {
+				for securitySchemeName, updatedSecuritySchemeScopes := range updatedSecurity.Scopes {
 					for _, addedScope := range updatedSecuritySchemeScopes.Added {
 						result = append(result, NewApiChange(
 							APISecurityScopeAddedId,

--- a/checker/check_api_security_updated_test.go
+++ b/checker/check_api_security_updated_test.go
@@ -22,10 +22,10 @@ func TestAPIGlobalSecurityyAdded(t *testing.T) {
 	require.Len(t, errs, 1)
 	require.Equal(t, checker.SecurityChange{
 		Id:    checker.APIGlobalSecurityAddedCheckId,
-		Args:  []any{"petstore_auth"},
+		Args:  []any{"petstore_auth: [read:pets, write:pets]"},
 		Level: checker.INFO,
 	}, errs[0])
-	require.Equal(t, "the security scheme `petstore_auth` was added to the API", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "the security scheme `petstore_auth: [read:pets, write:pets]` was added to the API", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // CL: removing a global security from the API
@@ -41,10 +41,10 @@ func TestAPIGlobalSecurityyDeleted(t *testing.T) {
 	require.Len(t, errs, 1)
 	require.Equal(t, checker.SecurityChange{
 		Id:    checker.APIGlobalSecurityRemovedCheckId,
-		Args:  []any{"petstore_auth"},
+		Args:  []any{"petstore_auth: [read:pets, write:pets]"},
 		Level: checker.INFO,
 	}, errs[0])
-	require.Equal(t, "the security scheme `petstore_auth` was removed from the API", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "the security scheme `petstore_auth: [read:pets, write:pets]` was removed from the API", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // CL: removing a security scope from an API global security
@@ -100,13 +100,13 @@ func TestAPISecurityAdded(t *testing.T) {
 	require.Len(t, errs, 1)
 	require.Equal(t, checker.ApiChange{
 		Id:        checker.APISecurityAddedCheckId,
-		Args:      []any{"petstore_auth"},
+		Args:      []any{"petstore_auth: [read:pets, write:pets]"},
 		Level:     checker.INFO,
 		Operation: "POST",
 		Path:      "/subscribe",
 		Source:    load.NewSource("../data/checker/api_security_added_revision.yaml"),
 	}, errs[0])
-	require.Equal(t, "the endpoint scheme security `petstore_auth` was added to the API", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "the endpoint scheme security `petstore_auth: [read:pets, write:pets]` was added to the API", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // CL: removing a new security to the API endpoint
@@ -122,13 +122,13 @@ func TestAPISecurityDeleted(t *testing.T) {
 	require.Len(t, errs, 1)
 	require.Equal(t, checker.ApiChange{
 		Id:        checker.APISecurityRemovedCheckId,
-		Args:      []any{"petstore_auth"},
+		Args:      []any{"petstore_auth: [read:pets, write:pets]"},
 		Level:     checker.INFO,
 		Operation: "POST",
 		Path:      "/subscribe",
 		Source:    load.NewSource("../data/checker/api_security_added_base.yaml"),
 	}, errs[0])
-	require.Equal(t, "the endpoint scheme security `petstore_auth` was removed from the API", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "the endpoint scheme security `petstore_auth: [read:pets, write:pets]` was removed from the API", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // CL: removing a security scope from an API endpoint security

--- a/data/security-requirements/or_alternatives_two_changed.yaml
+++ b/data/security-requirements/or_alternatives_two_changed.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.0
+info:
+  title: Security Requirement Example
+  version: 1.0.0
+paths:
+  /pets/{petId}:
+    get:
+      operationId: getPet
+      # both same-scheme alternatives change scopes in place -> ambiguous to pair
+      security:
+      - petstore_auth:
+        - read:pets
+        - list:pets
+      - petstore_auth:
+        - write:pets
+        - audit:pets
+      responses:
+        "200":
+          description: OK
+components:
+  securitySchemes:
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: http://example.org/api/oauth/dialog
+          scopes:
+            read:pets: read your pets
+            write:pets: modify pets in your account
+            admin:pets: administer pets
+            list:pets: list your pets
+            audit:pets: audit pets

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -1187,3 +1187,28 @@ func TestSecurityAlternative_SchemeNames(t *testing.T) {
 	require.Equal(t, "apiKey AND oauth",
 		diff.SecurityAlternative{Schemes: map[string][]string{"oauth": {"read:pets"}, "apiKey": {}}}.SchemeNames())
 }
+
+// Two alternatives sharing a scheme, both changing scopes in place, are
+// ambiguous to pair, so they are reported as deleted + added (each carrying its
+// full scopes), never as two same-scheme "modified" entries. This is the
+// invariant the report relies on when it labels a modified requirement by scheme
+// name alone (modified is reserved for the unambiguous, one-per-scheme-set case).
+func TestDiff_SharedSchemeORAlternatives_AmbiguousScopeChangeIsAddDelete(t *testing.T) {
+	loader := openapi3.NewLoader()
+	base, err := loader.LoadFromFile("../data/security-requirements/or_alternatives_two.yaml")
+	require.NoError(t, err)
+	changed, err := loader.LoadFromFile("../data/security-requirements/or_alternatives_two_changed.yaml")
+	require.NoError(t, err)
+
+	d, err := diff.Get(diff.NewConfig(), base, changed)
+	require.NoError(t, err)
+
+	securityDiff := d.PathsDiff.Modified["/pets/{petId}"].OperationsDiff.Modified["GET"].SecurityDiff
+	require.Empty(t, securityDiff.Modified, "ambiguous scope changes must not become same-scheme modified entries")
+	require.ElementsMatch(t,
+		[]string{"petstore_auth: [read:pets]", "petstore_auth: [write:pets]"},
+		securityAlternativeStrings(securityDiff.Deleted))
+	require.ElementsMatch(t,
+		[]string{"petstore_auth: [list:pets, read:pets]", "petstore_auth: [audit:pets, write:pets]"},
+		securityAlternativeStrings(securityDiff.Added))
+}

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -1178,3 +1178,12 @@ func TestSecurityAlternative_String(t *testing.T) {
 		})
 	}
 }
+
+// TestSecurityAlternative_SchemeNames covers the scheme-name-only label used for
+// a scope modification (scopes omitted; they're reported separately).
+func TestSecurityAlternative_SchemeNames(t *testing.T) {
+	require.Equal(t, "petstore_auth",
+		diff.SecurityAlternative{Schemes: map[string][]string{"petstore_auth": {"read:pets"}}}.SchemeNames())
+	require.Equal(t, "apiKey AND oauth",
+		diff.SecurityAlternative{Schemes: map[string][]string{"oauth": {"read:pets"}, "apiKey": {}}}.SchemeNames())
+}

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -626,18 +626,39 @@ func TestFilterOperationssByExtension(t *testing.T) {
 		d.GetSummary().Details[diff.EndpointsDetail])
 }
 
+// securityAlternativeStrings renders a list of alternatives to their String()
+// forms, for asserting which alternative was added/deleted.
+func securityAlternativeStrings(alts diff.SecurityAlternatives) []string {
+	out := make([]string, len(alts))
+	for i, a := range alts {
+		out[i] = a.String()
+	}
+	return out
+}
+
+// modifiedSecurityRequirementByScheme finds the modified alternative carrying a
+// given scheme, or nil.
+func modifiedSecurityRequirementByScheme(modified diff.ModifiedSecurityRequirements, scheme string) *diff.ModifiedSecurityRequirement {
+	for _, m := range modified {
+		if _, ok := m.Base.Schemes[scheme]; ok {
+			return m
+		}
+	}
+	return nil
+}
+
 func TestAddedSecurityRequirement(t *testing.T) {
-	require.Contains(t,
-		d(t, diff.NewConfig(), 3, 1).PathsDiff.Modified["/register"].OperationsDiff.Modified["POST"].SecurityDiff.Added,
-		"bearerAuth")
+	added := d(t, diff.NewConfig(), 3, 1).PathsDiff.Modified["/register"].OperationsDiff.Modified["POST"].SecurityDiff.Added
+	require.Contains(t, securityAlternativeStrings(added), "bearerAuth")
 }
 
 func TestSecurityRequirementScopesDeleted(t *testing.T) {
-	securityScopesDiff := d(t, diff.NewConfig(), 3, 1).PathsDiff.Modified["/register"].OperationsDiff.Modified["POST"].SecurityDiff.Modified["OAuth"]
-	require.NotEmpty(t, securityScopesDiff)
+	modified := d(t, diff.NewConfig(), 3, 1).PathsDiff.Modified["/register"].OperationsDiff.Modified["POST"].SecurityDiff.Modified
+	oauth := modifiedSecurityRequirementByScheme(modified, "OAuth")
+	require.NotNil(t, oauth)
 
 	require.Contains(t,
-		securityScopesDiff["OAuth"].Deleted,
+		oauth.Scopes["OAuth"].Deleted,
 		"write:pets")
 }
 
@@ -1108,7 +1129,9 @@ func TestDiff_SharedSchemeORAlternatives_ScopeAddedStillReported(t *testing.T) {
 	require.NoError(t, err)
 
 	securityDiff := d.PathsDiff.Modified["/pets/{petId}"].OperationsDiff.Modified["GET"].SecurityDiff
-	require.Contains(t, securityDiff.Modified["petstore_auth"]["petstore_auth"].Added, "list:pets")
+	petstore := modifiedSecurityRequirementByScheme(securityDiff.Modified, "petstore_auth")
+	require.NotNil(t, petstore)
+	require.Contains(t, petstore.Scopes["petstore_auth"].Added, "list:pets")
 	require.Empty(t, securityDiff.Added)
 	require.Empty(t, securityDiff.Deleted)
 }
@@ -1126,7 +1149,11 @@ func TestDiff_SharedSchemeORAlternatives_AlternativeRemoved(t *testing.T) {
 	require.NoError(t, err)
 
 	securityDiff := d.PathsDiff.Modified["/pets/{petId}"].OperationsDiff.Modified["GET"].SecurityDiff
-	require.Contains(t, securityDiff.Deleted, "petstore_auth")
+	// Identified by index + schemes/scopes, so it's unambiguous which of the
+	// three same-scheme alternatives was removed.
+	require.Len(t, securityDiff.Deleted, 1)
+	require.Equal(t, "petstore_auth: [admin:pets]", securityDiff.Deleted[0].String())
+	require.Equal(t, 2, securityDiff.Deleted[0].Index)
 	require.Empty(t, securityDiff.Modified)
 	require.Empty(t, securityDiff.Added)
 }

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -1157,3 +1157,24 @@ func TestDiff_SharedSchemeORAlternatives_AlternativeRemoved(t *testing.T) {
 	require.Empty(t, securityDiff.Modified)
 	require.Empty(t, securityDiff.Added)
 }
+
+// TestSecurityAlternative_String covers each branch of SecurityAlternative.String():
+// the empty requirement ({}), a scheme with no scopes (bare name), a scheme with
+// scopes (sorted), and several schemes AND-ed (sorted by scheme name).
+func TestSecurityAlternative_String(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		schemes map[string][]string
+		want    string
+	}{
+		{"empty requirement", map[string][]string{}, "{}"},
+		{"nil schemes", nil, "{}"},
+		{"scheme without scopes", map[string][]string{"bearerAuth": {}}, "bearerAuth"},
+		{"scheme with scopes, sorted", map[string][]string{"petstore_auth": {"write:pets", "read:pets"}}, "petstore_auth: [read:pets, write:pets]"},
+		{"schemes AND-ed, sorted by name", map[string][]string{"oauth": {"read:pets"}, "apiKey": {}}, "apiKey AND oauth: [read:pets]"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, diff.SecurityAlternative{Schemes: tc.schemes}.String())
+		})
+	}
+}

--- a/diff/security_requirements_diff.go
+++ b/diff/security_requirements_diff.go
@@ -12,10 +12,12 @@ import (
 
 // SecurityRequirementsDiff describes the changes between a pair of lists of security requirement objects: https://swagger.io/specification/#security-requirement-object
 //
-// A security list is an unordered set of OR-alternatives. Alternatives have no
-// name, and several may even share a scheme (the only way to express an OR of
-// scopes), so they cannot be keyed by a string. Like SubschemasDiff, they are
-// identified by index and carried as structured values.
+// A security list is an unordered set of OR-alternatives. An alternative is a
+// map of scheme->scopes with no identity of its own: its scheme names aren't a
+// unique key (several alternatives may share a scheme, the only way to express
+// an OR of scopes), and one alternative may AND several schemes at once. So they
+// cannot be keyed by a string; like SubschemasDiff, they are identified by index
+// and carried as structured values.
 type SecurityRequirementsDiff struct {
 	Added    SecurityAlternatives         `json:"added,omitempty" yaml:"added,omitempty"`
 	Deleted  SecurityAlternatives         `json:"deleted,omitempty" yaml:"deleted,omitempty"`

--- a/diff/security_requirements_diff.go
+++ b/diff/security_requirements_diff.go
@@ -12,12 +12,23 @@ import (
 
 // SecurityRequirementsDiff describes the changes between a pair of lists of security requirement objects: https://swagger.io/specification/#security-requirement-object
 //
-// A security list is an unordered set of OR-alternatives. An alternative is a
-// map of scheme->scopes with no identity of its own: its scheme names aren't a
-// unique key (several alternatives may share a scheme, the only way to express
-// an OR of scopes), and one alternative may AND several schemes at once. So they
-// cannot be keyed by a string; like SubschemasDiff, they are identified by index
-// and carried as structured values.
+// Semantics, which drive the modeling below:
+//   - the list is an OR: a request is authorized if it satisfies any one item;
+//   - the schemes within one item are AND-ed: all of them must be satisfied;
+//   - the scopes within a scheme are AND-ed too.
+//
+// So an OR of scopes for a single scheme can only be written by repeating the
+// scheme across items (- petstore_auth: [read] / - petstore_auth: [write]), and
+// a single item may carry several schemes AND-ed together (both an oauth and an
+// apiKey key).
+//
+// An alternative therefore has no identity of its own to key on: its scheme
+// names aren't unique (the repeated-scheme case above) and there may be several
+// of them. The scheme name is only a reference into components.securitySchemes,
+// an author-chosen label; the scheme's actual meaning (type, flows) is diffed
+// separately in SecuritySchemesDiff. So alternatives cannot be keyed by a
+// string; like SubschemasDiff, they are identified by index and carried as
+// structured values.
 type SecurityRequirementsDiff struct {
 	Added    SecurityAlternatives         `json:"added,omitempty" yaml:"added,omitempty"`
 	Deleted  SecurityAlternatives         `json:"deleted,omitempty" yaml:"deleted,omitempty"`

--- a/diff/security_requirements_diff.go
+++ b/diff/security_requirements_diff.go
@@ -69,6 +69,13 @@ func (a SecurityAlternative) String() string {
 	return strings.Join(parts, " AND ")
 }
 
+// SchemeNames returns the alternative's scheme names, sorted and AND-joined
+// (e.g. "apiKey AND oauth"). It labels a scope modification, where the changed
+// scopes are reported separately, so it omits the scopes that String() carries.
+func (a SecurityAlternative) SchemeNames() string {
+	return strings.Join(slices.Sorted(maps.Keys(a.Schemes)), " AND ")
+}
+
 func newSecurityAlternative(index int, securityRequirement openapi3.SecurityRequirement) SecurityAlternative {
 	return SecurityAlternative{
 		Index:   index,

--- a/diff/security_requirements_diff.go
+++ b/diff/security_requirements_diff.go
@@ -48,9 +48,13 @@ type SecurityAlternatives []SecurityAlternative
 // String renders an alternative by its schemes and scopes. The index is kept in
 // the structured data but left out of the human-readable form, since it is
 // positional rather than a meaningful identity. Schemes and scopes are sorted so
-// the output is deterministic; a scheme with no scopes (API key, bearer) shows
-// as its bare name.
+// the output is deterministic. A scheme with no scopes (API key, bearer) shows
+// as its bare name; an empty requirement (`{}`, this alternative requires no
+// authentication) shows as "{}".
 func (a SecurityAlternative) String() string {
+	if len(a.Schemes) == 0 {
+		return "{}"
+	}
 	schemes := slices.Sorted(maps.Keys(a.Schemes))
 	parts := make([]string, len(schemes))
 	for i, scheme := range schemes {

--- a/diff/security_requirements_diff.go
+++ b/diff/security_requirements_diff.go
@@ -1,6 +1,7 @@
 package diff
 
 import (
+	"fmt"
 	"maps"
 	"slices"
 	"strings"
@@ -9,11 +10,66 @@ import (
 	"github.com/oasdiff/oasdiff/utils"
 )
 
-// SecurityRequirementsDiff describes the changes between a pair of sets of security requirement objects: https://swagger.io/specification/#security-requirement-object
+// SecurityRequirementsDiff describes the changes between a pair of lists of security requirement objects: https://swagger.io/specification/#security-requirement-object
+//
+// A security list is an unordered set of OR-alternatives. Alternatives have no
+// name, and several may even share a scheme (the only way to express an OR of
+// scopes), so they cannot be keyed by a string. Like SubschemasDiff, they are
+// identified by index and carried as structured values.
 type SecurityRequirementsDiff struct {
-	Added    []string                     `json:"added,omitempty" yaml:"added,omitempty"`
-	Deleted  []string                     `json:"deleted,omitempty" yaml:"deleted,omitempty"`
+	Added    SecurityAlternatives         `json:"added,omitempty" yaml:"added,omitempty"`
+	Deleted  SecurityAlternatives         `json:"deleted,omitempty" yaml:"deleted,omitempty"`
 	Modified ModifiedSecurityRequirements `json:"modified,omitempty" yaml:"modified,omitempty"`
+}
+
+// SecurityAlternative is one alternative (one security requirement object) in a
+// security list, identified by its index plus its schemes and their scopes.
+type SecurityAlternative struct {
+	Index   int                 `json:"index" yaml:"index"`     // zero-based index in the security list
+	Schemes map[string][]string `json:"schemes" yaml:"schemes"` // scheme name -> scopes
+}
+
+// SecurityAlternatives is a list of security alternatives.
+type SecurityAlternatives []SecurityAlternative
+
+// String renders an alternative by its schemes and scopes. The index is kept in
+// the structured data but left out of the human-readable form, since it is
+// positional rather than a meaningful identity. Schemes and scopes are sorted so
+// the output is deterministic; a scheme with no scopes (API key, bearer) shows
+// as its bare name.
+func (a SecurityAlternative) String() string {
+	schemes := slices.Sorted(maps.Keys(a.Schemes))
+	parts := make([]string, len(schemes))
+	for i, scheme := range schemes {
+		scopes := slices.Clone(a.Schemes[scheme])
+		if len(scopes) == 0 {
+			parts[i] = scheme
+			continue
+		}
+		slices.Sort(scopes)
+		parts[i] = fmt.Sprintf("%s: [%s]", scheme, strings.Join(scopes, ", "))
+	}
+	return strings.Join(parts, " AND ")
+}
+
+func newSecurityAlternative(index int, securityRequirement openapi3.SecurityRequirement) SecurityAlternative {
+	return SecurityAlternative{
+		Index:   index,
+		Schemes: maps.Clone(securityRequirement),
+	}
+}
+
+// ModifiedSecurityRequirements is a list of alternatives whose scopes changed.
+// Like ModifiedSubschemas, it is modeled as a slice rather than a map to avoid a
+// composite key.
+type ModifiedSecurityRequirements []*ModifiedSecurityRequirement
+
+// ModifiedSecurityRequirement is an alternative whose scopes changed, with its
+// identity in base and revision and the per-scheme scope diff.
+type ModifiedSecurityRequirement struct {
+	Base     SecurityAlternative `json:"base" yaml:"base"`
+	Revision SecurityAlternative `json:"revision" yaml:"revision"`
+	Scopes   SecurityScopesDiff  `json:"scopes" yaml:"scopes"`
 }
 
 // Empty indicates whether a change was found in this element
@@ -27,13 +83,10 @@ func (diff *SecurityRequirementsDiff) Empty() bool {
 		len(diff.Modified) == 0
 }
 
-// ModifiedSecurityRequirements is map of security requirements to their respective diffs
-type ModifiedSecurityRequirements map[string]SecurityScopesDiff
-
 func newSecurityRequirementsDiff() *SecurityRequirementsDiff {
 	return &SecurityRequirementsDiff{
-		Added:    []string{},
-		Deleted:  []string{},
+		Added:    SecurityAlternatives{},
+		Deleted:  SecurityAlternatives{},
 		Modified: ModifiedSecurityRequirements{},
 	}
 }
@@ -87,20 +140,24 @@ func getSecurityRequirementsDiffInternal(securityRequirements1, securityRequirem
 			continue
 		}
 		matched1[i], matched2[j] = true, true
-		if securityScopesDiff := getSecurityScopesDiff(reqs1[i], reqs2[j]); !securityScopesDiff.Empty() {
-			result.Modified[getSecurityRequirementID(reqs1[i])] = securityScopesDiff
+		if scopesDiff := getSecurityScopesDiff(reqs1[i], reqs2[j]); !scopesDiff.Empty() {
+			result.Modified = append(result.Modified, &ModifiedSecurityRequirement{
+				Base:     newSecurityAlternative(i, reqs1[i]),
+				Revision: newSecurityAlternative(j, reqs2[j]),
+				Scopes:   scopesDiff,
+			})
 		}
 	}
 
 	// Pass 3: whatever is still unmatched was genuinely deleted or added.
 	for i := range reqs1 {
 		if !matched1[i] {
-			result.Deleted = append(result.Deleted, getSecurityRequirementID(reqs1[i]))
+			result.Deleted = append(result.Deleted, newSecurityAlternative(i, reqs1[i]))
 		}
 	}
 	for j := range reqs2 {
 		if !matched2[j] {
-			result.Added = append(result.Added, getSecurityRequirementID(reqs2[j]))
+			result.Added = append(result.Added, newSecurityAlternative(j, reqs2[j]))
 		}
 	}
 
@@ -162,10 +219,6 @@ func getSecuritySchemes(securityRequirement openapi3.SecurityRequirement) utils.
 		result.Add(name)
 	}
 	return result
-}
-
-func getSecurityRequirementID(securityRequirement openapi3.SecurityRequirement) string {
-	return strings.Join(slices.Collect(maps.Keys(securityRequirement)), " AND ")
 }
 
 func (diff *SecurityRequirementsDiff) getSummary() *SummaryDetails {

--- a/report/report.go
+++ b/report/report.go
@@ -716,7 +716,9 @@ func (r *report) printSecurityRequirements(d *diff.SecurityRequirementsDiff) {
 	}
 
 	for _, modified := range d.Modified {
-		r.print("Modified security requirements:", modified.Base.String())
+		// Label by scheme name, not the full String(): the scope changes are
+		// listed beneath, so including the base scopes here would just be noise.
+		r.print("Modified security requirements:", modified.Base.SchemeNames())
 		r.indent().printSecurityScopes(modified.Scopes)
 	}
 }

--- a/report/report.go
+++ b/report/report.go
@@ -705,19 +705,19 @@ func (r *report) printSecurityRequirements(d *diff.SecurityRequirementsDiff) {
 		return
 	}
 
-	slices.Sort(d.Added)
+	// Added/Deleted/Modified are already in spec (index) order, which is
+	// deterministic, so no extra sort is needed.
 	for _, added := range d.Added {
-		r.print("New security requirements:", added)
+		r.print("New security requirements:", added.String())
 	}
 
-	slices.Sort(d.Deleted)
 	for _, deleted := range d.Deleted {
-		r.print("Deleted security requirements:", deleted)
+		r.print("Deleted security requirements:", deleted.String())
 	}
 
-	for _, securityRequirementID := range getKeys(d.Modified) {
-		r.print("Modified security requirements:", securityRequirementID)
-		r.indent().printSecurityScopes(d.Modified[securityRequirementID])
+	for _, modified := range d.Modified {
+		r.print("Modified security requirements:", modified.Base.String())
+		r.indent().printSecurityScopes(modified.Scopes)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #1043 (the phantom-diff fix). That PR left a rough edge: when several OR-alternatives share a scheme, a removed/added alternative was identified by scheme name only, so `deleted: [petstore_auth]` couldn't say *which* of `[read]` / `[write]` / `[admin]` went. Rather than patch that with a stringified id, this models the security diff on the existing `SubschemasDiff` / `ModifiedSubschemas` pattern.

## Why this shape
A `security:` list is an unordered set of OR-alternatives. An alternative is a map of scheme->scopes with no identity of its own: its scheme names aren't a unique key (several alternatives may share a scheme, the only way to express an OR of scopes), and an alternative may AND several schemes. So they can't be keyed by a string, exactly the situation `ModifiedSubschemas` already handles by identifying elements by **index** and carrying them as structured values. The doc comment there says it outright: *"modeled as a slice to avoid complex mapping keys."*

## Change
- `Added`/`Deleted`: `[]string` -> `SecurityAlternatives` (`[]SecurityAlternative`), each `{ Index, Schemes map[string][]string }`, with a `String()` method (rendering lives on the type, not in the diff loop).
- `Modified`: `map[string]SecurityScopesDiff` -> `ModifiedSecurityRequirements` (`[]*ModifiedSecurityRequirement`), each `{ Base, Revision SecurityAlternative, Scopes SecurityScopesDiff }`, mirroring `ModifiedSubschema { Base, Revision Subschema, Diff }`.

## Output
The diff now carries the scopes structurally, so a removed alternative is unambiguous:
```yaml
securityRequirements:
    deleted:
        - index: 2
          schemes:
            petstore_auth: [admin:pets]
```
and the changelog renders it via `String()`: `the endpoint scheme security `petstore_auth: [admin:pets]` was removed from the API`. The index stays in the structured output only (it's positional, not a meaningful identity to a reader).

## Compatibility
This is a deliberate **diff output schema change** for security requirements: added/deleted go from strings to objects, and modified from a map to a list. Consumers updated: `checker/check_api_security_updated.go` (uses `String()` for the add/remove message args, `.Scopes` for the scope messages) and `report/report.go`. `go test ./...` and `go vet ./...` are green; the existing security checker tests assert the scoped wording, and the #1043 regression tests are updated to the structured shape.
