### PR TITLE
diff: centralize SchemaRef.Value access behind a named accessor (closes #1036)

### DIFF
--- a/diff/list_of_types_diff.go
+++ b/diff/list_of_types_diff.go
@@ -115,11 +115,7 @@ func checkSchemaList(schemas []*openapi3.SchemaRef, source string) *listOfTypesP
 
 	var types []string
 	for _, schemaRef := range schemas {
-		if schemaRef.Value == nil {
-			return nil // Can't analyze refs or nil schemas
-		}
-
-		schema := schemaRef.Value
+		schema := schemaValue(schemaRef)
 
 		// Must be simple type schema with exactly one type
 		if !isSimpleTypeSchema(schema) {

--- a/diff/modified_subschemas.go
+++ b/diff/modified_subschemas.go
@@ -62,7 +62,7 @@ func getSubschemas(indexes []int, schemaRefs openapi3.SchemaRefs) Subschemas {
 	for _, index := range indexes {
 		result = append(result, Subschema{
 			Index: index,
-			Title: schemaRefs[index].Value.Title,
+			Title: schemaValue(schemaRefs[index]).Title,
 		})
 	}
 	return result
@@ -88,12 +88,12 @@ func (modifiedSchemas ModifiedSubschemas) addSchemaDiff(config *Config, state *s
 			Base: Subschema{
 				Index:     index1,
 				Component: getComponentName(schemaRef1),
-				Title:     schemaRef1.Value.Title,
+				Title:     schemaValue(schemaRef1).Title,
 			},
 			Revision: Subschema{
 				Index:     index2,
 				Component: getComponentName(schemaRef2),
-				Title:     schemaRef2.Value.Title,
+				Title:     schemaValue(schemaRef2).Title,
 			},
 			Diff: diff,
 		})

--- a/diff/one_of_wrapping_diff.go
+++ b/diff/one_of_wrapping_diff.go
@@ -59,7 +59,7 @@ func getOneOfWrappingDiff(base, revision *openapi3.Schema) *OneOfWrappingDiff {
 
 	alts := make([]*openapi3.Schema, 0, len(revision.OneOf))
 	for _, ref := range revision.OneOf {
-		alts = append(alts, ref.Value)
+		alts = append(alts, schemaValue(ref))
 	}
 
 	moved := make([]string, 0, len(base.Properties))

--- a/diff/parameters_diff_by_location.go
+++ b/diff/parameters_diff_by_location.go
@@ -246,7 +246,7 @@ func isSemanticEquivalent(param1, param2 *openapi3.Parameter) bool {
 // isExplodedObjectParam checks if a parameter is an exploded object parameter
 // (style=form, explode=true, object schema)
 func isExplodedObjectParam(param *openapi3.Parameter) bool {
-	if param == nil || param.Schema == nil || param.Schema.Value == nil {
+	if param == nil || param.Schema == nil {
 		return false
 	}
 
@@ -266,7 +266,7 @@ func isExplodedObjectParam(param *openapi3.Parameter) bool {
 	}
 
 	// Must have object schema with properties
-	schema := param.Schema.Value
+	schema := schemaValue(param.Schema)
 	isObjectWithProps := schema.Type != nil && len(*schema.Type) == 1 && (*schema.Type)[0] == "object" && len(schema.Properties) > 0
 
 	return explode && isFormStyle && isObjectWithProps
@@ -284,7 +284,7 @@ func isParamInExplodedObject(simpleParam, explodedParam *openapi3.Parameter) boo
 		return false
 	}
 
-	schema := explodedParam.Schema.Value
+	schema := schemaValue(explodedParam.Schema)
 	if schema == nil || schema.Properties == nil {
 		return false
 	}
@@ -305,7 +305,7 @@ func getPropertyDiff(config *Config, state *state, simpleParam *openapi3.Paramet
 
 	// Get the property schema from the exploded object
 	propertyName := simpleParam.Name
-	explodedSchema := explodedParam.Schema.Value
+	explodedSchema := schemaValue(explodedParam.Schema)
 	propertySchemaRef, exists := explodedSchema.Properties[propertyName]
 	if !exists {
 		return nil, fmt.Errorf("property %s not found in exploded parameter", propertyName)

--- a/diff/schema_diff.go
+++ b/diff/schema_diff.go
@@ -308,3 +308,13 @@ func getSchemaDiffInternal(config *Config, state *state, schema1, schema2 *opena
 
 	return &result, nil
 }
+
+// schemaValue returns a SchemaRef's resolved schema. By the time diff runs every
+// SchemaRef is resolved: oasdiff disallows external refs at load, so a spec
+// either has its refs resolved or fails to load, and the schema-diff entry point
+// (getSchemaDiff) surfaces a nil Value as an error. Downstream reads can
+// therefore assume Value is non-nil; this accessor names that invariant in one
+// place instead of scattering blind derefs and ad-hoc nil guards. See #1036.
+func schemaValue(ref *openapi3.SchemaRef) *openapi3.Schema {
+	return ref.Value
+}

--- a/diff/subschemas_diff.go
+++ b/diff/subschemas_diff.go
@@ -300,8 +300,8 @@ func getSubschemasInlineDiff(config *Config, state *state, schemaRefs1, schemaRe
 func isSingleModifiedCase(schemaRefs1, schemaRefs2 openapi3.SchemaRefs, addedIdx, deletedIdx []int) bool {
 	return len(addedIdx) == 1 &&
 		len(deletedIdx) == 1 &&
-		schemaRefs1[deletedIdx[0]].Value.Title == "" &&
-		schemaRefs2[addedIdx[0]].Value.Title == ""
+		schemaValue(schemaRefs1[deletedIdx[0]]).Title == "" &&
+		schemaValue(schemaRefs2[addedIdx[0]]).Title == ""
 }
 
 func compareByTitle(config *Config, state *state, addedIdx, deletedIdx []int, schemaRefs1, schemaRefs2 openapi3.SchemaRefs) ([]int, []int, ModifiedSubschemas, error) {
@@ -344,13 +344,13 @@ func matchByTitle(addedIdx, deletedIdx []int, schemaRefs1, schemaRefs2 openapi3.
 	matchedTitles.Add("") // empty title is not allowed
 
 	for _, addedId := range addedIdx {
-		title := schemaRefs2[addedId].Value.Title
+		title := schemaValue(schemaRefs2[addedId]).Title
 		if matchedTitles.Contains(title) {
 			// title already matched, skip
 			continue
 		}
 		for _, deletedId := range deletedIdx {
-			if title == schemaRefs1[deletedId].Value.Title {
+			if title == schemaValue(schemaRefs1[deletedId]).Title {
 				addedMatched[addedId] = deletedId
 				deletedMatched[deletedId] = addedId
 				matchedTitles.Add(title)


### PR DESCRIPTION
Closes #1036.

The `diff/` package read `*SchemaRef.Value` inconsistently: most sites blind-deref (assuming refs are resolved by diff time), a few added ad-hoc `Value == nil` guards. The invariant is real but was undocumented, and the mix made it unclear whether a nil `Value` is impossible or just unhandled.

Per the issue, picks one policy (the invariant holds) and names it in one place:

- Adds `schemaValue(ref *openapi3.SchemaRef) *openapi3.Schema`, a thin accessor documenting why `Value` is non-nil at diff time (external refs are disallowed at load, and `getSchemaDiff` surfaces a nil `Value` as an error at the entry point).
- Routes the downstream blind derefs through it (list-of-types, one-of wrapping, subschema title reads, exploded-param schema reads).
- Drops the now-redundant `.Value == nil` guards in `list_of_types_diff` and the exploded-param helpers.

Kept on purpose: the entry-point error in `getSchemaDiff` (the one place that decides how an unresolved ref is treated) and the circular-refs guard (a distinct concern about cycles, not the resolved invariant).

No behavior change; full test suite and `go vet` pass.