### PR TITLE
checker tests: add requireChange helper, migrate positional assertions (#905)

### DIFF
--- a/checker/check_api_deprecation_test.go
+++ b/checker/check_api_deprecation_test.go
@@ -27,8 +27,7 @@ func TestBreaking_DeprecationWithInvalidSunset(t *testing.T) {
 	errs := checker.CheckBackwardCompatibility(c, d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.APIDeprecatedSunsetParseId, errs[0].GetId())
-	require.Equal(t, "failed to parse sunset date: `sunset date doesn't conform with RFC3339: invalid`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "failed to parse sunset date: `sunset date doesn't conform with RFC3339: invalid`", requireChange(t, errs, checker.APIDeprecatedSunsetParseId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // BC: deprecating an operation with a deprecation policy and an invalid stability level is breaking
@@ -46,8 +45,7 @@ func TestBreaking_DeprecationWithInvalidStabilityLevel(t *testing.T) {
 	errs := checker.CheckBackwardCompatibility(c, d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.APIInvalidStabilityLevelId, errs[0].GetId())
-	require.Equal(t, "failed to parse stability level: `value is not one of draft, alpha, beta or stable: \"invalid\"`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "failed to parse stability level: `value is not one of draft, alpha, beta or stable: \"invalid\"`", requireChange(t, errs, checker.APIInvalidStabilityLevelId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 	require.Equal(t, "../data/deprecation/deprecated-with-invalid-stability.yaml", errs[0].GetSource())
 }
 
@@ -81,8 +79,7 @@ func TestBreaking_DeprecationWithoutSunsetWithPolicy(t *testing.T) {
 	c := singleCheckConfig(checker.APIDeprecationCheck, checker.WithDeprecation(30, 100))
 	errs := checker.CheckBackwardCompatibility(c, d, osm)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.APIDeprecatedSunsetMissingId, errs[0].GetId())
-	require.Equal(t, "sunset date is missing for deprecated API", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "sunset date is missing for deprecated API", requireChange(t, errs, checker.APIDeprecatedSunsetMissingId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // BC: deprecating an operation with a default deprecation policy but without specifying sunset date is not breaking
@@ -156,8 +153,7 @@ func TestBreaking_DeprecationWithEarlySunset(t *testing.T) {
 	errs := checker.CheckBackwardCompatibility(c, d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.APISunsetDateTooSmallId, errs[0].GetId())
-	require.Equal(t, fmt.Sprintf("sunset date `%s` is too small, must be at least `10` days from now", sunsetDate), errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, fmt.Sprintf("sunset date `%s` is too small, must be at least `10` days from now", sunsetDate), requireChange(t, errs, checker.APISunsetDateTooSmallId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // BC: deprecating an operation with a deprecation policy and sunset date after required deprecation period is not breaking
@@ -177,7 +173,7 @@ func TestBreaking_DeprecationWithProperSunset(t *testing.T) {
 	errs := checker.CheckBackwardCompatibilityUntilLevel(c, d, osm, checker.INFO)
 	require.Len(t, errs, 1)
 	// only a non-breaking change detected
-	require.Equal(t, checker.EndpointDeprecatedWithSunsetId, errs[0].GetId())
+	requireChange(t, errs, checker.EndpointDeprecatedWithSunsetId)
 	require.Equal(t, checker.INFO, errs[0].GetLevel())
 	require.Contains(t, errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()), "endpoint deprecated")
 }
@@ -265,7 +261,7 @@ func TestApiDeprecated_MessageIncludesSunset(t *testing.T) {
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
 
-	require.Equal(t, checker.EndpointDeprecatedWithSunsetId, errs[0].GetId())
+	requireChange(t, errs, checker.EndpointDeprecatedWithSunsetId)
 	require.Contains(t, errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()), "endpoint deprecated")
 }
 
@@ -304,8 +300,7 @@ func TestApiDeprecated_MessageWithoutDetails(t *testing.T) {
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
 
-	require.Equal(t, checker.EndpointDeprecatedId, errs[0].GetId())
-	require.Equal(t, "endpoint deprecated", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "endpoint deprecated", requireChange(t, errs, checker.EndpointDeprecatedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // CL: message includes stability when endpoint deprecated with stability but no sunset
@@ -323,8 +318,7 @@ func TestApiDeprecated_MessageIncludesStabilityOnly(t *testing.T) {
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
 
-	require.Equal(t, checker.EndpointDeprecatedId, errs[0].GetId())
-	require.Equal(t, "endpoint deprecated (stability: beta)", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "endpoint deprecated (stability: beta)", requireChange(t, errs, checker.EndpointDeprecatedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // CL: deprecating an operation with a sunset date in RFC3339 format is properly parsed
@@ -346,7 +340,7 @@ func TestBreaking_DeprecationWithRFC3339Sunset(t *testing.T) {
 	errs := checker.CheckBackwardCompatibilityUntilLevel(c, d, osm, checker.INFO)
 	require.Len(t, errs, 1)
 	// only a non-breaking change detected
-	require.Equal(t, checker.EndpointDeprecatedWithSunsetId, errs[0].GetId())
+	requireChange(t, errs, checker.EndpointDeprecatedWithSunsetId)
 	require.Equal(t, checker.INFO, errs[0].GetLevel())
 }
 
@@ -366,7 +360,7 @@ func TestBreaking_DeprecationWithInvalidJsonSunset(t *testing.T) {
 	c := singleCheckConfig(checker.APIDeprecationCheck, checker.WithDeprecation(0, 10))
 	errs := checker.CheckBackwardCompatibility(c, d, osm)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.APIDeprecatedSunsetParseId, errs[0].GetId())
+	requireChange(t, errs, checker.APIDeprecatedSunsetParseId)
 	require.Contains(t, errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()), "failed to unmarshal sunset json")
 }
 

--- a/checker/check_api_operation_id_updated_test.go
+++ b/checker/check_api_operation_id_updated_test.go
@@ -72,7 +72,7 @@ func TestOperationIdRemoved_WithSources(t *testing.T) {
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.APIOperationIdUpdatedCheck), d, osm, checker.INFO)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.APIOperationIdRemovedId, errs[0].GetId())
+	requireChange(t, errs, checker.APIOperationIdRemovedId)
 
 	// Verify source tracking: base has operationId, revision does not
 	require.NotEmpty(t, errs[0].GetBaseSource())

--- a/checker/check_api_stability_level_test.go
+++ b/checker/check_api_stability_level_test.go
@@ -61,8 +61,7 @@ func TestBreaking_InvalidStabilityLevelInRevision(t *testing.T) {
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibility(allChecksConfig(), d, osm)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.APIInvalidStabilityLevelId, errs[0].GetId())
-	require.Equal(t, "failed to parse stability level: `value is not one of draft, alpha, beta or stable: \"invalid\"`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "failed to parse stability level: `value is not one of draft, alpha, beta or stable: \"invalid\"`", requireChange(t, errs, checker.APIInvalidStabilityLevelId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 	require.Equal(t, "../data/deprecation/base-invalid-stability.yaml", errs[0].GetSource())
 }
 
@@ -78,8 +77,7 @@ func TestBreaking_InvalidStabilityLevelInBase(t *testing.T) {
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibility(allChecksConfig(), d, osm)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.APIInvalidStabilityLevelId, errs[0].GetId())
-	require.Equal(t, "failed to parse stability level: `value is not one of draft, alpha, beta or stable: \"invalid\"`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "failed to parse stability level: `value is not one of draft, alpha, beta or stable: \"invalid\"`", requireChange(t, errs, checker.APIInvalidStabilityLevelId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 	require.Equal(t, "../data/deprecation/base-invalid-stability.yaml", errs[0].GetSource())
 }
 
@@ -95,8 +93,7 @@ func TestBreaking_InvalidNonJsonStabilityLevel(t *testing.T) {
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibility(allChecksConfig(), d, osm)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.APIInvalidStabilityLevelId, errs[0].GetId())
-	require.Equal(t, "failed to parse stability level: `x-stability-level isn't a string nor valid json`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "failed to parse stability level: `x-stability-level isn't a string nor valid json`", requireChange(t, errs, checker.APIInvalidStabilityLevelId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 	require.Equal(t, "../data/deprecation/base-invalid-stability-2.yaml", errs[0].GetSource())
 }
 
@@ -107,13 +104,13 @@ func TestBreaking_InvalidNonJsonStabilityLevel(t *testing.T) {
 // At Draft, an endpoint stability decrease (stable→draft) is reported.
 func TestEndpointStability_StableToDraft_Decreased(t *testing.T) {
 	errs := stabilityChanges(t, "base-endpoint-stable.yaml", "revision-endpoint-draft.yaml", checker.StabilityLevelDraft)
-	require.True(t, containsId(errs, checker.APIStabilityDecreasedId))
+	requireChange(t, errs, checker.APIStabilityDecreasedId)
 }
 
 // At Draft, an endpoint stability increase (draft→stable) is reported.
 func TestEndpointStability_DraftToStable_Increased(t *testing.T) {
 	errs := stabilityChanges(t, "revision-endpoint-draft.yaml", "base-endpoint-stable.yaml", checker.StabilityLevelDraft)
-	require.True(t, containsId(errs, checker.APIStabilityIncreasedId))
+	requireChange(t, errs, checker.APIStabilityIncreasedId)
 }
 
 // At Beta (default), a stable→draft decrease IS reported: the base (stable) is
@@ -121,11 +118,11 @@ func TestEndpointStability_DraftToStable_Increased(t *testing.T) {
 // level instead would drop this and regress the existing api-stability-decreased ERR.
 func TestEndpointStability_BetaLevel_StableToDraftDetected(t *testing.T) {
 	errs := stabilityChanges(t, "base-endpoint-stable.yaml", "revision-endpoint-draft.yaml", checker.StabilityLevelBeta)
-	require.True(t, containsId(errs, checker.APIStabilityDecreasedId))
+	requireChange(t, errs, checker.APIStabilityDecreasedId)
 }
 
 // At Stable, draft→stable is not reported because base (draft) is below the threshold.
 func TestEndpointStability_StableLevel_DraftToStableNotDetected(t *testing.T) {
 	errs := stabilityChanges(t, "revision-endpoint-draft.yaml", "base-endpoint-stable.yaml", checker.StabilityLevelStable)
-	require.False(t, containsId(errs, checker.APIStabilityIncreasedId))
+	requireNoChange(t, errs, checker.APIStabilityIncreasedId)
 }

--- a/checker/check_api_sunset_changed_test.go
+++ b/checker/check_api_sunset_changed_test.go
@@ -22,8 +22,7 @@ func TestBreaking_SunsetDeletedForDeprecatedEndpoint(t *testing.T) {
 	errs := checker.CheckBackwardCompatibility(singleCheckConfig(checker.APISunsetChangedCheck), d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.APISunsetDeletedId, errs[0].GetId())
-	require.Equal(t, "api sunset date deleted, but deprecated=true kept", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "api sunset date deleted, but deprecated=true kept", requireChange(t, errs, checker.APISunsetDeletedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // BC: changing sunset to an earlier date for a deprecated endpoint with a deprecation policy is breaking
@@ -40,8 +39,7 @@ func TestBreaking_SunsetModifiedForDeprecatedEndpoint(t *testing.T) {
 	errs := checker.CheckBackwardCompatibility(singleCheckConfig(checker.APISunsetChangedCheck, checker.WithDeprecation(31, 180)), d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.APISunsetDateChangedTooSmallId, errs[0].GetId())
-	require.Equal(t, "api sunset date changed to an earlier date, from `9999-08-10` to `2022-08-10`, new sunset date must be not earlier than `9999-08-10` and at least `180` days from now", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "api sunset date changed to an earlier date, from `9999-08-10` to `2022-08-10`, new sunset date must be not earlier than `9999-08-10` and at least `180` days from now", requireChange(t, errs, checker.APISunsetDateChangedTooSmallId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // BC: changing sunset to an invalid date for a deprecated endpoint is breaking
@@ -58,8 +56,7 @@ func TestBreaking_SunsetModifiedToInvalidForDeprecatedEndpoint(t *testing.T) {
 	errs := checker.CheckBackwardCompatibility(singleCheckConfig(checker.APISunsetChangedCheck), d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.APIPathSunsetParseId, errs[0].GetId())
-	require.Equal(t, "failed to parse sunset date: `sunset date doesn't conform with RFC3339: invalid-date`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "failed to parse sunset date: `sunset date doesn't conform with RFC3339: invalid-date`", requireChange(t, errs, checker.APIPathSunsetParseId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // BC: changing sunset from an invalid date for a deprecated endpoint is breaking
@@ -76,8 +73,7 @@ func TestBreaking_SunsetModifiedFromInvalidForDeprecatedEndpoint(t *testing.T) {
 	errs := checker.CheckBackwardCompatibility(singleCheckConfig(checker.APISunsetChangedCheck), d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.APIPathSunsetParseId, errs[0].GetId())
-	require.Equal(t, "failed to parse sunset date: `sunset date doesn't conform with RFC3339: invalid-date`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "failed to parse sunset date: `sunset date doesn't conform with RFC3339: invalid-date`", requireChange(t, errs, checker.APIPathSunsetParseId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 	require.Equal(t, "../data/deprecation/deprecated-invalid.yaml", errs[0].GetSource())
 }
 

--- a/checker/check_breaking_min_max_test.go
+++ b/checker/check_breaking_min_max_test.go
@@ -25,7 +25,7 @@ func TestBreaking_RequestMaxLengthSmaller(t *testing.T) {
 	errs := checker.CheckBackwardCompatibility(allChecksConfig(), d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestParameterMaxLengthDecreasedId, errs[0].GetId())
+	requireChange(t, errs, checker.RequestParameterMaxLengthDecreasedId)
 }
 
 // BC: reducing max length in response is not breaking
@@ -70,7 +70,7 @@ func TestBreaking_MinLengthSmaller(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibility(allChecksConfig(), d, osm)
-	require.Equal(t, checker.ResponseBodyMinLengthDecreasedId, errs[0].GetId())
+	requireChange(t, errs, checker.ResponseBodyMinLengthDecreasedId)
 }
 
 // BC: increasing max length in request is not breaking
@@ -122,7 +122,7 @@ func TestBreaking_MaxLengthFromNil(t *testing.T) {
 	errs := checker.CheckBackwardCompatibility(allChecksConfig(), d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestParameterMaxLengthSetId, errs[0].GetId())
+	requireChange(t, errs, checker.RequestParameterMaxLengthSetId)
 }
 
 // BC: changing max length in response from nil to any value is not breaking
@@ -172,7 +172,7 @@ func TestBreaking_ResponseMaxLengthToNil(t *testing.T) {
 	errs := checker.CheckBackwardCompatibility(allChecksConfig(), d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.ResponseBodyMaxLengthUnsetId, errs[0].GetId())
+	requireChange(t, errs, checker.ResponseBodyMaxLengthUnsetId)
 }
 
 // BC: both max lengths in request are nil is not breaking
@@ -230,7 +230,7 @@ func TestBreaking_ResponseMinItemsSmaller(t *testing.T) {
 	errs := checker.CheckBackwardCompatibility(allChecksConfig(), d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.ResponseBodyMinItemsDecreasedId, errs[0].GetId())
+	requireChange(t, errs, checker.ResponseBodyMinItemsDecreasedId)
 }
 
 // BC: increasing min items in request is breaking

--- a/checker/check_breaking_request_type_changed_test.go
+++ b/checker/check_breaking_request_type_changed_test.go
@@ -25,8 +25,7 @@ func TestBreaking_ReqTypeStringToNumber(t *testing.T) {
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibility(allChecksConfig(), d, osm)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestBodyTypeChangedId, errs[0].GetId())
-	require.Equal(t, "the request's body `type` changed from `string` to `number`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "the request's body `type` changed from `string` to `number`", requireChange(t, errs, checker.RequestBodyTypeChangedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // BC: changing request's body schema type from number to string is breaking
@@ -45,8 +44,7 @@ func TestBreaking_ReqTypeNumberToString(t *testing.T) {
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibility(allChecksConfig(), d, osm)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestBodyTypeChangedId, errs[0].GetId())
-	require.Equal(t, "the request's body `type` changed from `number` to `string`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "the request's body `type` changed from `number` to `string`", requireChange(t, errs, checker.RequestBodyTypeChangedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // BC: changing request's body schema type from number to integer is breaking
@@ -65,8 +63,7 @@ func TestBreaking_ReqTypeNumberToInteger(t *testing.T) {
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibility(allChecksConfig(), d, osm)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestBodyTypeChangedId, errs[0].GetId())
-	require.Equal(t, "the request's body `type` changed from `number` to `integer`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "the request's body `type` changed from `number` to `integer`", requireChange(t, errs, checker.RequestBodyTypeChangedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // BC: changing request's body schema type from integer to number is not breaking
@@ -85,8 +82,7 @@ func TestBreaking_ReqTypeIntegerToNumber(t *testing.T) {
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(allChecksConfig(), d, osm, checker.INFO)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestBodyTypeGeneralizedId, errs[0].GetId())
-	require.Equal(t, "the request's body `type` was generalized from `integer` to `number`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "the request's body `type` was generalized from `integer` to `number`", requireChange(t, errs, checker.RequestBodyTypeGeneralizedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // BC: narrowing a request's body schema union type is breaking (server rejects previously-valid values)
@@ -105,7 +101,7 @@ func TestBreaking_ReqTypeUnionNarrowed(t *testing.T) {
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibility(allChecksConfig(), d, osm)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestBodyTypeChangedId, errs[0].GetId())
+	requireChange(t, errs, checker.RequestBodyTypeChangedId)
 }
 
 // BC: removing request's body schema type is not breaking (server becomes more permissive)
@@ -124,8 +120,7 @@ func TestBreaking_ReqTypeStringDeleted(t *testing.T) {
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(allChecksConfig(), d, osm, checker.INFO)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestBodyTypeGeneralizedId, errs[0].GetId())
-	require.Equal(t, "the request's body `type` was generalized from `string` to `any`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "the request's body `type` was generalized from `string` to `any`", requireChange(t, errs, checker.RequestBodyTypeGeneralizedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // BC: changing request's body schema type from number/none to integer/int32 is breaking
@@ -145,6 +140,5 @@ func TestBreaking_ReqTypeNumberToInt32(t *testing.T) {
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibility(allChecksConfig(), d, osm)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestBodyTypeChangedId, errs[0].GetId())
-	require.Equal(t, "the request's body `type/format` changed from `number` to `integer/int32`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "the request's body `type/format` changed from `number` to `integer/int32`", requireChange(t, errs, checker.RequestBodyTypeChangedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }

--- a/checker/check_breaking_response_type_changed_test.go
+++ b/checker/check_breaking_response_type_changed_test.go
@@ -25,8 +25,7 @@ func TestBreaking_RespTypeStringToNumber(t *testing.T) {
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibility(allChecksConfig(), d, osm)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.ResponseBodyTypeChangedId, errs[0].GetId())
-	require.Equal(t, "the response's body `type` changed from `string` to `number` for status `200`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "the response's body `type` changed from `string` to `number` for status `200`", requireChange(t, errs, checker.ResponseBodyTypeChangedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // BC: changing response's body schema type from number to string is breaking
@@ -45,8 +44,7 @@ func TestBreaking_RespTypeNumberToString(t *testing.T) {
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibility(allChecksConfig(), d, osm)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.ResponseBodyTypeChangedId, errs[0].GetId())
-	require.Equal(t, "the response's body `type` changed from `number` to `string` for status `200`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "the response's body `type` changed from `number` to `string` for status `200`", requireChange(t, errs, checker.ResponseBodyTypeChangedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // BC: changing response's body schema type from number to integer is not breaking
@@ -83,8 +81,7 @@ func TestBreaking_RespTypeIntegerToNumber(t *testing.T) {
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibility(allChecksConfig(), d, osm)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.ResponseBodyTypeChangedId, errs[0].GetId())
-	require.Equal(t, "the response's body `type` changed from `integer` to `number` for status `200`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "the response's body `type` changed from `integer` to `number` for status `200`", requireChange(t, errs, checker.ResponseBodyTypeChangedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // BC: changing response's body schema type from number/none to integer/int32 is not breaking

--- a/checker/check_property_stability_level_test.go
+++ b/checker/check_property_stability_level_test.go
@@ -15,47 +15,47 @@ import (
 // At Beta (default), draft→stable is not reported because base (draft) is below the threshold.
 func TestRequestPropertyStability_BetaLevel_DraftToStableNotDetected(t *testing.T) {
 	errs := stabilityChanges(t, "base-property-stable-draft.yaml", "revision-property-all-stable.yaml", checker.StabilityLevelBeta)
-	require.False(t, containsId(errs, checker.RequestPropertyStabilityIncreasedId))
+	requireNoChange(t, errs, checker.RequestPropertyStabilityIncreasedId)
 }
 
 // At Draft, a draft→stable increase on a request property is reported.
 func TestRequestPropertyStability_DraftToStable_Increased(t *testing.T) {
 	errs := stabilityChanges(t, "base-property-stable-draft.yaml", "revision-property-all-stable.yaml", checker.StabilityLevelDraft)
-	require.True(t, containsId(errs, checker.RequestPropertyStabilityIncreasedId))
+	requireChange(t, errs, checker.RequestPropertyStabilityIncreasedId)
 }
 
 // At Draft, a stable→draft decrease on a request property is reported.
 func TestRequestPropertyStability_StableToDraft_Decreased(t *testing.T) {
 	errs := stabilityChanges(t, "revision-property-all-stable.yaml", "base-property-stable-draft.yaml", checker.StabilityLevelDraft)
-	require.True(t, containsId(errs, checker.RequestPropertyStabilityDecreasedId))
+	requireChange(t, errs, checker.RequestPropertyStabilityDecreasedId)
 }
 
 // At Alpha, draft→stable is not reported because base (draft) is below the threshold.
 func TestRequestPropertyStability_AlphaLevel_DraftToStableNotDetected(t *testing.T) {
 	errs := stabilityChanges(t, "base-property-stable-draft.yaml", "revision-property-all-stable.yaml", checker.StabilityLevelAlpha)
-	require.False(t, containsId(errs, checker.RequestPropertyStabilityIncreasedId))
+	requireNoChange(t, errs, checker.RequestPropertyStabilityIncreasedId)
 }
 
 // When no property stability actually changed, no stability change is reported.
 func TestRequestPropertyStability_NoChange(t *testing.T) {
 	errs := stabilityChanges(t, "base-property-stable-draft.yaml", "base-property-stable-draft.yaml", checker.StabilityLevelDraft)
-	require.False(t, containsId(errs, checker.RequestPropertyStabilityIncreasedId))
-	require.False(t, containsId(errs, checker.RequestPropertyStabilityDecreasedId))
+	requireNoChange(t, errs, checker.RequestPropertyStabilityIncreasedId)
+	requireNoChange(t, errs, checker.RequestPropertyStabilityDecreasedId)
 }
 
 // An unparseable x-stability-level on a request property is reported as invalid,
 // since checkInvalidStabilityLevels does not descend into property schemas.
 func TestRequestPropertyStability_InvalidLevel(t *testing.T) {
 	errs := stabilityChanges(t, "base-property-stable-draft.yaml", "revision-property-invalid.yaml", checker.StabilityLevelDraft)
-	require.True(t, containsId(errs, checker.APIInvalidStabilityLevelId))
+	requireChange(t, errs, checker.APIInvalidStabilityLevelId)
 }
 
 // A property change on an endpoint below the threshold is not reported: the
 // operation is out of scope, so its property changes are filtered out with it.
 func TestRequestPropertyStability_BelowThresholdEndpoint_NotReported(t *testing.T) {
 	errs := stabilityChanges(t, "base-draft-endpoint-property.yaml", "revision-draft-endpoint-property.yaml", checker.StabilityLevelBeta)
-	require.False(t, containsId(errs, checker.RequestPropertyStabilityDecreasedId))
-	require.False(t, containsId(errs, checker.RequestPropertyStabilityIncreasedId))
+	requireNoChange(t, errs, checker.RequestPropertyStabilityDecreasedId)
+	requireNoChange(t, errs, checker.RequestPropertyStabilityIncreasedId)
 }
 
 // Nil config returns empty
@@ -79,25 +79,25 @@ func TestRequestPropertyStability_NilPathsDiff(t *testing.T) {
 // At Beta (default), draft→stable is not reported because base (draft) is below the threshold.
 func TestResponsePropertyStability_BetaLevel_DraftToStableNotDetected(t *testing.T) {
 	errs := stabilityChanges(t, "base-property-stable-draft.yaml", "revision-property-all-stable.yaml", checker.StabilityLevelBeta)
-	require.False(t, containsId(errs, checker.ResponsePropertyStabilityIncreasedId))
+	requireNoChange(t, errs, checker.ResponsePropertyStabilityIncreasedId)
 }
 
 // At Draft, a draft→stable increase on a response property is reported.
 func TestResponsePropertyStability_DraftToStable_Increased(t *testing.T) {
 	errs := stabilityChanges(t, "base-property-stable-draft.yaml", "revision-property-all-stable.yaml", checker.StabilityLevelDraft)
-	require.True(t, containsId(errs, checker.ResponsePropertyStabilityIncreasedId))
+	requireChange(t, errs, checker.ResponsePropertyStabilityIncreasedId)
 }
 
 // At Draft, a stable→draft decrease on a response property is reported.
 func TestResponsePropertyStability_StableToDraft_Decreased(t *testing.T) {
 	errs := stabilityChanges(t, "revision-property-all-stable.yaml", "base-property-stable-draft.yaml", checker.StabilityLevelDraft)
-	require.True(t, containsId(errs, checker.ResponsePropertyStabilityDecreasedId))
+	requireChange(t, errs, checker.ResponsePropertyStabilityDecreasedId)
 }
 
 // At Alpha, draft→stable is not reported because base (draft) is below the threshold.
 func TestResponsePropertyStability_AlphaLevel_DraftToStableNotDetected(t *testing.T) {
 	errs := stabilityChanges(t, "base-property-stable-draft.yaml", "revision-property-all-stable.yaml", checker.StabilityLevelAlpha)
-	require.False(t, containsId(errs, checker.ResponsePropertyStabilityIncreasedId))
+	requireNoChange(t, errs, checker.ResponsePropertyStabilityIncreasedId)
 }
 
 // Nil config returns empty

--- a/checker/check_request_parameter_deprecation_test.go
+++ b/checker/check_request_parameter_deprecation_test.go
@@ -26,8 +26,7 @@ func TestBreaking_ParameterDeprecationWithInvalidSunset(t *testing.T) {
 	errs := checker.CheckBackwardCompatibility(c, d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestParameterSunsetParseId, errs[0].GetId())
-	require.Equal(t, "failed to parse sunset date for the `query` request parameter `id`: `sunset date doesn't conform with RFC3339: invalid-date`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "failed to parse sunset date for the `query` request parameter `id`: `sunset date doesn't conform with RFC3339: invalid-date`", requireChange(t, errs, checker.RequestParameterSunsetParseId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // BC: deprecating a parameter without a deprecation policy but without specifying sunset date is not breaking
@@ -60,8 +59,7 @@ func TestBreaking_ParameterDeprecationWithoutSunsetWithPolicy(t *testing.T) {
 	c := singleCheckConfig(checker.RequestParameterDeprecationCheck, checker.WithDeprecation(30, 100))
 	errs := checker.CheckBackwardCompatibility(c, d, osm)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestParameterDeprecatedSunsetMissingId, errs[0].GetId())
-	require.Equal(t, "`query` request parameter `id` was deprecated without sunset date", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "`query` request parameter `id` was deprecated without sunset date", requireChange(t, errs, checker.RequestParameterDeprecatedSunsetMissingId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // BC: deprecating a parameter with a default deprecation policy but without specifying sunset date is not breaking
@@ -112,8 +110,7 @@ func TestBreaking_ParameterDeprecationWithEarlySunset(t *testing.T) {
 	errs := checker.CheckBackwardCompatibility(c, d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestParameterSunsetDateTooSmallId, errs[0].GetId())
-	require.Equal(t, fmt.Sprintf("`query` request parameter `id` sunset date `%s` is too small, must be at least `10` days from now", sunsetDate), errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, fmt.Sprintf("`query` request parameter `id` sunset date `%s` is too small, must be at least `10` days from now", sunsetDate), requireChange(t, errs, checker.RequestParameterSunsetDateTooSmallId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // BC: deprecating a parameter with a deprecation policy and sunset date after required deprecation period is not breaking
@@ -133,7 +130,7 @@ func TestBreaking_ParameterDeprecationWithProperSunset(t *testing.T) {
 	errs := checker.CheckBackwardCompatibilityUntilLevel(c, d, osm, checker.INFO)
 	require.Len(t, errs, 1)
 	// only a non-breaking change detected
-	require.Equal(t, checker.RequestParameterDeprecatedId, errs[0].GetId())
+	requireChange(t, errs, checker.RequestParameterDeprecatedId)
 	require.Equal(t, checker.INFO, errs[0].GetLevel())
 	require.Contains(t, errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()), "`query` request parameter `id` was deprecated")
 }
@@ -199,8 +196,7 @@ func TestParameterDeprecated_MessageIncludesSunset(t *testing.T) {
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
 
-	require.Equal(t, checker.RequestParameterDeprecatedId, errs[0].GetId())
-	require.Equal(t, "`query` request parameter `id` was deprecated (sunset: 9999-08-10)", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "`query` request parameter `id` was deprecated (sunset: 9999-08-10)", requireChange(t, errs, checker.RequestParameterDeprecatedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // CL: message includes both sunset and stability when parameter deprecated with both
@@ -218,8 +214,7 @@ func TestParameterDeprecated_MessageIncludesSunsetAndStability(t *testing.T) {
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
 
-	require.Equal(t, checker.RequestParameterDeprecatedId, errs[0].GetId())
-	require.Equal(t, "`query` request parameter `id` was deprecated (sunset: 9999-08-10, stability: beta)", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "`query` request parameter `id` was deprecated (sunset: 9999-08-10, stability: beta)", requireChange(t, errs, checker.RequestParameterDeprecatedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // CL: message has no details when parameter deprecated without sunset or stability
@@ -237,8 +232,7 @@ func TestParameterDeprecated_MessageWithoutDetails(t *testing.T) {
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
 
-	require.Equal(t, checker.RequestParameterDeprecatedId, errs[0].GetId())
-	require.Equal(t, "`query` request parameter `id` was deprecated", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "`query` request parameter `id` was deprecated", requireChange(t, errs, checker.RequestParameterDeprecatedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // CL: message includes stability when parameter deprecated with stability but no sunset
@@ -256,6 +250,5 @@ func TestParameterDeprecated_MessageIncludesStabilityOnly(t *testing.T) {
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
 
-	require.Equal(t, checker.RequestParameterDeprecatedId, errs[0].GetId())
-	require.Equal(t, "`query` request parameter `id` was deprecated (stability: beta)", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "`query` request parameter `id` was deprecated (stability: beta)", requireChange(t, errs, checker.RequestParameterDeprecatedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }

--- a/checker/check_request_parameter_removed_test.go
+++ b/checker/check_request_parameter_removed_test.go
@@ -20,8 +20,7 @@ func TestBreaking_DeletedParameter(t *testing.T) {
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibility(singleCheckConfig(checker.RequestParameterRemovedCheck), d, osm)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestParameterRemovedId, errs[0].GetId())
-	require.Equal(t, "deleted the `query` request parameter `id`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "deleted the `query` request parameter `id`", requireChange(t, errs, checker.RequestParameterRemovedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 	require.Equal(t, "This is a warning because some clients may return an error when receiving an unexpected parameter. It is recommended to deprecate the parameter first.", errs[0].GetComment(checker.NewDefaultLocalizer()))
 }
 
@@ -54,8 +53,7 @@ func TestBreaking_ParameterDeprecationFuture(t *testing.T) {
 	errs := checker.CheckBackwardCompatibility(singleCheckConfig(checker.RequestParameterRemovedCheck), d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.ParameterRemovedBeforeSunsetId, errs[0].GetId())
-	require.Equal(t, "deleted the `query` request parameter `id` before the sunset date `9999-08-10`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "deleted the `query` request parameter `id` before the sunset date `9999-08-10`", requireChange(t, errs, checker.ParameterRemovedBeforeSunsetId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // BC: deleting a deprecated parameter without sunset date is not breaking
@@ -101,7 +99,6 @@ func TestBreaking_RemoveParameterWithInvalidSunset(t *testing.T) {
 	errs := checker.CheckBackwardCompatibility(singleCheckConfig(checker.RequestParameterRemovedCheck), d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestParameterSunsetParseId, errs[0].GetId())
-	require.Equal(t, "failed to parse sunset date for the `query` request parameter `id`: `sunset date doesn't conform with RFC3339: invalid-date`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "failed to parse sunset date for the `query` request parameter `id`: `sunset date doesn't conform with RFC3339: invalid-date`", requireChange(t, errs, checker.RequestParameterSunsetParseId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 	require.Equal(t, "../data/param-deprecation/sunset.yaml", errs[0].GetSource())
 }

--- a/checker/check_request_parameter_required_value_updated_test.go
+++ b/checker/check_request_parameter_required_value_updated_test.go
@@ -44,7 +44,7 @@ func TestBreaking_HeaderParamBecameRequired_WithSources(t *testing.T) {
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibility(singleCheckConfig(checker.RequestParameterRequiredValueUpdatedCheck), d, osm)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestParameterBecomeRequiredId, errs[0].GetId())
+	requireChange(t, errs, checker.RequestParameterBecomeRequiredId)
 
 	// The 'required' field is not explicitly in the YAML (set in-memory),
 	// so both sources are nil when origin tracking is enabled

--- a/checker/check_request_parameter_sunset_changed_test.go
+++ b/checker/check_request_parameter_sunset_changed_test.go
@@ -22,8 +22,7 @@ func TestBreaking_SunsetDeletedForDeprecatedParameter(t *testing.T) {
 	errs := checker.CheckBackwardCompatibility(singleCheckConfig(checker.RequestParameterSunsetChangedCheck), d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestParameterSunsetDeletedId, errs[0].GetId())
-	require.Equal(t, "`query` request parameter `id` sunset date deleted, but deprecated=true kept", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "`query` request parameter `id` sunset date deleted, but deprecated=true kept", requireChange(t, errs, checker.RequestParameterSunsetDeletedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // BC: deleting sunset header for a deprecated parameter is breaking even if the parameter is renamed
@@ -40,8 +39,7 @@ func TestBreaking_SunsetDeletedForDeprecatedAndRenamedParameter(t *testing.T) {
 	errs := checker.CheckBackwardCompatibility(singleCheckConfig(checker.RequestParameterSunsetChangedCheck), d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestParameterSunsetDeletedId, errs[0].GetId())
-	require.Equal(t, "`path` request parameter `id` sunset date deleted, but deprecated=true kept", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "`path` request parameter `id` sunset date deleted, but deprecated=true kept", requireChange(t, errs, checker.RequestParameterSunsetDeletedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // BC: changing sunset to an earlier date for a deprecated parameter with a deprecation policy is breaking
@@ -58,8 +56,7 @@ func TestBreaking_SunsetModifiedForDeprecatedParameter(t *testing.T) {
 	errs := checker.CheckBackwardCompatibility(singleCheckConfig(checker.RequestParameterSunsetChangedCheck, checker.WithDeprecation(31, 180)), d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestParameterSunsetDateChangedTooSmallId, errs[0].GetId())
-	require.Equal(t, "`query` request parameter `id` sunset date changed to an earlier date, from `9999-08-10` to `2022-08-10`, new sunset date must be not earlier than `9999-08-10` and at least `180` days from now", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "`query` request parameter `id` sunset date changed to an earlier date, from `9999-08-10` to `2022-08-10`, new sunset date must be not earlier than `9999-08-10` and at least `180` days from now", requireChange(t, errs, checker.RequestParameterSunsetDateChangedTooSmallId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
 // BC: changing sunset to an invalid date for a deprecated parameter is breaking
@@ -76,8 +73,7 @@ func TestBreaking_SunsetModifiedToInvalidForDeprecatedParameter(t *testing.T) {
 	errs := checker.CheckBackwardCompatibility(singleCheckConfig(checker.RequestParameterSunsetChangedCheck), d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestParameterSunsetParseId, errs[0].GetId())
-	require.Equal(t, "failed to parse sunset date for the `query` request parameter `id`: `sunset date doesn't conform with RFC3339: invalid-date`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "failed to parse sunset date for the `query` request parameter `id`: `sunset date doesn't conform with RFC3339: invalid-date`", requireChange(t, errs, checker.RequestParameterSunsetParseId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 	require.Equal(t, "../data/param-deprecation/deprecated-invalid.yaml", errs[0].GetSource())
 }
 
@@ -95,8 +91,7 @@ func TestBreaking_SunsetModifiedFromInvalidForDeprecatedParameter(t *testing.T) 
 	errs := checker.CheckBackwardCompatibility(singleCheckConfig(checker.RequestParameterSunsetChangedCheck), d, osm)
 	require.NotEmpty(t, errs)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestParameterSunsetParseId, errs[0].GetId())
-	require.Equal(t, "failed to parse sunset date for the `query` request parameter `id`: `sunset date doesn't conform with RFC3339: invalid-date`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "failed to parse sunset date for the `query` request parameter `id`: `sunset date doesn't conform with RFC3339: invalid-date`", requireChange(t, errs, checker.RequestParameterSunsetParseId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 	require.Equal(t, "../data/param-deprecation/deprecated-invalid.yaml", errs[0].GetSource())
 }
 

--- a/checker/check_request_parameter_x_extensible_enum_value_removed_test.go
+++ b/checker/check_request_parameter_x_extensible_enum_value_removed_test.go
@@ -20,6 +20,5 @@ func TestRequestParameterXExtensibleEnumValueRemoved(t *testing.T) {
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibility(singleCheckConfig(checker.RequestParameterXExtensibleEnumValueRemovedCheck), d, osm)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestParameterXExtensibleEnumValueRemovedId, errs[0].GetId())
-	require.Equal(t, "removed the x-extensible-enum value `2` from the `path` request parameter `groupId`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "removed the x-extensible-enum value `2` from the `path` request parameter `groupId`", requireChange(t, errs, checker.RequestParameterXExtensibleEnumValueRemovedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }

--- a/checker/check_request_parameters_type_changed_test.go
+++ b/checker/check_request_parameters_type_changed_test.go
@@ -231,7 +231,7 @@ func TestRequestQueryParamSingleToListOfTypesNotDuplicated(t *testing.T) {
 	})
 	errs := checker.CheckBackwardCompatibilityUntilLevel(config, d, osm, checker.INFO)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestParameterListOfTypesWidenedId, errs[0].GetId())
+	requireChange(t, errs, checker.RequestParameterListOfTypesWidenedId)
 }
 
 // BC: changing request's query param property type from number to string is breaking
@@ -246,8 +246,7 @@ func TestBreaking_ReqQueryParamTypeNumberToString(t *testing.T) {
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestParameterTypeChangedCheck), d, osm, checker.INFO)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestParameterPropertyTypeChangedId, errs[0].GetId())
-	require.Equal(t, "for the `query` request parameter `filters`, the `type` of property `groupId` was changed from `number` to `string`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "for the `query` request parameter `filters`, the `type` of property `groupId` was changed from `number` to `string`", requireChange(t, errs, checker.RequestParameterPropertyTypeChangedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 	require.Equal(t, checker.WARN, errs[0].GetLevel())
 }
 
@@ -263,8 +262,7 @@ func TestBreaking_ReqQueryParamTypeStringToNumber(t *testing.T) {
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestParameterTypeChangedCheck), d, osm, checker.INFO)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestParameterPropertyTypeSpecializedId, errs[0].GetId())
-	require.Equal(t, "for the `query` request parameter `filters`, the `type` of property `groupId` was specialized from `string` to `number`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "for the `query` request parameter `filters`, the `type` of property `groupId` was specialized from `string` to `number`", requireChange(t, errs, checker.RequestParameterPropertyTypeSpecializedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 	require.Equal(t, checker.ERR, errs[0].GetLevel())
 }
 
@@ -280,8 +278,7 @@ func TestBreaking_ReqQueryParamTypeIntegerToNumber(t *testing.T) {
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestParameterTypeChangedCheck), d, osm, checker.INFO)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestParameterPropertyTypeGeneralizedId, errs[0].GetId())
-	require.Equal(t, "for the `query` request parameter `filters`, the `type` of property `groupId` was generalized from `integer` to `number`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	require.Equal(t, "for the `query` request parameter `filters`, the `type` of property `groupId` was generalized from `integer` to `number`", requireChange(t, errs, checker.RequestParameterPropertyTypeGeneralizedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 	require.Equal(t, checker.INFO, errs[0].GetLevel())
 }
 
@@ -309,7 +306,7 @@ func TestRequestQueryParamScalarToFormExplodeArray(t *testing.T) {
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestParameterTypeChangedCheck), d, osm, checker.INFO)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestParameterTypeGeneralizedId, errs[0].GetId())
+	requireChange(t, errs, checker.RequestParameterTypeGeneralizedId)
 	require.Equal(t, checker.INFO, errs[0].GetLevel())
 }
 
@@ -332,7 +329,7 @@ func TestRequestPathParamScalarToArrayStillBreaking(t *testing.T) {
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestParameterTypeChangedCheck), d, osm, checker.INFO)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestParameterTypeChangedId, errs[0].GetId())
+	requireChange(t, errs, checker.RequestParameterTypeChangedId)
 	require.Equal(t, checker.ERR, errs[0].GetLevel())
 }
 
@@ -375,7 +372,7 @@ func TestResponsePropertyFormatRemovedCheck(t *testing.T) {
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyTypeChangedCheck), d, osm, checker.ERR)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.ResponsePropertyTypeChangedId, errs[0].GetId())
+	requireChange(t, errs, checker.ResponsePropertyTypeChangedId)
 	require.Equal(t, checker.ERR, errs[0].GetLevel())
 }
 

--- a/checker/check_request_property_all_of_updated_test.go
+++ b/checker/check_request_property_all_of_updated_test.go
@@ -80,7 +80,7 @@ func TestRequestPropertyAllOfAdded_WithSources_Inline(t *testing.T) {
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyAllOfUpdatedCheck), d, osm, checker.INFO)
 
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestBodyAllOfAddedId, errs[0].GetId())
+	requireChange(t, errs, checker.RequestBodyAllOfAddedId)
 
 	// Added inline subschema: revision source should point to the specific subschema, not the allOf keyword
 	require.NotEmpty(t, errs[0].GetRevisionSource())
@@ -145,7 +145,7 @@ func TestRequestPropertyAllOfAdded_AnnotationOnly_EmitsInfo(t *testing.T) {
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyAllOfUpdatedCheck), d, osm, checker.INFO)
 
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestBodyAllOfAddedAnnotationOnlyId, errs[0].GetId())
+	requireChange(t, errs, checker.RequestBodyAllOfAddedAnnotationOnlyId)
 	require.Equal(t, checker.INFO, errs[0].GetLevel())
 	// And critically: not the original ERR-level breaking-change ID.
 	require.NotEqual(t, checker.RequestBodyAllOfAddedId, errs[0].GetId())
@@ -165,7 +165,7 @@ func TestRequestPropertyAllOfAdded_AnnotationOnly_AtProperty_EmitsInfo(t *testin
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyAllOfUpdatedCheck), d, osm, checker.INFO)
 
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestPropertyAllOfAddedAnnotationOnlyId, errs[0].GetId())
+	requireChange(t, errs, checker.RequestPropertyAllOfAddedAnnotationOnlyId)
 	require.Equal(t, checker.INFO, errs[0].GetLevel())
 	require.NotEqual(t, checker.RequestPropertyAllOfAddedId, errs[0].GetId())
 }

--- a/checker/check_request_property_contains_updated_test.go
+++ b/checker/check_request_property_contains_updated_test.go
@@ -62,7 +62,7 @@ func TestRequestBodyMinContainsIncreased(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyContainsUpdatedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.RequestBodyMinContainsIncreasedId))
+	requireChange(t, errs, checker.RequestBodyMinContainsIncreasedId)
 }
 
 // CL: decreasing minContains on request body
@@ -75,7 +75,7 @@ func TestRequestBodyMinContainsDecreased(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyContainsUpdatedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.RequestBodyMinContainsDecreasedId))
+	requireChange(t, errs, checker.RequestBodyMinContainsDecreasedId)
 }
 
 // CL: increasing maxContains on request body
@@ -88,7 +88,7 @@ func TestRequestBodyMaxContainsIncreased(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyContainsUpdatedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.RequestBodyMaxContainsIncreasedId))
+	requireChange(t, errs, checker.RequestBodyMaxContainsIncreasedId)
 }
 
 // CL: decreasing maxContains on request body
@@ -101,7 +101,7 @@ func TestRequestBodyMaxContainsDecreased(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyContainsUpdatedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.RequestBodyMaxContainsDecreasedId))
+	requireChange(t, errs, checker.RequestBodyMaxContainsDecreasedId)
 }
 
 // CL: adding contains constraint to request property
@@ -114,7 +114,7 @@ func TestRequestPropertyContainsAdded(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyContainsUpdatedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.RequestPropertyContainsAddedId))
+	requireChange(t, errs, checker.RequestPropertyContainsAddedId)
 }
 
 // CL: removing contains constraint from request property
@@ -127,7 +127,7 @@ func TestRequestPropertyContainsRemoved(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyContainsUpdatedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.RequestPropertyContainsRemovedId))
+	requireChange(t, errs, checker.RequestPropertyContainsRemovedId)
 }
 
 // CL: increasing minContains on request property
@@ -140,7 +140,7 @@ func TestRequestPropertyMinContainsIncreased(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyContainsUpdatedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.RequestPropertyMinContainsIncreasedId))
+	requireChange(t, errs, checker.RequestPropertyMinContainsIncreasedId)
 }
 
 // CL: decreasing minContains on request property
@@ -153,7 +153,7 @@ func TestRequestPropertyMinContainsDecreased(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyContainsUpdatedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.RequestPropertyMinContainsDecreasedId))
+	requireChange(t, errs, checker.RequestPropertyMinContainsDecreasedId)
 }
 
 // CL: increasing maxContains on request property
@@ -166,7 +166,7 @@ func TestRequestPropertyMaxContainsIncreased(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyContainsUpdatedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.RequestPropertyMaxContainsIncreasedId))
+	requireChange(t, errs, checker.RequestPropertyMaxContainsIncreasedId)
 }
 
 // CL: decreasing maxContains on request property
@@ -179,5 +179,5 @@ func TestRequestPropertyMaxContainsDecreased(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyContainsUpdatedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.RequestPropertyMaxContainsDecreasedId))
+	requireChange(t, errs, checker.RequestPropertyMaxContainsDecreasedId)
 }

--- a/checker/check_request_property_dependent_required_changed_test.go
+++ b/checker/check_request_property_dependent_required_changed_test.go
@@ -40,7 +40,7 @@ func TestRequestBodyDependentRequiredChanged(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyDependentRequiredChangedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.RequestBodyDependentRequiredChangedId))
+	requireChange(t, errs, checker.RequestBodyDependentRequiredChangedId)
 }
 
 // CL: adding dependentRequired to request property
@@ -53,7 +53,7 @@ func TestRequestPropertyDependentRequiredAdded(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyDependentRequiredChangedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.RequestPropertyDependentRequiredAddedId))
+	requireChange(t, errs, checker.RequestPropertyDependentRequiredAddedId)
 }
 
 // CL: removing dependentRequired from request property
@@ -66,7 +66,7 @@ func TestRequestPropertyDependentRequiredRemoved(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyDependentRequiredChangedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.RequestPropertyDependentRequiredRemovedId))
+	requireChange(t, errs, checker.RequestPropertyDependentRequiredRemovedId)
 }
 
 // CL: changing dependentRequired on request property
@@ -79,7 +79,7 @@ func TestRequestPropertyDependentRequiredChanged(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyDependentRequiredChangedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.RequestPropertyDependentRequiredChangedId))
+	requireChange(t, errs, checker.RequestPropertyDependentRequiredChangedId)
 }
 
 // CL: removing dependentRequired from request body

--- a/checker/check_request_property_unevaluated_updated_test.go
+++ b/checker/check_request_property_unevaluated_updated_test.go
@@ -38,8 +38,8 @@ func TestRequestPropertyUnevaluatedAdded(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyUnevaluatedUpdatedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.RequestPropertyUnevaluatedItemsAddedId))
-	require.True(t, containsId(errs, checker.RequestPropertyUnevaluatedPropertiesAddedId))
+	requireChange(t, errs, checker.RequestPropertyUnevaluatedItemsAddedId)
+	requireChange(t, errs, checker.RequestPropertyUnevaluatedPropertiesAddedId)
 }
 
 // CL: removing unevaluated constraints from request property
@@ -52,8 +52,8 @@ func TestRequestPropertyUnevaluatedRemoved(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyUnevaluatedUpdatedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.RequestPropertyUnevaluatedItemsRemovedId))
-	require.True(t, containsId(errs, checker.RequestPropertyUnevaluatedPropertiesRemovedId))
+	requireChange(t, errs, checker.RequestPropertyUnevaluatedItemsRemovedId)
+	requireChange(t, errs, checker.RequestPropertyUnevaluatedPropertiesRemovedId)
 }
 
 // CL: removing unevaluated constraints from request body

--- a/checker/check_request_property_updated_test.go
+++ b/checker/check_request_property_updated_test.go
@@ -74,7 +74,7 @@ func TestRequiredRequestPropertyAdded_WithSources(t *testing.T) {
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyUpdatedCheck), d, osm, checker.INFO)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.NewRequiredRequestPropertyId, errs[0].GetId())
+	requireChange(t, errs, checker.NewRequiredRequestPropertyId)
 
 	// Added property: base source is nil (property doesn't exist in base), revision source points to the property
 	require.Empty(t, errs[0].GetBaseSource())

--- a/checker/check_request_property_x_extensible_enum_value_removed_test.go
+++ b/checker/check_request_property_x_extensible_enum_value_removed_test.go
@@ -20,5 +20,5 @@ func TestRequestPropertyXExtensibleEnumValueRemovedCheck(t *testing.T) {
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibility(singleCheckConfig(checker.RequestPropertyXExtensibleEnumValueRemovedCheck), d, osm)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.RequestPropertyXExtensibleEnumValueRemovedId, errs[0].GetId())
+	requireChange(t, errs, checker.RequestPropertyXExtensibleEnumValueRemovedId)
 }

