### PR TITLE
fix: nil-panic when a media type schema is added or removed (#1047)

### DIFF
--- a/checker/media_type_walker.go
+++ b/checker/media_type_walker.go
@@ -106,10 +106,20 @@ type propertyInfo struct {
 	parent       *diff.SchemaDiff
 }
 
+// modifiedSchemaPresentBothSides reports whether a media type's schema changed
+// with a schema present on BOTH sides. A schema added (Base nil) or removed
+// (Revision nil) on an existing media type is not a modification of an existing
+// schema, and the per-schema-change checks built on these walkers dereference
+// Base/Revision unconditionally, so walking those cases nil-panics (#1047).
+func modifiedSchemaPresentBothSides(d *diff.MediaTypeDiff) bool {
+	return d.SchemaDiff != nil && d.SchemaDiff.Base != nil && d.SchemaDiff.Revision != nil
+}
+
 // walkModifiedRequestBodySchemas invokes processor once for each modified
 // request-body media type across the diff, with the per-media-type schema
-// diff and the plumbing needed to emit ApiChange values. Skips media
-// types whose SchemaDiff is nil.
+// diff and the plumbing needed to emit ApiChange values. Skips media types
+// whose schema is absent on either side (added or removed; see
+// modifiedSchemaPresentBothSides).
 func walkModifiedRequestBodySchemas(
 	diffReport *diff.Diff,
 	operationsSources *diff.OperationsSourcesMap,
@@ -132,7 +142,7 @@ func walkModifiedRequestBodySchemas(
 			}
 			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
 			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-				if mediaTypeDiff.SchemaDiff == nil {
+				if !modifiedSchemaPresentBothSides(mediaTypeDiff) {
 					continue
 				}
 				processor(mediaTypeInfo{
@@ -153,7 +163,7 @@ func walkModifiedRequestBodySchemas(
 // walkModifiedResponseSchemas mirrors walkModifiedRequestBodySchemas for
 // response bodies. The processor receives an info with responseStatus set
 // to the response status code (e.g. "200"). Skips media types whose
-// SchemaDiff is nil.
+// schema is absent on either side (see modifiedSchemaPresentBothSides).
 func walkModifiedResponseSchemas(
 	diffReport *diff.Diff,
 	operationsSources *diff.OperationsSourcesMap,
@@ -178,7 +188,7 @@ func walkModifiedResponseSchemas(
 				}
 				modifiedMediaTypes := responseDiff.ContentDiff.MediaTypeModified
 				for mediaType, mediaTypeDiff := range modifiedMediaTypes {
-					if mediaTypeDiff.SchemaDiff == nil {
+					if !modifiedSchemaPresentBothSides(mediaTypeDiff) {
 						continue
 					}
 					processor(mediaTypeInfo{

--- a/checker/media_type_walker_test.go
+++ b/checker/media_type_walker_test.go
@@ -29,3 +29,30 @@ func TestWalkPropertiesSkipsOneSidedSubSchemaDiff(t *testing.T) {
 		checker.CheckBackwardCompatibilityUntilLevel(checker.NewConfig(checker.GetAllChecks()), d, osm, checker.INFO)
 	})
 }
+
+// A media type that existed without a schema and gains one (SchemaDiff.Base nil)
+// — or loses its schema (SchemaDiff.Revision nil) — produces a one-sided schema
+// diff. The per-schema-change checks read SchemaDiff.Base/Revision, so the
+// media-type walkers must not hand them a one-sided diff. Regression for #1047,
+// which panicked with a nil pointer dereference when a response media type
+// gained a schema. Covers request + response, added + removed.
+func TestWalkModifiedSchemasSkipsOneSidedMediaTypeSchema(t *testing.T) {
+	base, err := open("../data/media-type-schema/base.yaml")
+	require.NoError(t, err)
+	revision, err := open("../data/media-type-schema/revision.yaml")
+	require.NoError(t, err)
+
+	// Added: request + response media types gain a schema (Base nil).
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), base, revision)
+	require.NoError(t, err)
+	require.NotPanics(t, func() {
+		checker.CheckBackwardCompatibilityUntilLevel(checker.NewConfig(checker.GetAllChecks()), d, osm, checker.INFO)
+	})
+
+	// Removed: the same media types lose their schema (Revision nil).
+	d, osm, err = diff.GetWithOperationsSourcesMap(diff.NewConfig(), revision, base)
+	require.NoError(t, err)
+	require.NotPanics(t, func() {
+		checker.CheckBackwardCompatibilityUntilLevel(checker.NewConfig(checker.GetAllChecks()), d, osm, checker.INFO)
+	})
+}

--- a/data/media-type-schema/base.yaml
+++ b/data/media-type-schema/base.yaml
@@ -1,0 +1,15 @@
+openapi: 3.0.0
+info:
+  title: base
+  version: 1.0.0
+paths:
+  /test:
+    post:
+      requestBody:
+        content:
+          application/json: {}
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json: {}

--- a/data/media-type-schema/revision.yaml
+++ b/data/media-type-schema/revision.yaml
@@ -1,0 +1,22 @@
+openapi: 3.0.0
+info:
+  title: revision
+  version: 1.0.0
+paths:
+  /test:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: string


### PR DESCRIPTION
Fixes #1047.

## Bug
`oasdiff breaking` nil-panics when a media type that existed **without** a schema gains one (or loses one). The reporter's repro: a response with `content: { application/json: {} }` in the base, and `schema: { type: string }` added in the revision, panics in `ResponsePropertyBecameNullableCheck` at `schemaDiff.Base.Type`.

## Root cause (a class, not one check)
`walkModifiedRequestBodySchemas` / `walkModifiedResponseSchemas` only guard `SchemaDiff == nil`, but a schema **added** yields `SchemaDiff.Base == nil` and a schema **removed** yields `SchemaDiff.Revision == nil`. The ~70 checks built on these walkers analyze how an *existing* schema changed and dereference `.Base` / `.Revision` unconditionally, so any of them can panic. The reporter's per-check `Base != nil` guard would fix one of a dozen-plus latent panics.

## Fix
Guard once in the walkers (`modifiedSchemaPresentBothSides`): skip a media type whose schema is absent on either side. A schema added/removed on an existing media type is not a *modification* of an existing schema, so the per-schema-change family correctly has nothing to say about it. This mirrors the existing one-sided guard already in `walkProperties` ("guard once here rather than in every check"). The add/remove is still reported at the diff level.

## Tests
`TestWalkModifiedSchemasSkipsOneSidedMediaTypeSchema` runs the full backward-compat check over request + response media types, schema added and removed, asserting no panic (mirrors the existing `TestWalkPropertiesSkipsOneSidedSubSchemaDiff`). `go test ./...` is green.

## Follow-up
A request body schema **added** where there was none narrows the accepted input and is arguably breaking; it isn't flagged today (it panicked). A separate PR will add that as a real check, designed by symmetry with its response-side dual (a response schema **removed** drops the output guarantee). Tracking it next.

Credits: @JosefKuchar reported the bug with a clean repro and root-cause analysis (#1047); @SAY-5 independently submitted a fix (#1048, closed) that confirmed the root cause.

