### PR TITLE
fix(validate): emit valid empty output for a clean spec in every format

### DIFF
--- a/formatters/findings_test.go
+++ b/formatters/findings_test.go
@@ -57,6 +57,14 @@ func TestTEXTFormatter_RenderValidate_Color(t *testing.T) {
 	require.Contains(t, s, color.InGreen("GET"))            // endpoint green
 }
 
+// Empty findings render as "No findings detected", mirroring
+// RenderChangelog's empty case rather than a "0 findings" summary.
+func TestTEXTFormatter_RenderValidate_Empty(t *testing.T) {
+	out, err := formatters.TEXTFormatter{Localizer: MockLocalizer}.RenderValidate(formatters.Findings{}, formatters.NewRenderOpts())
+	require.NoError(t, err)
+	require.Equal(t, "No findings detected", string(out))
+}
+
 func TestYAMLFormatter_RenderValidate(t *testing.T) {
 	out, err := formatters.YAMLFormatter{Localizer: MockLocalizer}.RenderValidate(sampleFindings(), formatters.NewRenderOpts())
 	require.NoError(t, err)

--- a/formatters/format_text.go
+++ b/formatters/format_text.go
@@ -74,6 +74,13 @@ func (f TEXTFormatter) RenderChecks(checks Checks, opts RenderOpts) ([]byte, err
 func (f TEXTFormatter) RenderValidate(findings Findings, opts RenderOpts) ([]byte, error) {
 	result := bytes.NewBuffer(nil)
 
+	// Mirror RenderChangelog's empty case ("No changes detected") rather than
+	// printing a "0 findings" summary, so the sibling commands read alike.
+	if len(findings) == 0 {
+		_, _ = fmt.Fprint(result, "No findings detected")
+		return result.Bytes(), nil
+	}
+
 	count := findings.GetLevelCount()
 	// Color the severity labels in the summary line, matching the changelog
 	// command's title (getChangelogTitle).

--- a/internal/validate.go
+++ b/internal/validate.go
@@ -81,10 +81,9 @@ func runValidate(flags *Flags, stdout io.Writer) (bool, *ReturnError) {
 		return false, getErrFailedToLoadSpec("original", flags.getBase(), err)
 	}
 
+	// Render zero findings through the formatter too: the empty representation
+	// is format-specific, so it's the formatter's call, not an early return's.
 	findings := validate.Validate(spec.Spec, flags.getBase().String())
-	if len(findings) == 0 {
-		return false, nil
-	}
 
 	if returnErr := outputFindings(flags, stdout, findings); returnErr != nil {
 		return false, returnErr

--- a/internal/validate_test.go
+++ b/internal/validate_test.go
@@ -12,10 +12,33 @@ import (
 )
 
 // Happy path: a well-formed minimal spec produces no findings and exit 0.
+// The empty representation is format-specific and owned by the formatter,
+// not suppressed by the command, so each format still emits valid output.
+// The text empty case mirrors changelog's "No changes detected".
 func Test_ValidateCmd_NoFindings(t *testing.T) {
 	var stdout bytes.Buffer
 	require.Zero(t, internal.Run(cmdToArgs("oasdiff validate ../data/validate/valid.yaml"), &stdout, io.Discard))
-	require.Empty(t, stdout.String())
+	require.Contains(t, stdout.String(), "No findings detected")
+}
+
+// A valid spec in JSON format yields a valid empty array, not empty output.
+func Test_ValidateCmd_NoFindings_JSON(t *testing.T) {
+	var stdout bytes.Buffer
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff validate -f json ../data/validate/valid.yaml"), &stdout, io.Discard))
+
+	var findings []map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &findings))
+	require.Empty(t, findings)
+}
+
+// A valid spec in YAML format yields a valid empty list, not empty output.
+func Test_ValidateCmd_NoFindings_YAML(t *testing.T) {
+	var stdout bytes.Buffer
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff validate -f yaml ../data/validate/valid.yaml"), &stdout, io.Discard))
+
+	var findings []map[string]any
+	require.NoError(t, yaml.Unmarshal(stdout.Bytes(), &findings))
+	require.Empty(t, findings)
 }
 
 // Empty info.version → kin returns *RequiredFieldError{Field:"info.version"}

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -34,14 +34,15 @@ const unknownValidationID = "spec-validation-error"
 // file:line:column anchors. Pass an empty string when there is no
 // meaningful source name (e.g. specs loaded from memory).
 //
-// Returns nil when the spec is fully valid.
+// A valid spec yields a non-nil empty Findings (nil only for the nil-spec
+// guard), so the formatters' nil guard doesn't collapse `[]` to empty bytes.
 func Validate(spec *openapi3.T, source string) formatters.Findings {
 	if spec == nil {
 		return nil
 	}
 	verr := spec.Validate(context.Background(), openapi3.EnableMultiError())
 	if verr == nil {
-		return nil
+		return formatters.Findings{}
 	}
 	return mapKinErrors(source, verr)
 }


### PR DESCRIPTION
## Problem

`oasdiff validate` on a spec with no findings prints nothing at all. The closest sibling command, `oasdiff changelog`, behaves the opposite way on its empty case: with no changes it prints `No changes detected` in text and a valid empty list (`[]`) in json/yaml. Both commands return a flat list (findings / changes) and render it through the formatters, so validate should match — but for a clean spec it instead produces empty output, which for `-f json` / `-f yaml` is not even a valid document.

The root cause is in `runValidate`, which short-circuits with an early return when there are zero findings — before the formatter runs. The empty case never reaches the per-format rendering path, so the format-specific empty representation (which differs per format) is never produced.

## Fix

Let the formatter own the empty representation, the way `changelog` already does:

- `validate.Validate` returns a non-nil empty `Findings` for a valid spec instead of `nil`. Zero findings is an empty list, not the absence of a result. This keeps `printJSON`/`printYAML` from being short-circuited to empty bytes by their nil guard, so they emit a valid empty list. (The shared nil guard is left intact — it is also used by `RenderDiff`, where nil→empty is intended.)
- `runValidate` drops the `len(findings) == 0` early return and always renders through `outputFindings`. Exit code is unchanged: `findings.HasLevelOrHigher(--fail-on)` is `false` for zero findings, so a clean spec still exits 0.
- The text formatter's empty case prints `No findings detected`, mirroring `changelog`'s `No changes detected`, instead of a `0 findings: ...` summary line.

## Result

Each format now yields valid output for a clean spec (exit 0), mirroring `changelog`'s no-changes output:

| format | validate (clean spec) | changelog (no changes) |
|---|---|---|
| text | `No findings detected` | `No changes detected` |
| json | `[]` | `[]` |
| yaml | `[]` | `[]` |
| githubactions | (no annotations) | n/a |

## Tests

- Updated `Test_ValidateCmd_NoFindings` to assert the `No findings detected` text.
- Added `Test_ValidateCmd_NoFindings_JSON` and `_YAML` that unmarshal the output and assert a valid empty list.
- Added `TestTEXTFormatter_RenderValidate_Empty` covering the formatter's empty-text branch.

`make lint` is clean and the full `go test ./...` suite passes.