--- a/checker/check_response_property_all_of_updated_test.go
+++ b/checker/check_response_property_all_of_updated_test.go
@@ -79,7 +79,7 @@ func TestResponsePropertyAllOfAdded_WithSources_Inline(t *testing.T) {
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyAllOfUpdatedCheck), d, osm, checker.INFO)
 
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.ResponseBodyAllOfAddedId, errs[0].GetId())
+	requireChange(t, errs, checker.ResponseBodyAllOfAddedId)
 
 	// Added inline subschema: source should point to specific subschema, not allOf keyword
 	require.NotEmpty(t, errs[0].GetRevisionSource())
@@ -140,7 +140,7 @@ func TestResponsePropertyAllOfAdded_AnnotationOnly_EmitsInfoWithDistinctId(t *te
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyAllOfUpdatedCheck), d, osm, checker.INFO)
 
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.ResponseBodyAllOfAddedAnnotationOnlyId, errs[0].GetId())
+	requireChange(t, errs, checker.ResponseBodyAllOfAddedAnnotationOnlyId)
 	require.Equal(t, checker.INFO, errs[0].GetLevel())
 	// Distinct from the original allOf-added INFO ID.
 	require.NotEqual(t, checker.ResponseBodyAllOfAddedId, errs[0].GetId())

