### PR TITLE
checker: privatize the property-walk primitives (closes #953)

### DIFF
--- a/checker/check_new_requried_request_header_property.go
+++ b/checker/check_new_requried_request_header_property.go
@@ -33,7 +33,7 @@ func NewRequiredRequestHeaderPropertyCheck(diffReport *diff.Diff, operationsSour
 
 				for paramName, paramDiff := range paramDiffs {
 					baseSource, revisionSource := ParameterSources(operationsSources, operationItem, paramDiff)
-					CheckAddedPropertiesDiff(
+					checkAddedPropertiesDiff(
 						paramDiff.SchemaDiff,
 						func(propertyPath string, newPropertyName string, newProperty *openapi3.Schema, parent *diff.SchemaDiff) {
 							if newProperty.ReadOnly {

--- a/checker/check_property_stability_level.go
+++ b/checker/check_property_stability_level.go
@@ -31,7 +31,7 @@ func RequestPropertyStabilityUpdatedCheck(diffReport *diff.Diff, operationsSourc
 			}
 			op := operationItem.Revision
 			for _, mediaTypeDiff := range operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified {
-				CheckModifiedPropertiesDiff(
+				checkModifiedPropertiesDiff(
 					mediaTypeDiff.SchemaDiff,
 					func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
 						checkPropertyStabilityChange(propertyDiff, propertyPath, propertyName,
@@ -67,7 +67,7 @@ func ResponsePropertyStabilityUpdatedCheck(diffReport *diff.Diff, operationsSour
 					continue
 				}
 				for _, mediaTypeDiff := range responseDiff.ContentDiff.MediaTypeModified {
-					CheckModifiedPropertiesDiff(
+					checkModifiedPropertiesDiff(
 						mediaTypeDiff.SchemaDiff,
 						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
 							checkPropertyStabilityChange(propertyDiff, propertyPath, propertyName,

--- a/checker/check_request_header_property_became_enum.go
+++ b/checker/check_request_header_property_became_enum.go
@@ -48,7 +48,7 @@ func RequestHeaderPropertyBecameEnumCheck(diffReport *diff.Diff, operationsSourc
 						).WithSources(baseSource, revisionSource))
 					}
 
-					CheckModifiedPropertiesDiff(
+					checkModifiedPropertiesDiff(
 						paramDiff.SchemaDiff,
 						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
 

--- a/checker/check_request_header_property_became_required.go
+++ b/checker/check_request_header_property_became_required.go
@@ -62,7 +62,7 @@ func RequestHeaderPropertyBecameRequiredCheck(diffReport *diff.Diff, operationsS
 						}
 					}
 
-					CheckModifiedPropertiesDiff(
+					checkModifiedPropertiesDiff(
 						paramDiff.SchemaDiff,
 						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
 							requiredDiff := propertyDiff.RequiredDiff

--- a/checker/check_request_parameter_enum_value_updated.go
+++ b/checker/check_request_parameter_enum_value_updated.go
@@ -45,7 +45,7 @@ func RequestParameterEnumValueUpdatedCheck(diffReport *diff.Diff, operationsSour
 						func(enumVal any) []any { return []any{enumVal, paramLocation, paramName} },
 					)...)
 
-					CheckModifiedPropertiesDiff(
+					checkModifiedPropertiesDiff(
 						paramItem.SchemaDiff,
 						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
 							result = append(result, checkParameterEnumDiff(

--- a/checker/check_request_parameter_list_of_types_changed.go
+++ b/checker/check_request_parameter_list_of_types_changed.go
@@ -44,7 +44,7 @@ func RequestParameterListOfTypesChangedCheck(diffReport *diff.Diff, operationsSo
 
 					// Check parameter properties
 					if paramDiff.SchemaDiff != nil {
-						CheckModifiedPropertiesDiff(
+						checkModifiedPropertiesDiff(
 							paramDiff.SchemaDiff,
 							func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
 								changes := checkParameterPropertyListOfTypesChange(

--- a/checker/check_request_parameters_type_changed.go
+++ b/checker/check_request_parameters_type_changed.go
@@ -171,7 +171,7 @@ func RequestParameterTypeChangedCheck(diffReport *diff.Diff, operationsSources *
 						).WithSources(baseSource, revisionSource))
 					}
 
-					CheckModifiedPropertiesDiff(
+					checkModifiedPropertiesDiff(
 						schemaDiff,
 						func(propertyPath string, propertyName string, propertyDiff *diff.SchemaDiff, parent *diff.SchemaDiff) {
 

--- a/checker/check_request_property_updated.go
+++ b/checker/check_request_property_updated.go
@@ -31,10 +31,10 @@ func RequestPropertyUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.
 			).WithSources(nil, nil))
 		}
 
-		// CheckDeletedPropertiesDiff / CheckAddedPropertiesDiff handle the
+		// checkDeletedPropertiesDiff / checkAddedPropertiesDiff handle the
 		// added/removed property sides — different from info.walkProperties,
-		// which delegates to CheckModifiedPropertiesDiff. Used directly here.
-		CheckDeletedPropertiesDiff(
+		// which delegates to checkModifiedPropertiesDiff. Used directly here.
+		checkDeletedPropertiesDiff(
 			info.schemaDiff,
 			func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, parent *diff.SchemaDiff) {
 				if propertyItem.ReadOnly {
@@ -57,7 +57,7 @@ func RequestPropertyUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.
 				).WithSources(baseSource, nil))
 			})
 
-		CheckAddedPropertiesDiff(
+		checkAddedPropertiesDiff(
 			info.schemaDiff,
 			func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, parent *diff.SchemaDiff) {
 				if propertyItem.ReadOnly {

--- a/checker/check_response_optional_property_updated.go
+++ b/checker/check_response_optional_property_updated.go
@@ -18,11 +18,11 @@ func ResponseOptionalPropertyUpdatedCheck(diffReport *diff.Diff, operationsSourc
 	result := make(Changes, 0)
 
 	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
-		// CheckDeletedPropertiesDiff / CheckAddedPropertiesDiff handle the
+		// checkDeletedPropertiesDiff / checkAddedPropertiesDiff handle the
 		// added/removed property sides; info.walkProperties only delegates
-		// to CheckModifiedPropertiesDiff so the primitives are called
+		// to checkModifiedPropertiesDiff so the primitives are called
 		// directly inside the walker callback.
-		CheckDeletedPropertiesDiff(
+		checkDeletedPropertiesDiff(
 			info.schemaDiff,
 			func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, parent *diff.SchemaDiff) {
 				if slices.Contains(parent.Base.Required, propertyName) {
@@ -50,7 +50,7 @@ func ResponseOptionalPropertyUpdatedCheck(diffReport *diff.Diff, operationsSourc
 				).WithSources(baseSource, nil))
 			})
 
-		CheckAddedPropertiesDiff(
+		checkAddedPropertiesDiff(
 			info.schemaDiff,
 			func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, parent *diff.SchemaDiff) {
 				if slices.Contains(parent.Revision.Required, propertyName) {

--- a/checker/check_response_required_property_updated.go
+++ b/checker/check_response_required_property_updated.go
@@ -33,11 +33,11 @@ func ResponseRequiredPropertyUpdatedCheck(diffReport *diff.Diff, operationsSourc
 			).WithSources(nil, nil))
 		}
 
-		// CheckDeletedPropertiesDiff / CheckAddedPropertiesDiff walk
+		// checkDeletedPropertiesDiff / checkAddedPropertiesDiff walk
 		// properties that were dropped or introduced entirely, not just
 		// modified ones — different from info.walkProperties, which
-		// delegates to CheckModifiedPropertiesDiff. Used directly here.
-		CheckDeletedPropertiesDiff(
+		// delegates to checkModifiedPropertiesDiff. Used directly here.
+		checkDeletedPropertiesDiff(
 			info.schemaDiff,
 			func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, parent *diff.SchemaDiff) {
 				id := ResponseRequiredPropertyRemovedId
@@ -65,7 +65,7 @@ func ResponseRequiredPropertyUpdatedCheck(diffReport *diff.Diff, operationsSourc
 					"",
 				).WithSources(baseSource, nil))
 			})
-		CheckAddedPropertiesDiff(
+		checkAddedPropertiesDiff(
 			info.schemaDiff,
 			func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, parent *diff.SchemaDiff) {
 				id := ResponseRequiredPropertyAddedId

--- a/checker/checks_utils.go
+++ b/checker/checks_utils.go
@@ -65,7 +65,7 @@ func interfaceToString(arg any) string {
 	return fmt.Sprintf("%v", arg)
 }
 
-func CheckModifiedPropertiesDiff(schemaDiff *diff.SchemaDiff, processor func(propertyPath string, propertyName string, propertyItem *diff.SchemaDiff, propertyParentItem *diff.SchemaDiff)) {
+func checkModifiedPropertiesDiff(schemaDiff *diff.SchemaDiff, processor func(propertyPath string, propertyName string, propertyItem *diff.SchemaDiff, propertyParentItem *diff.SchemaDiff)) {
 	if schemaDiff == nil {
 		return
 	}
@@ -174,7 +174,7 @@ func processModifiedPropertiesDiff(propertyPath string, propertyName string, sch
 	}
 }
 
-func CheckAddedPropertiesDiff(schemaDiff *diff.SchemaDiff, processor func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, propertyParentDiff *diff.SchemaDiff)) {
+func checkAddedPropertiesDiff(schemaDiff *diff.SchemaDiff, processor func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, propertyParentDiff *diff.SchemaDiff)) {
 	if schemaDiff == nil {
 		return
 	}
@@ -281,7 +281,7 @@ func processAddedPropertiesDiff(propertyPath string, propertyName string, schema
 	}
 }
 
-func CheckDeletedPropertiesDiff(schemaDiff *diff.SchemaDiff, processor func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, propertyParentDiff *diff.SchemaDiff)) {
+func checkDeletedPropertiesDiff(schemaDiff *diff.SchemaDiff, processor func(propertyPath string, propertyName string, propertyItem *openapi3.Schema, propertyParentDiff *diff.SchemaDiff)) {
 	if schemaDiff == nil {
 		return
 	}

--- a/checker/media_type_walker.go
+++ b/checker/media_type_walker.go
@@ -56,7 +56,7 @@ func (info mediaTypeInfo) newChange(id string, args []any, comment string) ApiCh
 
 // walkProperties walks every modified property under info.schemaDiff and
 // invokes processor with a propertyInfo for each. Delegates to
-// CheckModifiedPropertiesDiff, so the recursion covers AllOf / AnyOf /
+// checkModifiedPropertiesDiff, so the recursion covers AllOf / AnyOf /
 // OneOf / Items / PatternProperties / DependentSchemas and the OpenAPI 3.1
 // sub-schema fields exactly as that primitive does.
 //
@@ -66,7 +66,7 @@ func (info mediaTypeInfo) newChange(id string, args []any, comment string) ApiCh
 // WithSources(propBaseSource, propRevisionSource) with the property-
 // specific sources.
 func (info mediaTypeInfo) walkProperties(processor func(p propertyInfo)) {
-	CheckModifiedPropertiesDiff(info.schemaDiff, func(propertyPath, propertyName string, propertyDiff, parent *diff.SchemaDiff) {
+	checkModifiedPropertiesDiff(info.schemaDiff, func(propertyPath, propertyName string, propertyDiff, parent *diff.SchemaDiff) {
 		// The traversal also descends into single-valued sub-schemas (items,
 		// not, if/then/else, contentSchema, ...). When such a sub-schema exists
 		// on only one side (e.g. `items` removed in the revision), its diff has
@@ -96,7 +96,7 @@ func (info mediaTypeInfo) walkProperties(processor func(p propertyInfo)) {
 // media-type).
 //
 // propertyPath, propertyName, and propertyDiff are the same triple
-// CheckModifiedPropertiesDiff passes to its processor; parent is the
+// checkModifiedPropertiesDiff passes to its processor; parent is the
 // containing schema diff.
 type propertyInfo struct {
 	mediaTypeInfo


### PR DESCRIPTION
Closes #953.

`CheckModifiedPropertiesDiff` / `CheckAddedPropertiesDiff` / `CheckDeletedPropertiesDiff` in `checker/checks_utils.go` are exported but have **zero external callers** - verified across this repo, the `checker_test` files, and oasdiff-service. They are internal property-walk primitives consumed by the media-type walker, and that migration is complete.

Lower-cased to `check*PropertiesDiff` across the 12 files that use them. No behavior change, suite is green. The only effect is removing them from the public Go API surface (a library-only change; no CLI or machine-output impact).