### PR TITLE
checker: emit a single finding for a oneOf wrapping (#702 follow-up)

### DIFF
--- a/checker/check_request_property_one_of_updated.go
+++ b/checker/check_request_property_one_of_updated.go
@@ -22,6 +22,13 @@ func RequestPropertyOneOfUpdatedCheck(diffReport *diff.Diff, operationsSources *
 			return
 		}
 
+		// A oneOf wrapping (#702) is reported once per body as
+		// request-body-wrapped-in-one-of; don't also report its added
+		// alternatives as a raw one-of-added.
+		if !info.schemaDiff.OneOfWrappingDiff.Empty() {
+			return
+		}
+
 		if info.schemaDiff.OneOfDiff != nil {
 			if added := info.schemaDiff.OneOfDiff.Added; len(added) > 0 {
 				baseSource, revisionSource := SubschemaSources(operationsSources, info.operationItem, info.schemaDiff, "oneOf", -1, added[0].Index)

--- a/checker/check_request_property_type_changed.go
+++ b/checker/check_request_property_type_changed.go
@@ -25,6 +25,13 @@ func RequestPropertyTypeChangedCheck(diffReport *diff.Diff, operationsSources *d
 			if shouldSuppressTypeChangedForListOfTypes(schemaDiff) {
 				return
 			}
+			// A oneOf wrapping (#702) reads as a top-level type change to "any"
+			// (the oneOf wrapper has no type of its own); it's reported once per
+			// body as request-body-wrapped-in-one-of, so don't also report a
+			// body type change.
+			if !schemaDiff.OneOfWrappingDiff.Empty() {
+				return
+			}
 			// Suppress null-only type changes (handled by nullable checkers).
 			if isNullTypeChange(typeDiff) && formatDiff.Empty() {
 				return

--- a/checker/check_request_property_updated_test.go
+++ b/checker/check_request_property_updated_test.go
@@ -156,6 +156,11 @@ func TestRequiredRequestPropertyAddedWithDefault(t *testing.T) {
 // The moved properties must not be reported as removed, and the wrapping must
 // be reported once as request-body-wrapped-in-one-of (ERR), not as
 // request-property-became-optional. Reproduces oasdiff/oasdiff#702.
+//
+// Runs the full check set so it also asserts the mechanical artifacts
+// (one-of-added, type-generalized) are suppressed. The fixture moves both
+// required (foo, bar) and optional (baz) properties into the wrapping, so the
+// moved-property suppression is exercised for both.
 func TestRequestPropertyOneOfWrappingIsBreaking(t *testing.T) {
 	s1, err := open("../data/checker/request_property_one_of_wrapped_base.yaml")
 	require.NoError(t, err)
@@ -164,21 +169,24 @@ func TestRequestPropertyOneOfWrappingIsBreaking(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.RequestPropertyUpdatedCheck), d, osm, checker.INFO)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(allChecksConfig(), d, osm, checker.INFO)
 
 	require.False(t, containsId(errs, checker.RequestPropertyRemovedId),
 		"properties moved into a oneOf wrapping must not be reported as removed (#702)")
 	require.False(t, containsId(errs, checker.RequestPropertyBecameOptionalId),
 		"oneOf wrapping must not be reported as became-optional (#702)")
 
+	// The mechanical artifacts of the wrapping (the added oneOf alternatives,
+	// the top-level type going to "any") are redundant with the single wrapped
+	// finding and must be suppressed too.
+	require.False(t, containsId(errs, checker.RequestBodyOneOfAddedId),
+		"the wrapping's added alternatives must not also be reported as one-of-added (#702)")
+	require.False(t, containsId(errs, checker.RequestBodyTypeGeneralizedId),
+		"the wrapping's top-level type change to 'any' must not also be reported (#702)")
+
 	// The wrapping must be reported exactly once per request body (not per
-	// property), as a breaking error.
-	wrapped := 0
-	for _, e := range errs {
-		if e.GetId() == checker.RequestBodyWrappedInOneOfId {
-			wrapped++
-			require.Equal(t, checker.ERR, e.GetLevel())
-		}
-	}
-	require.Equal(t, 1, wrapped, "the wrapping must be reported once as a breaking error (#702)")
+	// property), as a breaking error, and nothing else.
+	require.Len(t, errs, 1, "a oneOf wrapping must produce exactly one finding (#702)")
+	require.Equal(t, checker.RequestBodyWrappedInOneOfId, errs[0].GetId())
+	require.Equal(t, checker.ERR, errs[0].GetLevel())
 }

--- a/checker/check_response_property_one_of_updated.go
+++ b/checker/check_response_property_one_of_updated.go
@@ -22,6 +22,13 @@ func ResponsePropertyOneOfUpdated(diffReport *diff.Diff, operationsSources *diff
 			return
 		}
 
+		// A oneOf wrapping (#702) is reported once per body as
+		// response-body-wrapped-in-one-of; don't also report its added
+		// alternatives as a raw one-of-added.
+		if !info.schemaDiff.OneOfWrappingDiff.Empty() {
+			return
+		}
+
 		if info.schemaDiff.OneOfDiff != nil {
 			if added := info.schemaDiff.OneOfDiff.Added; len(added) > 0 {
 				baseSource, revisionSource := SubschemaSources(operationsSources, info.operationItem, info.schemaDiff, "oneOf", -1, added[0].Index)

--- a/checker/check_response_property_type_changed.go
+++ b/checker/check_response_property_type_changed.go
@@ -21,6 +21,14 @@ func ResponsePropertyTypeChangedCheck(diffReport *diff.Diff, operationsSources *
 			return
 		}
 
+		// A oneOf wrapping (#702) reads as a top-level type change to "any"
+		// (the oneOf wrapper has no type of its own); it's reported once per
+		// body as response-body-wrapped-in-one-of, so don't also report a body
+		// type change.
+		if !schemaDiff.OneOfWrappingDiff.Empty() {
+			return
+		}
+
 		typeDiff := schemaDiff.TypeDiff
 		formatDiff := schemaDiff.FormatDiff
 

--- a/checker/check_response_required_property_updated_test.go
+++ b/checker/check_response_required_property_updated_test.go
@@ -128,14 +128,17 @@ func TestResponsePropertyOneOfWrappingIsBreaking(t *testing.T) {
 	require.False(t, containsId(errs, checker.ResponseOptionalPropertyRemovedId),
 		"properties moved into a oneOf wrapping must not be reported as removed (#702)")
 
+	// The mechanical artifacts of the wrapping (the added oneOf alternatives,
+	// the top-level type going to "any") are redundant with the single wrapped
+	// finding and must be suppressed too.
+	require.False(t, containsId(errs, checker.ResponseBodyOneOfAddedId),
+		"the wrapping's added alternatives must not also be reported as one-of-added (#702)")
+	require.False(t, containsId(errs, checker.ResponseBodyTypeChangedId),
+		"the wrapping's top-level type change to 'any' must not also be reported (#702)")
+
 	// The wrapping must be reported exactly once per response body (not per
-	// property), as a breaking error.
-	wrapped := 0
-	for _, e := range errs {
-		if e.GetId() == checker.ResponseBodyWrappedInOneOfId {
-			wrapped++
-			require.Equal(t, checker.ERR, e.GetLevel())
-		}
-	}
-	require.Equal(t, 1, wrapped, "the wrapping must be reported once as a breaking error (#702)")
+	// property), as a breaking error, and nothing else.
+	require.Len(t, errs, 1, "a oneOf wrapping must produce exactly one finding (#702)")
+	require.Equal(t, checker.ResponseBodyWrappedInOneOfId, errs[0].GetId())
+	require.Equal(t, checker.ERR, errs[0].GetLevel())
 }

--- a/data/checker/request_property_one_of_wrapped_base.yaml
+++ b/data/checker/request_property_one_of_wrapped_base.yaml
@@ -15,5 +15,6 @@ paths:
               properties:
                 foo: { type: string }
                 bar: { type: string }
+                baz: { type: string }
       responses:
         "200": { description: Success }

--- a/data/checker/request_property_one_of_wrapped_revision.yaml
+++ b/data/checker/request_property_one_of_wrapped_revision.yaml
@@ -16,10 +16,12 @@ paths:
                   properties:
                     foo: { type: string }
                     bar: { type: string }
+                    baz: { type: string }
                 - type: object
                   required: ["bar"]
                   properties:
                     foo: { type: string }
                     bar: { type: string }
+                    baz: { type: string }
       responses:
         "200": { description: Success }


### PR DESCRIPTION
Follow-up to #1038. When a concrete object body is wrapped into a `oneOf` (#702), the restructuring was reported by three separate checks:

- `*-body-wrapped-in-one-of` (the accurate, human-readable finding added in #1022/#1038)
- `*-body-one-of-added` (the raw "alternatives were added")
- `*-body-type-changed` / `*-body-type-generalized` (the top-level `type` reading as `any`, because a `oneOf` wrapper has no `type` of its own)

On the request side the latter two are INFO, so the noise was hidden (1 error + 2 info). On the response side contravariance makes them ERROR, so a single wrapping produced **three** overlapping breaking findings:

```
3 changes: 3 error, 0 warning, 0 info
error  [response-body-one-of-added] ...
error  [response-body-type-changed] ...
error  [response-body-wrapped-in-one-of] ...
```

## Change

Suppress `one-of-added` and the body type change when the schema diff carries a recognized `OneOfWrappingDiff`, on both request and response sides. This mirrors the existing `ListOfTypesDiff` suppression already present in those same checks (`shouldSuppress*ForListOfTypes`). Each wrapped body now emits exactly one finding on each side, symmetric, with severity differing only by contravariance:

```
1 changes: 1 error, 0 warning, 0 info
error  [response-body-wrapped-in-one-of] ...
```

The `type` going to `any` here is also borderline misleading: the body did not become "anything", it became a union of typed alternatives. The `wrapped-in-one-of` finding is the accurate description.

## Tests

- Added an optional property to the request fixture (the response fixture already had one in #1038) so the moved-property suppression is exercised for both required and optional properties.
- Broadened both wrapping tests to run the full check set and assert the single-finding outcome (one-of-added and the body type change explicitly absent).
- No rule count change; `TestRuleSymmetry` and the full suite pass.