--- a/checker/check_response_property_became_required_test.go
+++ b/checker/check_response_property_became_required_test.go
@@ -41,7 +41,7 @@ func TestResponsePropertyBecameRequired_WithSources(t *testing.T) {
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyBecameRequiredCheck), d, osm, checker.INFO)
 	require.Len(t, errs, 1)
-	require.Equal(t, checker.ResponsePropertyBecameRequiredId, errs[0].GetId())
+	requireChange(t, errs, checker.ResponsePropertyBecameRequiredId)
 
 	// Base has no 'required' list in YAML, so baseSource is nil
 	require.Empty(t, errs[0].GetBaseSource())

--- a/checker/check_response_property_contains_updated_test.go
+++ b/checker/check_response_property_contains_updated_test.go
@@ -18,7 +18,7 @@ func TestResponseBodyContainsAdded(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyContainsUpdatedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.ResponseBodyContainsAddedId))
+	requireChange(t, errs, checker.ResponseBodyContainsAddedId)
 }
 
 // CL: removing contains constraint from response body
@@ -31,7 +31,7 @@ func TestResponseBodyContainsRemoved(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyContainsUpdatedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.ResponseBodyContainsRemovedId))
+	requireChange(t, errs, checker.ResponseBodyContainsRemovedId)
 }
 
 // CL: increasing minContains on response body
