### PR TITLE
ci: stop double-running workflows on PR branches

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,7 +1,8 @@
 name: go
 on:
-  pull_request:
   push:
+    branches: [main]
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,6 +1,7 @@
 name: detect-broken-links
 on:
   push:
+    branches: [main]
   pull_request:
 
 permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,7 @@
 name: golangci-lint
 on:
   push:
+    branches: [main]
   pull_request:
 
 permissions:

--- a/.github/workflows/vuln.yaml
+++ b/.github/workflows/vuln.yaml
@@ -1,6 +1,7 @@
 name: govulncheck
 on:
   push:
+    branches: [main]
   pull_request:
 
 permissions:


### PR DESCRIPTION
## Problem

`go`, `links`, `lint`, and `vuln` triggered on both `push` and `pull_request` with no branch filter:

```yaml
on:
  push:
  pull_request:
```

So every push to a PR branch fires **both** events, running each workflow twice. That roughly doubles Actions usage for these four workflows.

## Fix

Restrict `push` to `main`, matching the `deploy` workflow in oasdiff-service:

```yaml
on:
  push:
    branches: [main]
  pull_request:
```

- PR branch pushes now trigger only `pull_request` (one run).
- A merge to `main` triggers only `push` (one run; the closed PR does not re-fire `pull_request`).
- `pull_request` stays unfiltered so PRs against any base branch (for example stacked PRs) still run.

No coverage is lost: every change still runs on its PR and again on `main` after merge. Direct pushes to non-`main` branches without a PR no longer run CI, which is fine since the workflow here is always branch plus PR.

`codeql-analysis` (already `branches: [main]`), `docker`, and `release_build` (tag/main only) were already correct and are unchanged.