### PR TITLE
fix(formatters): emit a valid empty document for nil json/yaml output

### DIFF
--- a/formatters/format_json.go
+++ b/formatters/format_json.go
@@ -51,7 +51,7 @@ func (f JSONFormatter) SupportedOutputs() []Output {
 
 func printJSON(output any) ([]byte, error) {
 	if reflect.ValueOf(output).IsNil() {
-		return nil, nil
+		return []byte(emptyDocFor(output)), nil
 	}
 
 	bytes, err := json.Marshal(output)
@@ -60,6 +60,26 @@ func printJSON(output any) ([]byte, error) {
 	}
 
 	return bytes, nil
+}
+
+// emptyDocFor returns the valid empty document to emit for a nil value of
+// output's type: "[]" for slice/array kinds (after dereferencing pointers),
+// "{}" otherwise (structs, maps, pointers to them). A nil value would marshal
+// to null, and the previous behavior — empty bytes — is not valid JSON at all.
+// Emitting the empty container keeps the output valid and shape-stable for
+// every command, and, unlike marshaling a zero value, stays "{}" for structs
+// whose fields aren't omitempty (a zeroed openapi3.T marshals to
+// {"info":null,"openapi":"","paths":null}, not {}). Shared with printYAML,
+// where "[]"/"{}" are valid flow-style documents too.
+func emptyDocFor(output any) string {
+	t := reflect.TypeOf(output)
+	if t != nil && t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if t != nil && (t.Kind() == reflect.Slice || t.Kind() == reflect.Array) {
+		return "[]"
+	}
+	return "{}"
 }
 
 // adaptStructure wraps the changes list in an object when the caller asks

--- a/formatters/format_json_test.go
+++ b/formatters/format_json_test.go
@@ -51,16 +51,29 @@ func TestJsonFormatter_RenderChecks(t *testing.T) {
 	require.Equal(t, `[{"id":"change_id","level":"info","direction":"request","area":"schema","kind":"existence","action":"remove","description":"This is a breaking change.","mitigation":"Fix it."}]`, string(out))
 }
 
+// An empty (nil) diff renders as the empty JSON object, not empty bytes,
+// so the output is always valid JSON.
 func TestJsonFormatter_RenderDiff(t *testing.T) {
 	out, err := jsonFormatter.RenderDiff(nil, formatters.NewRenderOpts())
 	require.NoError(t, err)
-	require.Empty(t, string(out))
+	require.Equal(t, "{}", string(out))
 }
 
+// A nil pointer-shaped value (here a nil spec) renders as the empty object,
+// not empty bytes, so the output is valid JSON. Note this is "{}" rather than
+// a marshaled zero value: a zeroed openapi3.T would marshal to
+// {"info":null,"openapi":"","paths":null}.
 func TestJsonFormatter_RenderFlatten(t *testing.T) {
 	out, err := jsonFormatter.RenderFlatten(nil, formatters.NewRenderOpts())
 	require.NoError(t, err)
-	require.Empty(t, string(out))
+	require.Equal(t, "{}", string(out))
+}
+
+// A nil slice-shaped value renders as the empty array, not empty bytes.
+func TestJsonFormatter_RenderValidate_Nil(t *testing.T) {
+	out, err := jsonFormatter.RenderValidate(nil, formatters.NewRenderOpts())
+	require.NoError(t, err)
+	require.Equal(t, "[]", string(out))
 }
 
 func TestJsonFormatter_RenderSummary(t *testing.T) {

--- a/formatters/format_yaml.go
+++ b/formatters/format_yaml.go
@@ -51,7 +51,7 @@ func (f YAMLFormatter) SupportedOutputs() []Output {
 
 func printYAML(output any) ([]byte, error) {
 	if reflect.ValueOf(output).IsNil() {
-		return nil, nil
+		return []byte(emptyDocFor(output)), nil
 	}
 
 	bytes, err := yaml.Marshal(output)

--- a/formatters/format_yaml_test.go
+++ b/formatters/format_yaml_test.go
@@ -65,16 +65,27 @@ func TestYamlFormatter_RenderChecks(t *testing.T) {
 	require.Equal(t, "- id: change_id\n  level: info\n  direction: request\n  area: schema\n  kind: existence\n  action: remove\n  description: This is a breaking change.\n  mitigation: Fix it.\n", string(out))
 }
 
+// An empty (nil) diff renders as the empty YAML mapping, for parity with
+// the JSON formatter, rather than empty bytes.
 func TestYamlFormatter_RenderDiff(t *testing.T) {
 	out, err := yamlFormatter.RenderDiff(nil, formatters.NewRenderOpts())
 	require.NoError(t, err)
-	require.Empty(t, string(out))
+	require.Equal(t, "{}", string(out))
 }
 
+// A nil pointer-shaped value renders as the empty mapping, for parity with
+// the JSON formatter, rather than empty bytes.
 func TestYamlFormatter_RenderFlatten(t *testing.T) {
 	out, err := yamlFormatter.RenderFlatten(nil, formatters.NewRenderOpts())
 	require.NoError(t, err)
-	require.Empty(t, string(out))
+	require.Equal(t, "{}", string(out))
+}
+
+// A nil slice-shaped value renders as the empty sequence, not empty bytes.
+func TestYamlFormatter_RenderValidate_Nil(t *testing.T) {
+	out, err := yamlFormatter.RenderValidate(nil, formatters.NewRenderOpts())
+	require.NoError(t, err)
+	require.Equal(t, "[]", string(out))
 }
 
 func TestYamlFormatter_RenderSummary(t *testing.T) {

--- a/internal/run_test.go
+++ b/internal/run_test.go
@@ -95,6 +95,24 @@ func Test_DiffJson(t *testing.T) {
 	require.Nil(t, json.Unmarshal(stdout.Bytes(), &bc))
 }
 
+// Identical specs produce an empty diff. json/yaml must still emit a valid
+// empty document (`{}`), not empty bytes — an empty string is not valid JSON.
+func Test_DiffEmptyJson(t *testing.T) {
+	var stdout bytes.Buffer
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff diff ../data/openapi-test1.yaml ../data/openapi-test1.yaml -f json"), &stdout, io.Discard))
+	require.Equal(t, "{}", strings.TrimSpace(stdout.String()))
+	var bc any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &bc))
+}
+
+func Test_DiffEmptyYaml(t *testing.T) {
+	var stdout bytes.Buffer
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff diff ../data/openapi-test1.yaml ../data/openapi-test1.yaml -f yaml"), &stdout, io.Discard))
+	require.Equal(t, "{}", strings.TrimSpace(stdout.String()))
+	var bc any
+	require.NoError(t, yaml.Unmarshal(stdout.Bytes(), &bc))
+}
+
 func Test_DiffHtml(t *testing.T) {
 	var stdout bytes.Buffer
 	require.Zero(t, internal.Run(cmdToArgs("oasdiff diff ../data/openapi-test1.yaml ../data/openapi-test3.yaml -f html"), &stdout, io.Discard))


### PR DESCRIPTION
## Problem

`printJSON` / `printYAML` rendered a nil value as **empty bytes**. An empty string is not valid JSON (`JSON.parse("")` throws), and in YAML it's a shapeless empty document (parses to null).

`oasdiff diff` of identical specs hit this directly: the diff report is `nil` for an empty diff, so json/yaml output was empty rather than a valid document. (The text / html / markdown diff formatters already print a `No changes` report — only the structured formatters were broken.)

This is the companion to the validate fix (#1045), generalized: the formatter should always emit a valid, format-appropriate empty document.

## Fix

Make the shared `printJSON` / `printYAML` helpers emit a valid, **type-appropriate** empty document for a nil input, so every command that renders through them benefits:

- `[]` for slice/array shapes (findings, changes, checks)
- `{}` otherwise (diff, summary, flattened spec, maps)

The token is chosen from the value's reflect kind, **not** by marshaling a zero value — that distinction matters: a zeroed `openapi3.T` marshals to `{"info":null,"openapi":"","paths":null}`, not `{}`. Emitting the empty container keeps the output valid and shape-stable regardless of the type's omitempty story.

With this in place the diff formatters no longer need a special case — they just call the shared helper.

### Empty-output, before → after

| command / format | before | after |
|---|---|---|
| `diff` json/yaml (identical specs) | `` (invalid) | `{}` |
| `diff` text/html/markdown | `No changes` | unchanged |
| `validate` json/yaml (valid spec) | `[]` | `[]` (unchanged) |
| any nil pointer render (e.g. flatten) | `` | `{}` |

## Tests

- `formatters`: `RenderDiff(nil)` and `RenderFlatten(nil)` now assert `{}`; added `RenderValidate(nil)` cases asserting `[]` to lock the slice path. (json + yaml)
- `internal`: `Test_DiffEmptyJson` / `Test_DiffEmptyYaml` — identical specs at the CLI emit `{}` and parse as a valid empty document.

`make lint` is clean and the full `go test ./...` suite passes.

## Downstream

- **oasdiff-service** picks this up on its next oasdiff dependency bump; after that, `POST /public/diff` returns `{}` (not an empty body) for an empty diff.
- **w3 diff tool**: once the service is bumped, an empty diff renders `{}` (and validate `[]`) — the valid empty document shown raw, consistent across the two modes.