@@ -44,7 +44,7 @@ func TestResponseBodyMinContainsIncreased(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyContainsUpdatedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.ResponseBodyMinContainsIncreasedId))
+	requireChange(t, errs, checker.ResponseBodyMinContainsIncreasedId)
 }
 
 // CL: decreasing minContains on response body
@@ -57,7 +57,7 @@ func TestResponseBodyMinContainsDecreased(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyContainsUpdatedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.ResponseBodyMinContainsDecreasedId))
+	requireChange(t, errs, checker.ResponseBodyMinContainsDecreasedId)
 }
 
 // CL: increasing maxContains on response body
@@ -70,7 +70,7 @@ func TestResponseBodyMaxContainsIncreased(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyContainsUpdatedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.ResponseBodyMaxContainsIncreasedId))
+	requireChange(t, errs, checker.ResponseBodyMaxContainsIncreasedId)
 }
 
 // CL: decreasing maxContains on response body
@@ -83,7 +83,7 @@ func TestResponseBodyMaxContainsDecreased(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyContainsUpdatedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.ResponseBodyMaxContainsDecreasedId))
+	requireChange(t, errs, checker.ResponseBodyMaxContainsDecreasedId)
 }
 
 // CL: adding contains constraint to response property
@@ -96,7 +96,7 @@ func TestResponsePropertyContainsAdded(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyContainsUpdatedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.ResponsePropertyContainsAddedId))
+	requireChange(t, errs, checker.ResponsePropertyContainsAddedId)
 }
 
 // CL: removing contains constraint from response property
