### PR TITLE
fix(checker): guard nil base schema when a response media type adds a schema

### DIFF
--- a/checker/check_request_property_became_not_nuallable_test.go
+++ b/checker/check_request_property_became_not_nuallable_test.go
@@ -285,3 +285,19 @@ func TestRequestBodyTypeAddedFromUntypedStaysNullable(t *testing.T) {
 	require.False(t, containsId(errs, checker.RequestBodyBecomeNullableId),
 		"adding a type to a previously untyped schema does not add nullability (untyped already accepts null)")
 }
+
+// CL: adding a schema to a response media type that previously had none must not
+// panic. The base schema diff is nil in this case, so the nullable check has no
+// base type to inspect. (#1047)
+func TestResponseMediaTypeSchemaAddedNoPanic(t *testing.T) {
+	s1, err := open("../data/checker/response_media_type_schema_added_base.yaml")
+	require.NoError(t, err)
+	s2, err := open("../data/checker/response_media_type_schema_added_revision.yaml")
+	require.NoError(t, err)
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyBecameNullableCheck), d, osm, checker.INFO)
+	require.False(t, containsId(errs, checker.ResponseBodyBecameNullableId),
+		"adding a schema to a previously schema-less response body is not a became-nullable change")
+}

--- a/checker/check_response_property_became_nuallable.go
+++ b/checker/check_response_property_became_nuallable.go
@@ -17,7 +17,7 @@ func ResponsePropertyBecameNullableCheck(diffReport *diff.Diff, operationsSource
 		if info.schemaDiff.NullableDiff != nil && info.schemaDiff.NullableDiff.To == true {
 			result = append(result, info.newChange(ResponseBodyBecameNullableId, nil, "").
 				WithSources(baseSource, revisionSource))
-		} else if nullAddedToTypeArray(info.schemaDiff.TypeDiff, info.schemaDiff.Base.Type) {
+		} else if info.schemaDiff.Base != nil && nullAddedToTypeArray(info.schemaDiff.TypeDiff, info.schemaDiff.Base.Type) {
 			// OpenAPI 3.1: type changed from "string" to ["string", "null"]
 			result = append(result, info.newChange(ResponseBodyBecameNullableId, nil, "").
 				WithSources(baseSource, revisionSource))

--- a/data/checker/response_media_type_schema_added_base.yaml
+++ b/data/checker/response_media_type_schema_added_base.yaml
@@ -1,0 +1,13 @@
+openapi: 3.0.0
+info:
+  title: base
+  version: 1.0.0
+paths:
+  /test:
+    get:
+      operationId: getTest
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json: {}

--- a/data/checker/response_media_type_schema_added_revision.yaml
+++ b/data/checker/response_media_type_schema_added_revision.yaml
@@ -1,0 +1,15 @@
+openapi: 3.0.0
+info:
+  title: revision
+  version: 1.0.0
+paths:
+  /test:
+    get:
+      operationId: getTest
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: string


### PR DESCRIPTION
Fixes #1047.

`oasdiff breaking` panics with a nil pointer dereference when the base response media type has no `schema` and the revision adds one: `ResponsePropertyBecameNullableCheck` reaches `info.schemaDiff.Base.Type` while `Base` is nil. I added a nil check on the base schema diff before the type-array lookup, matching how the rest of the checker guards `schemaDiff.Base`. `nullAddedToTypeArray` already returns false for a nil base type, so behaviour is unchanged otherwise. Added a regression test with a minimal spec pair.