### PR TITLE
ci: concurrency groups + gate link-check on docs changes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-and-test:
     env:
@@ -39,8 +43,6 @@ jobs:
       run: |
         echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
         echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
-    - run: echo ${{ steps.go-cache-paths.outputs.go-build }}
-    - run: echo ${{ steps.go-cache-paths.outputs.go-mod }}
 
     - name: Go Build Cache
       uses: actions/cache@v6

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -2,10 +2,16 @@ name: detect-broken-links
 on:
   push:
     branches: [main]
+    paths: ['**.md', '**.html', '.github/workflows/links.yml', '.github/workflows/mlc_config.json']
   pull_request:
+    paths: ['**.md', '**.html', '.github/workflows/links.yml', '.github/workflows/mlc_config.json']
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   check-links:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   golangci:
     name: lint

--- a/.github/workflows/vuln.yaml
+++ b/.github/workflows/vuln.yaml
@@ -9,6 +9,10 @@ permissions:
   # Optional: allow read access to pull request. Use with `only-new-issues` option.
   # pull-requests: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
     govulncheck_job:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Three small CI cleanups:

1. **Concurrency groups** on `go`, `lint`, `links`, `vuln`. A new push to a PR branch now cancels the in-progress run for that ref instead of running both to completion. Scoped to `pull_request` events (`cancel-in-progress: ${{ github.event_name == 'pull_request' }}`), so pushes to `main` after merge always finish. Frees runner slots and gives faster feedback on force-push/rapid iteration.
2. **Link check gated on docs.** `links` ran on every PR; it now only runs when Markdown/HTML (or the link-check config) change. Code-only PRs skip the slow, network-bound, occasionally-flaky check.
3. **Tidy.** Removed two leftover debug `echo` steps in `go.yml` that printed cache paths.

No change to what is tested. (This repo is public, so these are hygiene/latency wins rather than billed-minute savings.)