@@ -109,7 +109,7 @@ func TestResponsePropertyContainsRemoved(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyContainsUpdatedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.ResponsePropertyContainsRemovedId))
+	requireChange(t, errs, checker.ResponsePropertyContainsRemovedId)
 }
 
 // CL: increasing minContains on response property
@@ -122,7 +122,7 @@ func TestResponsePropertyMinContainsIncreased(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyContainsUpdatedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.ResponsePropertyMinContainsIncreasedId))
+	requireChange(t, errs, checker.ResponsePropertyMinContainsIncreasedId)
 }
 
 // CL: decreasing minContains on response property
@@ -135,7 +135,7 @@ func TestResponsePropertyMinContainsDecreased(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyContainsUpdatedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.ResponsePropertyMinContainsDecreasedId))
+	requireChange(t, errs, checker.ResponsePropertyMinContainsDecreasedId)
 }
 
 // CL: increasing maxContains on response property
@@ -148,7 +148,7 @@ func TestResponsePropertyMaxContainsIncreased(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyContainsUpdatedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.ResponsePropertyMaxContainsIncreasedId))
+	requireChange(t, errs, checker.ResponsePropertyMaxContainsIncreasedId)
 }
 
 // CL: decreasing maxContains on response property
@@ -161,5 +161,5 @@ func TestResponsePropertyMaxContainsDecreased(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyContainsUpdatedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.ResponsePropertyMaxContainsDecreasedId))
+	requireChange(t, errs, checker.ResponsePropertyMaxContainsDecreasedId)
 }

--- a/checker/check_response_property_dependent_required_changed_test.go
+++ b/checker/check_response_property_dependent_required_changed_test.go
@@ -18,7 +18,7 @@ func TestResponseBodyDependentRequiredAdded(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyDependentRequiredChangedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.ResponseBodyDependentRequiredAddedId))
+	requireChange(t, errs, checker.ResponseBodyDependentRequiredAddedId)
 }
 
 // CL: removing dependentRequired from response body
@@ -31,7 +31,7 @@ func TestResponseBodyDependentRequiredRemoved(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyDependentRequiredChangedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.ResponseBodyDependentRequiredRemovedId))
+	requireChange(t, errs, checker.ResponseBodyDependentRequiredRemovedId)
 }
 
 // CL: changing dependentRequired on response body
@@ -44,7 +44,7 @@ func TestResponseBodyDependentRequiredChanged(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyDependentRequiredChangedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.ResponseBodyDependentRequiredChangedId))
+	requireChange(t, errs, checker.ResponseBodyDependentRequiredChangedId)
 }
 
 // CL: changing dependentRequired on response property
@@ -57,7 +57,7 @@ func TestResponsePropertyDependentRequiredChanged(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyDependentRequiredChangedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.ResponsePropertyDependentRequiredChangedId))
+	requireChange(t, errs, checker.ResponsePropertyDependentRequiredChangedId)
 }
 
 // CL: adding dependentRequired to response property
@@ -70,7 +70,7 @@ func TestResponsePropertyDependentRequiredAdded(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyDependentRequiredChangedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.ResponsePropertyDependentRequiredAddedId))
+	requireChange(t, errs, checker.ResponsePropertyDependentRequiredAddedId)
 }
 
 // CL: removing dependentRequired from response property
@@ -83,5 +83,5 @@ func TestResponsePropertyDependentRequiredRemoved(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyDependentRequiredChangedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.ResponsePropertyDependentRequiredRemovedId))
+	requireChange(t, errs, checker.ResponsePropertyDependentRequiredRemovedId)
 }

--- a/checker/check_response_property_unevaluated_updated_test.go
+++ b/checker/check_response_property_unevaluated_updated_test.go
@@ -18,8 +18,8 @@ func TestResponseBodyUnevaluatedRemoved(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyUnevaluatedUpdatedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.ResponseBodyUnevaluatedItemsRemovedId))
-	require.True(t, containsId(errs, checker.ResponseBodyUnevaluatedPropertiesRemovedId))
+	requireChange(t, errs, checker.ResponseBodyUnevaluatedItemsRemovedId)
+	requireChange(t, errs, checker.ResponseBodyUnevaluatedPropertiesRemovedId)
 }
 
 // CL: adding unevaluated constraints to response property
@@ -32,8 +32,8 @@ func TestResponsePropertyUnevaluatedAdded(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyUnevaluatedUpdatedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.ResponsePropertyUnevaluatedItemsAddedId))
-	require.True(t, containsId(errs, checker.ResponsePropertyUnevaluatedPropertiesAddedId))
+	requireChange(t, errs, checker.ResponsePropertyUnevaluatedItemsAddedId)
+	requireChange(t, errs, checker.ResponsePropertyUnevaluatedPropertiesAddedId)
 }
 
 // CL: removing unevaluated constraints from response property
@@ -46,8 +46,8 @@ func TestResponsePropertyUnevaluatedRemoved(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.ResponsePropertyUnevaluatedUpdatedCheck), d, osm, checker.INFO)
-	require.True(t, containsId(errs, checker.ResponsePropertyUnevaluatedItemsRemovedId))
-	require.True(t, containsId(errs, checker.ResponsePropertyUnevaluatedPropertiesRemovedId))
+	requireChange(t, errs, checker.ResponsePropertyUnevaluatedItemsRemovedId)
+	requireChange(t, errs, checker.ResponsePropertyUnevaluatedPropertiesRemovedId)
 }
 
 // CL: adding unevaluated constraints to response body

--- a/checker/helpers_test.go
+++ b/checker/helpers_test.go
@@ -114,3 +114,19 @@ func findChange(changes checker.Changes, id string) checker.Change {
 func containsId(changes checker.Changes, id string) bool {
 	return findChange(changes, id) != nil
 }
+
+// requireChange asserts that changes contains a change with the given id and
+// returns it, so callers can chain assertions on the change (its text, level,
+// sources, ...) without depending on its position in the slice.
+func requireChange(t *testing.T, changes checker.Changes, id string) checker.Change {
+	t.Helper()
+	change := findChange(changes, id)
+	require.NotNil(t, change, "expected a change with id %q", id)
+	return change
+}
+
+// requireNoChange asserts that changes contains no change with the given id.
+func requireNoChange(t *testing.T, changes checker.Changes, id string) {
+	t.Helper()
+	require.Nil(t, findChange(changes, id), "unexpected change with id %q", id)
+}


### PR DESCRIPTION
Fixes the brittleness in #905.

`require.Equal(t, X, errs[0].GetId())` assumes a fixed slice position, so a reordering or an extra emitted change fails the test for the wrong reason.

Adds a **returning** helper, `requireChange(t, errs, id) checker.Change`, that finds the change or fails and returns it, plus `requireNoChange` for absence. Returning the change is what makes it general: callers chain whatever else they assert on it, without depending on position:

```go
requireChange(t, errs, X)                                                   // presence
require.Equal(t, want, requireChange(t, errs, X).GetUncolorizedText(l))      // + message text
c := requireChange(t, errs, X); require.Equal(t, checker.ERR, c.GetLevel())  // + level, etc.
```

**Migration: 125 sites across 25 files.** Presence checks (`require.True`/`False` on `containsId`) become `requireChange`/`requireNoChange`; the common id+text pair collapses to one chained assertion; remaining standalone id checks become `requireChange`. Every transform is equivalence-preserving, so the full checker suite stays green.

**Left untouched on purpose:** files asserting *ordered* multi-index sequences (`errs[1]`, `errs[2]`, ...), where position is the intent. `containsId` stays for its remaining direct bool uses.

**Issue note:** #905 references `requireChange`/`requireNoChange` from #845, but those were removed in the #845 pivot; this reintroduces them (returning the change, which the originals likely didn't) on top of the existing `findChange`/`containsId`.