### PR TITLE
test(checker): drop the vestigial BC:/CL: prefixes from test comments

### DIFF
--- a/checker/check_api_added_test.go
+++ b/checker/check_api_added_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: new paths or path operations
+// new paths or path operations
 func TestApiAdded_DetectsNewPathsAndNewOperations(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
 	s1, err := open("../data/new_endpoints/base.yaml", loader)
@@ -43,7 +43,7 @@ func TestApiAdded_DetectsNewPathsAndNewOperations(t *testing.T) {
 	require.Equal(t, checker.NewSource("../data/new_endpoints/revision.yaml", 27, 5), e1.GetRevisionSource())
 }
 
-// CL: new paths or path operations
+// new paths or path operations
 func TestApiAdded_DetectsModifiedPathsWithPathParam(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
 	s1, err := open("../data/new_endpoints/base_with_path_param.yaml", loader)

--- a/checker/check_api_deprecation_test.go
+++ b/checker/check_api_deprecation_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// BC: deprecating an operation with a deprecation policy and an invalid sunset date is breaking
+// deprecating an operation with a deprecation policy and an invalid sunset date is breaking
 func TestBreaking_DeprecationWithInvalidSunset(t *testing.T) {
 
 	s1, err := open(deprecationFile("base.yaml"))
@@ -30,7 +30,7 @@ func TestBreaking_DeprecationWithInvalidSunset(t *testing.T) {
 	require.Equal(t, "failed to parse sunset date: `sunset date doesn't conform with RFC3339: invalid`", requireChange(t, errs, checker.APIDeprecatedSunsetParseId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: deprecating an operation with a deprecation policy and an invalid stability level is breaking
+// deprecating an operation with a deprecation policy and an invalid stability level is breaking
 func TestBreaking_DeprecationWithInvalidStabilityLevel(t *testing.T) {
 
 	s1, err := open(deprecationFile("base.yaml"))
@@ -49,7 +49,7 @@ func TestBreaking_DeprecationWithInvalidStabilityLevel(t *testing.T) {
 	require.Equal(t, "../data/deprecation/deprecated-with-invalid-stability.yaml", errs[0].GetSource())
 }
 
-// BC: deprecating an operation without a deprecation policy but without specifying sunset date is not breaking
+// deprecating an operation without a deprecation policy but without specifying sunset date is not breaking
 func TestBreaking_DeprecationWithoutSunsetNoPolicy(t *testing.T) {
 
 	s1, err := open(deprecationFile("base.yaml"))
@@ -65,7 +65,7 @@ func TestBreaking_DeprecationWithoutSunsetNoPolicy(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: deprecating an operation with a deprecation policy but without specifying sunset date is breaking
+// deprecating an operation with a deprecation policy but without specifying sunset date is breaking
 func TestBreaking_DeprecationWithoutSunsetWithPolicy(t *testing.T) {
 
 	s1, err := open(deprecationFile("base.yaml"))
@@ -82,7 +82,7 @@ func TestBreaking_DeprecationWithoutSunsetWithPolicy(t *testing.T) {
 	require.Equal(t, "sunset date is missing for deprecated API", requireChange(t, errs, checker.APIDeprecatedSunsetMissingId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: deprecating an operation with a default deprecation policy but without specifying sunset date is not breaking
+// deprecating an operation with a default deprecation policy but without specifying sunset date is not breaking
 func TestBreaking_DeprecationWithoutSunset(t *testing.T) {
 
 	s1, err := open(deprecationFile("base.yaml"))
@@ -98,7 +98,7 @@ func TestBreaking_DeprecationWithoutSunset(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: deprecating an operation without a deprecation policy and without specifying sunset date is not breaking for alpha level
+// deprecating an operation without a deprecation policy and without specifying sunset date is not breaking for alpha level
 func TestBreaking_DeprecationForAlpha(t *testing.T) {
 
 	s1, err := open(deprecationFile("base-alpha-stability.yaml"))
@@ -113,7 +113,7 @@ func TestBreaking_DeprecationForAlpha(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: deprecating an operation without a deprecation policy and without specifying sunset date is not breaking for draft level
+// deprecating an operation without a deprecation policy and without specifying sunset date is not breaking for draft level
 func TestBreaking_DeprecationForDraft(t *testing.T) {
 	s1, err := open(deprecationFile("base-alpha-stability.yaml"))
 	require.NoError(t, err)
@@ -137,7 +137,7 @@ func toJson(t *testing.T, value string) json.RawMessage {
 	return data
 }
 
-// BC: deprecating an operation with a deprecation policy and sunset date before required deprecation period is breaking
+// deprecating an operation with a deprecation policy and sunset date before required deprecation period is breaking
 func TestBreaking_DeprecationWithEarlySunset(t *testing.T) {
 	s1, err := open(deprecationFile("base.yaml"))
 	require.NoError(t, err)
@@ -156,7 +156,7 @@ func TestBreaking_DeprecationWithEarlySunset(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("sunset date `%s` is too small, must be at least `10` days from now", sunsetDate), requireChange(t, errs, checker.APISunsetDateTooSmallId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: deprecating an operation with a deprecation policy and sunset date after required deprecation period is not breaking
+// deprecating an operation with a deprecation policy and sunset date after required deprecation period is not breaking
 func TestBreaking_DeprecationWithProperSunset(t *testing.T) {
 
 	s1, err := open(deprecationFile("base.yaml"))
@@ -178,7 +178,7 @@ func TestBreaking_DeprecationWithProperSunset(t *testing.T) {
 	require.Contains(t, errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()), "endpoint deprecated")
 }
 
-// CL: path operations that became deprecated
+// path operations that became deprecated
 func TestApiDeprecated_DetectsDeprecatedOperations(t *testing.T) {
 	s1, err := open(deprecationFile("base.yaml"))
 	require.NoError(t, err)
@@ -201,7 +201,7 @@ func TestApiDeprecated_DetectsDeprecatedOperations(t *testing.T) {
 	require.Contains(t, e0.GetUncolorizedText(checker.NewDefaultLocalizer()), "endpoint deprecated")
 }
 
-// CL: path operations that were re-activated
+// path operations that were re-activated
 func TestApiDeprecated_DetectsReactivatedOperations(t *testing.T) {
 	s1, err := open(deprecationFile("deprecated-future.yaml"))
 	require.NoError(t, err)
@@ -246,7 +246,7 @@ func TestBreaking_InvaidStability(t *testing.T) {
 	require.Equal(t, "../data/deprecation/invalid-stability.yaml", errs[0].GetSource())
 }
 
-// CL: message includes sunset details when endpoint deprecated with sunset date
+// message includes sunset details when endpoint deprecated with sunset date
 func TestApiDeprecated_MessageIncludesSunset(t *testing.T) {
 	s1, err := open(deprecationFile("base.yaml"))
 	require.NoError(t, err)
@@ -265,7 +265,7 @@ func TestApiDeprecated_MessageIncludesSunset(t *testing.T) {
 	require.Contains(t, errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()), "endpoint deprecated")
 }
 
-// CL: message includes both sunset and stability when endpoint deprecated with both
+// message includes both sunset and stability when endpoint deprecated with both
 func TestApiDeprecated_MessageIncludesSunsetAndStability(t *testing.T) {
 	s1, err := open(deprecationFile("base.yaml"))
 	require.NoError(t, err)
@@ -285,7 +285,7 @@ func TestApiDeprecated_MessageIncludesSunsetAndStability(t *testing.T) {
 	require.Contains(t, deprecationChange.GetUncolorizedText(checker.NewDefaultLocalizer()), "stability: beta")
 }
 
-// CL: message has no details when endpoint deprecated without sunset or stability
+// message has no details when endpoint deprecated without sunset or stability
 func TestApiDeprecated_MessageWithoutDetails(t *testing.T) {
 	s1, err := open(deprecationFile("base.yaml"))
 	require.NoError(t, err)
@@ -303,7 +303,7 @@ func TestApiDeprecated_MessageWithoutDetails(t *testing.T) {
 	require.Equal(t, "endpoint deprecated", requireChange(t, errs, checker.EndpointDeprecatedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: message includes stability when endpoint deprecated with stability but no sunset
+// message includes stability when endpoint deprecated with stability but no sunset
 func TestApiDeprecated_MessageIncludesStabilityOnly(t *testing.T) {
 	s1, err := open(deprecationFile("base-beta-stability.yaml"))
 	require.NoError(t, err)
@@ -321,7 +321,7 @@ func TestApiDeprecated_MessageIncludesStabilityOnly(t *testing.T) {
 	require.Equal(t, "endpoint deprecated (stability: beta)", requireChange(t, errs, checker.EndpointDeprecatedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: deprecating an operation with a sunset date in RFC3339 format is properly parsed
+// deprecating an operation with a sunset date in RFC3339 format is properly parsed
 func TestBreaking_DeprecationWithRFC3339Sunset(t *testing.T) {
 	s1, err := open(deprecationFile("base.yaml"))
 	require.NoError(t, err)
@@ -344,7 +344,7 @@ func TestBreaking_DeprecationWithRFC3339Sunset(t *testing.T) {
 	require.Equal(t, checker.INFO, errs[0].GetLevel())
 }
 
-// BC: deprecating an operation with invalid JSON sunset date is breaking
+// deprecating an operation with invalid JSON sunset date is breaking
 func TestBreaking_DeprecationWithInvalidJsonSunset(t *testing.T) {
 	s1, err := open(deprecationFile("base.yaml"))
 	require.NoError(t, err)
@@ -364,7 +364,7 @@ func TestBreaking_DeprecationWithInvalidJsonSunset(t *testing.T) {
 	require.Contains(t, errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()), "failed to unmarshal sunset json")
 }
 
-// CL: endpoint deprecation message includes sunset date
+// endpoint deprecation message includes sunset date
 func TestEndpointDeprecation_MessageWithSunsetDate(t *testing.T) {
 	s1, err := open(deprecationFile("base.yaml"))
 	require.NoError(t, err)

--- a/checker/check_api_operation_id_updated_test.go
+++ b/checker/check_api_operation_id_updated_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: removing an existing operation id
+// removing an existing operation id
 func TestOperationIdRemoved(t *testing.T) {
 	s1, err := open("../data/checker/operation_id_removed_base.yaml")
 	require.NoError(t, err)
@@ -31,7 +31,7 @@ func TestOperationIdRemoved(t *testing.T) {
 	}, errs)
 }
 
-// CL: updating an existing operation id
+// updating an existing operation id
 func TestOperationIdUpdated(t *testing.T) {
 	s1, err := open("../data/checker/operation_id_removed_base.yaml")
 	require.NoError(t, err)
@@ -55,7 +55,7 @@ func TestOperationIdUpdated(t *testing.T) {
 	require.Equal(t, "api operation id `createOneGroup` removed and replaced with `newOperationId`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: removing an existing operation id with source tracking
+// removing an existing operation id with source tracking
 func TestOperationIdRemoved_WithSources(t *testing.T) {
 	s1, err := open("../data/checker/operation_id_removed_base.yaml", newLoaderWithOriginTracking())
 	require.NoError(t, err)
@@ -78,7 +78,7 @@ func TestOperationIdRemoved_WithSources(t *testing.T) {
 	require.Empty(t, errs[0].GetRevisionSource())
 }
 
-// CL: adding a new operation id
+// adding a new operation id
 func TestOperationIdAdded(t *testing.T) {
 	s1, err := open("../data/checker/operation_id_added_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_api_removed_test.go
+++ b/checker/check_api_removed_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// BC: deleting a path without deprecation is breaking
+// deleting a path without deprecation is breaking
 func TestBreaking_DeletedPath(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
 	errs := d(t, diff.NewConfig(), 1, 701, loader)
@@ -20,7 +20,7 @@ func TestBreaking_DeletedPath(t *testing.T) {
 	require.Empty(t, errs[0].GetRevisionSource())
 }
 
-// BC: deleting an operation without deprecation is breaking
+// deleting an operation without deprecation is breaking
 func TestBreaking_DeletedOp(t *testing.T) {
 	s1 := l(t, 1, newLoaderWithOriginTracking())
 	s2 := l(t, 1, newLoaderWithOriginTracking())
@@ -38,7 +38,7 @@ func TestBreaking_DeletedOp(t *testing.T) {
 	require.Empty(t, errs[0].GetRevisionSource())
 }
 
-// BC: deleting an operation after sunset date is not breaking
+// deleting an operation after sunset date is not breaking
 func TestBreaking_DeprecationPast(t *testing.T) {
 
 	s1, err := open(deprecationFile("deprecated-past.yaml"))
@@ -53,7 +53,7 @@ func TestBreaking_DeprecationPast(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: deleting an operation before sunset date is breaking
+// deleting an operation before sunset date is breaking
 func TestBreaking_RemoveBeforeSunset(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
 
@@ -74,7 +74,7 @@ func TestBreaking_RemoveBeforeSunset(t *testing.T) {
 	require.Empty(t, errs[0].GetRevisionSource())
 }
 
-// BC: deleting a deprecated operation without sunset date is not breaking
+// deleting a deprecated operation without sunset date is not breaking
 func TestBreaking_DeprecationNoSunset(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
 
@@ -95,7 +95,7 @@ func TestBreaking_DeprecationNoSunset(t *testing.T) {
 	require.Empty(t, errs[0].GetRevisionSource())
 }
 
-// BC: removing the path without a deprecation policy and without specifying sunset date is not breaking for alpha level
+// removing the path without a deprecation policy and without specifying sunset date is not breaking for alpha level
 func TestBreaking_RemovedPathForAlpha(t *testing.T) {
 	s1, err := open(deprecationFile("base-alpha-stability.yaml"))
 	require.NoError(t, err)
@@ -114,7 +114,7 @@ func TestBreaking_RemovedPathForAlpha(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: removing the path without a deprecation policy and without specifying sunset date is not breaking for draft level
+// removing the path without a deprecation policy and without specifying sunset date is not breaking for draft level
 func TestBreaking_RemovedPathForDraft(t *testing.T) {
 	s1, err := open(deprecationFile("base-alpha-stability.yaml"))
 	require.NoError(t, err)
@@ -133,7 +133,7 @@ func TestBreaking_RemovedPathForDraft(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: removing the path without a deprecation policy and without specifying sunset date is breaking for endpoints with non draft/alpha stability level
+// removing the path without a deprecation policy and without specifying sunset date is breaking for endpoints with non draft/alpha stability level
 func TestBreaking_RemovedPathForAlphaBreaking(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
 	s1, err := open(deprecationFile("base-alpha-stability.yaml"), loader)
@@ -152,7 +152,7 @@ func TestBreaking_RemovedPathForAlphaBreaking(t *testing.T) {
 	require.Empty(t, errs[0].GetRevisionSource())
 }
 
-// BC: removing the path without a deprecation policy and without specifying sunset date is breaking for endpoints with non draft/alpha stability level
+// removing the path without a deprecation policy and without specifying sunset date is breaking for endpoints with non draft/alpha stability level
 func TestBreaking_RemovedPathForDraftBreaking(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
 	s1, err := open(deprecationFile("base-draft-stability.yaml"), loader)
@@ -171,7 +171,7 @@ func TestBreaking_RemovedPathForDraftBreaking(t *testing.T) {
 	require.Empty(t, errs[0].GetRevisionSource())
 }
 
-// BC: deleting a path after sunset date of all contained operations is not breaking
+// deleting a path after sunset date of all contained operations is not breaking
 func TestBreaking_DeprecationPathPast(t *testing.T) {
 
 	s1, err := open(deprecationFile("deprecated-path-past.yaml"))
@@ -186,7 +186,7 @@ func TestBreaking_DeprecationPathPast(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: deleting a path with some operations having sunset date in the future is breaking
+// deleting a path with some operations having sunset date in the future is breaking
 func TestBreaking_DeprecationPathMixed(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
 
@@ -207,7 +207,7 @@ func TestBreaking_DeprecationPathMixed(t *testing.T) {
 	require.Empty(t, errs[0].GetRevisionSource())
 }
 
-// BC: deleting a path with deprecated operations without sunset date is not breaking
+// deleting a path with deprecated operations without sunset date is not breaking
 func TestBreaking_PathDeprecationNoSunset(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
 
@@ -233,7 +233,7 @@ func TestBreaking_PathDeprecationNoSunset(t *testing.T) {
 	require.Empty(t, errs[0].GetRevisionSource())
 }
 
-// BC: removing a deprecated enpoint with an invalid date is breaking
+// removing a deprecated enpoint with an invalid date is breaking
 func TestBreaking_RemoveEndpointWithInvalidSunset(t *testing.T) {
 	s1, err := open(deprecationFile("deprecated-invalid.yaml"), newLoaderWithOriginTracking())
 	require.NoError(t, err)

--- a/checker/check_api_security_updated_test.go
+++ b/checker/check_api_security_updated_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding a new global security to the API
+// adding a new global security to the API
 func TestAPIGlobalSecurityyAdded(t *testing.T) {
 	s1, err := open("../data/checker/api_security_global_added_base.yaml")
 	require.NoError(t, err)
@@ -28,7 +28,7 @@ func TestAPIGlobalSecurityyAdded(t *testing.T) {
 	require.Equal(t, "the security scheme `petstore_auth: [read:pets, write:pets]` was added to the API", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: removing a global security from the API
+// removing a global security from the API
 func TestAPIGlobalSecurityyDeleted(t *testing.T) {
 	s1, err := open("../data/checker/api_security_global_added_revision.yaml")
 	require.NoError(t, err)
@@ -47,7 +47,7 @@ func TestAPIGlobalSecurityyDeleted(t *testing.T) {
 	require.Equal(t, "the security scheme `petstore_auth: [read:pets, write:pets]` was removed from the API", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: removing a security scope from an API global security
+// removing a security scope from an API global security
 func TestAPIGlobalSecurityScopeRemoved(t *testing.T) {
 	s1, err := open("../data/checker/api_security_global_added_revision.yaml")
 	require.NoError(t, err)
@@ -67,7 +67,7 @@ func TestAPIGlobalSecurityScopeRemoved(t *testing.T) {
 	require.Equal(t, "the security scope `read:pets` was removed from the global security scheme `petstore_auth`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: adding a security scope from an API global security
+// adding a security scope from an API global security
 func TestAPIGlobalSecurityScopeAdded(t *testing.T) {
 	s1, err := open("../data/checker/api_security_global_added_revision.yaml")
 	require.NoError(t, err)
@@ -87,7 +87,7 @@ func TestAPIGlobalSecurityScopeAdded(t *testing.T) {
 	require.Equal(t, "the security scope `read:pets` was added to the global security scheme `petstore_auth`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: adding a new security to the API endpoint
+// adding a new security to the API endpoint
 func TestAPISecurityAdded(t *testing.T) {
 	s1, err := open("../data/checker/api_security_added_base.yaml")
 	require.NoError(t, err)
@@ -107,7 +107,7 @@ func TestAPISecurityAdded(t *testing.T) {
 	require.Equal(t, "the endpoint scheme security `petstore_auth: [read:pets, write:pets]` was added to the API", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: removing a new security to the API endpoint
+// removing a new security to the API endpoint
 func TestAPISecurityDeleted(t *testing.T) {
 	s1, err := open("../data/checker/api_security_added_revision.yaml")
 	require.NoError(t, err)
@@ -127,7 +127,7 @@ func TestAPISecurityDeleted(t *testing.T) {
 	require.Equal(t, "the endpoint scheme security `petstore_auth: [read:pets, write:pets]` was removed from the API", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: removing a security scope from an API endpoint security
+// removing a security scope from an API endpoint security
 func TestAPISecurityScopeRemoved(t *testing.T) {
 	s1, err := open("../data/checker/api_security_updated_base.yaml")
 	require.NoError(t, err)
@@ -147,7 +147,7 @@ func TestAPISecurityScopeRemoved(t *testing.T) {
 	require.Equal(t, "the security scope `read:pets` was removed from the endpoint's security scheme `petstore_auth`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: adding a security scope to an API endpoint security
+// adding a security scope to an API endpoint security
 func TestAPISecurityScopeAdded(t *testing.T) {
 	s1, err := open("../data/checker/api_security_updated_revision.yaml")
 	require.NoError(t, err)

--- a/checker/check_api_stability_level_test.go
+++ b/checker/check_api_stability_level_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// BC: decreasing stability level is breaking
+// decreasing stability level is breaking
 func TestBreaking_StabilityLevelDecreased(t *testing.T) {
 
 	s1, err := open(deprecationFile("base-beta-stability.yaml"))
@@ -34,7 +34,7 @@ func TestBreaking_StabilityLevelDecreased(t *testing.T) {
 	require.Equal(t, "endpoint stability level decreased from `beta` to `alpha`", e0.GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: increasing stability level is not breaking
+// increasing stability level is not breaking
 func TestBreaking_StabilityLevelIncreased(t *testing.T) {
 
 	s1, err := open(deprecationFile("base-alpha-stability.yaml"))
@@ -49,7 +49,7 @@ func TestBreaking_StabilityLevelIncreased(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: specifying an invalid stability level in revision is breaking
+// specifying an invalid stability level in revision is breaking
 func TestBreaking_InvalidStabilityLevelInRevision(t *testing.T) {
 	s1, err := open(deprecationFile("base.yaml"))
 	require.NoError(t, err)
@@ -65,7 +65,7 @@ func TestBreaking_InvalidStabilityLevelInRevision(t *testing.T) {
 	require.Equal(t, "../data/deprecation/base-invalid-stability.yaml", errs[0].GetSource())
 }
 
-// BC: specifying an invalid stability level in base is breaking
+// specifying an invalid stability level in base is breaking
 func TestBreaking_InvalidStabilityLevelInBase(t *testing.T) {
 	s1, err := open(deprecationFile("base-invalid-stability.yaml"))
 	require.NoError(t, err)
@@ -81,7 +81,7 @@ func TestBreaking_InvalidStabilityLevelInBase(t *testing.T) {
 	require.Equal(t, "../data/deprecation/base-invalid-stability.yaml", errs[0].GetSource())
 }
 
-// BC: specifying a non-text, not-json stability level in base is breaking
+// specifying a non-text, not-json stability level in base is breaking
 func TestBreaking_InvalidNonJsonStabilityLevel(t *testing.T) {
 	s1, err := open(deprecationFile("base.yaml"))
 	require.NoError(t, err)

--- a/checker/check_api_sunset_changed_test.go
+++ b/checker/check_api_sunset_changed_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// BC: deleting sunset header for a deprecated endpoint is breaking
+// deleting sunset header for a deprecated endpoint is breaking
 func TestBreaking_SunsetDeletedForDeprecatedEndpoint(t *testing.T) {
 
 	s1, err := open(deprecationFile("deprecated-with-sunset.yaml"))
@@ -25,7 +25,7 @@ func TestBreaking_SunsetDeletedForDeprecatedEndpoint(t *testing.T) {
 	require.Equal(t, "api sunset date deleted, but deprecated=true kept", requireChange(t, errs, checker.APISunsetDeletedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: changing sunset to an earlier date for a deprecated endpoint with a deprecation policy is breaking
+// changing sunset to an earlier date for a deprecated endpoint with a deprecation policy is breaking
 func TestBreaking_SunsetModifiedForDeprecatedEndpoint(t *testing.T) {
 
 	s1, err := open(deprecationFile("deprecated-future.yaml"))
@@ -42,7 +42,7 @@ func TestBreaking_SunsetModifiedForDeprecatedEndpoint(t *testing.T) {
 	require.Equal(t, "api sunset date changed to an earlier date, from `9999-08-10` to `2022-08-10`, new sunset date must be not earlier than `9999-08-10` and at least `180` days from now", requireChange(t, errs, checker.APISunsetDateChangedTooSmallId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: changing sunset to an invalid date for a deprecated endpoint is breaking
+// changing sunset to an invalid date for a deprecated endpoint is breaking
 func TestBreaking_SunsetModifiedToInvalidForDeprecatedEndpoint(t *testing.T) {
 
 	s1, err := open(deprecationFile("deprecated-future.yaml"))
@@ -59,7 +59,7 @@ func TestBreaking_SunsetModifiedToInvalidForDeprecatedEndpoint(t *testing.T) {
 	require.Equal(t, "failed to parse sunset date: `sunset date doesn't conform with RFC3339: invalid-date`", requireChange(t, errs, checker.APIPathSunsetParseId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: changing sunset from an invalid date for a deprecated endpoint is breaking
+// changing sunset from an invalid date for a deprecated endpoint is breaking
 func TestBreaking_SunsetModifiedFromInvalidForDeprecatedEndpoint(t *testing.T) {
 
 	s1, err := open(deprecationFile("deprecated-invalid.yaml"))
@@ -77,7 +77,7 @@ func TestBreaking_SunsetModifiedFromInvalidForDeprecatedEndpoint(t *testing.T) {
 	require.Equal(t, "../data/deprecation/deprecated-invalid.yaml", errs[0].GetSource())
 }
 
-// BC: deleting other extension (not sunset) header for a deprecated endpoint is not breaking
+// deleting other extension (not sunset) header for a deprecated endpoint is not breaking
 func TestBreaking_NonSunsetDeletedForDeprecatedEndpoint(t *testing.T) {
 
 	s1, err := open(deprecationFile("deprecated-with-other-extension.yaml"))
@@ -92,7 +92,7 @@ func TestBreaking_NonSunsetDeletedForDeprecatedEndpoint(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: no change to headers for a deprecated endpoint is not breaking
+// no change to headers for a deprecated endpoint is not breaking
 func TestBreaking_NoChangeToSunsetDeprecatedEndpoint(t *testing.T) {
 
 	s1, err := open(deprecationFile("deprecated-future.yaml"))

--- a/checker/check_api_tag_updated_test.go
+++ b/checker/check_api_tag_updated_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding a new tag
+// adding a new tag
 func TestTagAdded(t *testing.T) {
 	s1, err := open("../data/checker/tag_added_base.yaml")
 	require.NoError(t, err)
@@ -32,7 +32,7 @@ func TestTagAdded(t *testing.T) {
 	require.Equal(t, "api tag `newTag` added", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: removing an existing tag
+// removing an existing tag
 func TestTagRemoved(t *testing.T) {
 	s1, err := open("../data/checker/tag_removed_base.yaml")
 	require.NoError(t, err)
@@ -57,7 +57,7 @@ func TestTagRemoved(t *testing.T) {
 
 }
 
-// CL: updating an existing tag
+// updating an existing tag
 func TestTagUpdated(t *testing.T) {
 	s1, err := open("../data/checker/tag_removed_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_breaking_min_max_test.go
+++ b/checker/check_breaking_min_max_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// BC: reducing max length in request is breaking
+// reducing max length in request is breaking
 func TestBreaking_RequestMaxLengthSmaller(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -28,7 +28,7 @@ func TestBreaking_RequestMaxLengthSmaller(t *testing.T) {
 	requireChange(t, errs, checker.RequestParameterMaxLengthDecreasedId)
 }
 
-// BC: reducing max length in response is not breaking
+// reducing max length in response is not breaking
 func TestBreaking_ResponseMaxLengthSmaller(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -45,7 +45,7 @@ func TestBreaking_ResponseMaxLengthSmaller(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: reducing min length in request is not breaking
+// reducing min length in request is not breaking
 func TestBreaking_RequestMinLengthSmaller(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -59,7 +59,7 @@ func TestBreaking_RequestMinLengthSmaller(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: reducing min length in response is breaking
+// reducing min length in response is breaking
 func TestBreaking_MinLengthSmaller(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -73,7 +73,7 @@ func TestBreaking_MinLengthSmaller(t *testing.T) {
 	requireChange(t, errs, checker.ResponseBodyMinLengthDecreasedId)
 }
 
-// BC: increasing max length in request is not breaking
+// increasing max length in request is not breaking
 func TestBreaking_RequestMaxLengthGreater(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -90,7 +90,7 @@ func TestBreaking_RequestMaxLengthGreater(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: increasing max length in response is breaking
+// increasing max length in response is breaking
 func TestBreaking_ResponseMaxLengthGreater(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -107,7 +107,7 @@ func TestBreaking_ResponseMaxLengthGreater(t *testing.T) {
 	require.NotEmpty(t, errs)
 }
 
-// BC: changing max length in request from nil to any value is breaking
+// changing max length in request from nil to any value is breaking
 func TestBreaking_MaxLengthFromNil(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -125,7 +125,7 @@ func TestBreaking_MaxLengthFromNil(t *testing.T) {
 	requireChange(t, errs, checker.RequestParameterMaxLengthSetId)
 }
 
-// BC: changing max length in response from nil to any value is not breaking
+// changing max length in response from nil to any value is not breaking
 func TestBreaking_ResponseMaxLengthFromNil(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -141,7 +141,7 @@ func TestBreaking_ResponseMaxLengthFromNil(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: changing max length in request from any value to nil is not breaking
+// changing max length in request from any value to nil is not breaking
 func TestBreaking_RequestMaxLengthToNil(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -157,7 +157,7 @@ func TestBreaking_RequestMaxLengthToNil(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: changing max length in response from any value to nil is breaking
+// changing max length in response from any value to nil is breaking
 func TestBreaking_ResponseMaxLengthToNil(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -175,7 +175,7 @@ func TestBreaking_ResponseMaxLengthToNil(t *testing.T) {
 	requireChange(t, errs, checker.ResponseBodyMaxLengthUnsetId)
 }
 
-// BC: both max lengths in request are nil is not breaking
+// both max lengths in request are nil is not breaking
 func TestBreaking_MaxLengthBothNil(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -189,7 +189,7 @@ func TestBreaking_MaxLengthBothNil(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: both max lengths in response are nil is not breaking
+// both max lengths in response are nil is not breaking
 func TestBreaking_ResponseMaxLengthBothNil(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -203,7 +203,7 @@ func TestBreaking_ResponseMaxLengthBothNil(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: reducing min items in request is not breaking
+// reducing min items in request is not breaking
 func TestBreaking_RequestMinItemsSmaller(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -217,7 +217,7 @@ func TestBreaking_RequestMinItemsSmaller(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: reducing min items in response is breaking
+// reducing min items in response is breaking
 func TestBreaking_ResponseMinItemsSmaller(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -233,7 +233,7 @@ func TestBreaking_ResponseMinItemsSmaller(t *testing.T) {
 	requireChange(t, errs, checker.ResponseBodyMinItemsDecreasedId)
 }
 
-// BC: increasing min items in request is breaking
+// increasing min items in request is breaking
 func TestBreaking_RequeatMinItemsGreater(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -247,7 +247,7 @@ func TestBreaking_RequeatMinItemsGreater(t *testing.T) {
 	require.NotEmpty(t, errs)
 }
 
-// BC: increasing min items in response is not breaking
+// increasing min items in response is not breaking
 func TestBreaking_ResponseMinItemsGreater(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -261,7 +261,7 @@ func TestBreaking_ResponseMinItemsGreater(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: reducing max in request is breaking
+// reducing max in request is breaking
 func TestBreaking_MaxSmaller(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -278,7 +278,7 @@ func TestBreaking_MaxSmaller(t *testing.T) {
 	require.NotEmpty(t, errs)
 }
 
-// BC: reducing max in response is not breaking
+// reducing max in response is not breaking
 func TestBreaking_MaxSmallerInResponse(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)

--- a/checker/check_breaking_property_test.go
+++ b/checker/check_breaking_property_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// BC: new required property in request header is breaking
+// new required property in request header is breaking
 func TestBreaking_NewRequiredProperty(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -31,7 +31,7 @@ func TestBreaking_NewRequiredProperty(t *testing.T) {
 	require.Equal(t, checker.NewRequiredRequestHeaderPropertyId, errs[0].GetId())
 }
 
-// BC: new optional property in request header is not breaking
+// new optional property in request header is not breaking
 func TestBreaking_NewNonRequiredProperty(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -49,7 +49,7 @@ func TestBreaking_NewNonRequiredProperty(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: changing an existing property in request header to required is breaking
+// changing an existing property in request header to required is breaking
 func TestBreaking_PropertyRequiredEnabled(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -75,7 +75,7 @@ func TestBreaking_PropertyRequiredEnabled(t *testing.T) {
 	require.Equal(t, checker.RequestHeaderPropertyBecameRequiredId, errs[0].GetId())
 }
 
-// BC: changing an existing property in request header to optional is not breaking
+// changing an existing property in request header to optional is not breaking
 func TestBreaking_PropertyRequiredDisabled(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -99,7 +99,7 @@ func TestBreaking_PropertyRequiredDisabled(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: changing an existing property in response body to optional is breaking
+// changing an existing property in response body to optional is breaking
 func TestBreaking_RespBodyRequiredPropertyDisabled(t *testing.T) {
 	s1, err := open(requiredPropertyFile("response-base.json"))
 	require.NoError(t, err)
@@ -115,7 +115,7 @@ func TestBreaking_RespBodyRequiredPropertyDisabled(t *testing.T) {
 	require.Equal(t, checker.ResponsePropertyBecameOptionalId, errs[0].GetId())
 }
 
-// BC: changing a request body to enum is breaking
+// changing a request body to enum is breaking
 func TestBreaking_ReqBodyBecameEnum(t *testing.T) {
 	s1, err := open("../data/enums/request-body-no-enum.yaml")
 	require.NoError(t, err)
@@ -131,7 +131,7 @@ func TestBreaking_ReqBodyBecameEnum(t *testing.T) {
 	require.Equal(t, checker.RequestBodyBecameEnumId, errs[0].GetId())
 }
 
-// BC: adding an enum value to request body is not breaking
+// adding an enum value to request body is not breaking
 func TestBreaking_ReqBodyEnumValueAdded(t *testing.T) {
 	s1, err := open("../data/enums/request-body-enum.yaml")
 	require.NoError(t, err)
@@ -145,7 +145,7 @@ func TestBreaking_ReqBodyEnumValueAdded(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: changing a request body type and changing it to enum simultaneously is breaking
+// changing a request body type and changing it to enum simultaneously is breaking
 func TestBreaking_ReqBodyBecameEnumAndTypeChanged(t *testing.T) {
 	s1, err := open("../data/enums/request-body-no-enum.yaml")
 	require.NoError(t, err)
@@ -161,7 +161,7 @@ func TestBreaking_ReqBodyBecameEnumAndTypeChanged(t *testing.T) {
 	require.Equal(t, checker.RequestBodyTypeChangedId, errs[1].GetId())
 }
 
-// BC: changing an existing property in request body to enum is breaking
+// changing an existing property in request body to enum is breaking
 func TestBreaking_ReqPropertyBecameEnum(t *testing.T) {
 	s1, err := open("../data/enums/request-property-no-enum.yaml")
 	require.NoError(t, err)
@@ -177,7 +177,7 @@ func TestBreaking_ReqPropertyBecameEnum(t *testing.T) {
 	require.Equal(t, checker.RequestPropertyBecameEnumId, errs[0].GetId())
 }
 
-// BC: changing an existing path param to enum is breaking
+// changing an existing path param to enum is breaking
 func TestBreaking_ReqParameterBecameEnum(t *testing.T) {
 	s1, err := open("../data/enums/request-parameter-op-no-enum.yaml")
 	require.NoError(t, err)
@@ -193,7 +193,7 @@ func TestBreaking_ReqParameterBecameEnum(t *testing.T) {
 	require.Equal(t, checker.RequestParameterBecameEnumId, errs[0].GetId())
 }
 
-// BC: changing an existing property in request header to enum is breaking
+// changing an existing property in request header to enum is breaking
 func TestBreaking_ReqParameterHeaderPropertyBecameEnum(t *testing.T) {
 	s1, err := open("../data/enums/request-parameter-property-no-enum.yaml")
 	require.NoError(t, err)
@@ -209,7 +209,7 @@ func TestBreaking_ReqParameterHeaderPropertyBecameEnum(t *testing.T) {
 	require.Equal(t, checker.RequestHeaderPropertyBecameEnumId, errs[0].GetId())
 }
 
-// BC: changing a response body to nullable is breaking
+// changing a response body to nullable is breaking
 func TestBreaking_RespBodyNullable(t *testing.T) {
 	s1, err := open("../data/nullable/base-body.yaml")
 	require.NoError(t, err)
@@ -225,7 +225,7 @@ func TestBreaking_RespBodyNullable(t *testing.T) {
 	require.Equal(t, checker.ResponseBodyBecameNullableId, errs[0].GetId())
 }
 
-// BC: changing a request property to not nullable is breaking
+// changing a request property to not nullable is breaking
 func TestBreaking_ReqBodyPropertyNotNullable(t *testing.T) {
 	s1, err := open("../data/nullable/base-req.yaml")
 	require.NoError(t, err)
@@ -241,7 +241,7 @@ func TestBreaking_ReqBodyPropertyNotNullable(t *testing.T) {
 	require.Equal(t, checker.RequestPropertyBecomeNotNullableId, errs[0].GetId())
 }
 
-// BC: changing a response property to nullable is breaking
+// changing a response property to nullable is breaking
 func TestBreaking_RespBodyPropertyNullable(t *testing.T) {
 	s1, err := open("../data/nullable/base-property.yaml")
 	require.NoError(t, err)
@@ -257,7 +257,7 @@ func TestBreaking_RespBodyPropertyNullable(t *testing.T) {
 	require.Equal(t, checker.ResponsePropertyBecameNullableId, errs[0].GetId())
 }
 
-// BC: changing an embedded response property to nullable is breaking
+// changing an embedded response property to nullable is breaking
 func TestBreaking_RespBodyEmbeddedPropertyNullable(t *testing.T) {
 	s1, err := open("../data/nullable/base-embedded-property.yaml")
 	require.NoError(t, err)
@@ -273,7 +273,7 @@ func TestBreaking_RespBodyEmbeddedPropertyNullable(t *testing.T) {
 	require.Equal(t, checker.ResponsePropertyBecameNullableId, errs[0].GetId())
 }
 
-// BC: changing a required property in response body to optional and also deleting it is breaking
+// changing a required property in response body to optional and also deleting it is breaking
 func TestBreaking_RespBodyDeleteAndDisableRequiredProperty(t *testing.T) {
 	s1, err := open(requiredPropertyFile("response-del-required-prop-base.yaml"))
 	require.NoError(t, err)
@@ -287,7 +287,7 @@ func TestBreaking_RespBodyDeleteAndDisableRequiredProperty(t *testing.T) {
 	require.NotEmpty(t, errs)
 }
 
-// BC: adding a non-existent required property in request body is not breaking
+// adding a non-existent required property in request body is not breaking
 func TestBreaking_ReqBodyNewRequiredPropertyNew(t *testing.T) {
 	s1, err := open(requiredPropertyFile("request-new-required-prop-base.yaml"))
 	require.NoError(t, err)
@@ -301,7 +301,7 @@ func TestBreaking_ReqBodyNewRequiredPropertyNew(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: changing an existing property in response body to required is not breaking
+// changing an existing property in response body to required is not breaking
 func TestBreaking_RespBodyRequiredPropertyEnabled(t *testing.T) {
 	s1, err := open(requiredPropertyFile("response-revision.json"))
 	require.NoError(t, err)
@@ -315,7 +315,7 @@ func TestBreaking_RespBodyRequiredPropertyEnabled(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: changing an existing property in request body to optional is not breaking
+// changing an existing property in request body to optional is not breaking
 func TestBreaking_ReqBodyRequiredPropertyDisabled(t *testing.T) {
 	s1, err := open(requiredPropertyFile("request-base.yaml"))
 	require.NoError(t, err)
@@ -329,7 +329,7 @@ func TestBreaking_ReqBodyRequiredPropertyDisabled(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: changing an existing property in request body to required is breaking
+// changing an existing property in request body to required is breaking
 func TestBreaking_ReqBodyRequiredPropertyEnabled(t *testing.T) {
 	s1, err := open(requiredPropertyFile("request-revision.yaml"))
 	require.NoError(t, err)
@@ -345,7 +345,7 @@ func TestBreaking_ReqBodyRequiredPropertyEnabled(t *testing.T) {
 	require.Equal(t, checker.RequestPropertyBecameRequiredId, errs[0].GetId())
 }
 
-// BC: adding a new required property in request body is breaking
+// adding a new required property in request body is breaking
 func TestBreaking_ReqBodyNewRequiredProperty(t *testing.T) {
 	s1, err := open(requiredPropertyFile("request-new-base.yaml"))
 	require.NoError(t, err)
@@ -361,7 +361,7 @@ func TestBreaking_ReqBodyNewRequiredProperty(t *testing.T) {
 	require.Equal(t, checker.NewRequiredRequestPropertyId, errs[0].GetId())
 }
 
-// BC: deleting a required property in request is breaking with warn
+// deleting a required property in request is breaking with warn
 func TestBreaking_ReqBodyDeleteRequiredProperty(t *testing.T) {
 	s1, err := open(requiredPropertyFile("request-new-revision.yaml"))
 	require.NoError(t, err)
@@ -378,7 +378,7 @@ func TestBreaking_ReqBodyDeleteRequiredProperty(t *testing.T) {
 	require.Equal(t, checker.WARN, errs[0].GetLevel())
 }
 
-// BC: deleting an embedded optional property in request is breaking with warn
+// deleting an embedded optional property in request is breaking with warn
 func TestBreaking_ReqBodyDeleteRequiredProperty2(t *testing.T) {
 	s1, err := open(requiredPropertyFile("request-property-items.yaml"))
 	require.NoError(t, err)
@@ -398,7 +398,7 @@ func TestBreaking_ReqBodyDeleteRequiredProperty2(t *testing.T) {
 	}, requireChange(t, errs, checker.RequestPropertyRemovedId))
 }
 
-// BC: adding a new required property in response body is not breaking
+// adding a new required property in response body is not breaking
 func TestBreaking_RespBodyNewRequiredProperty(t *testing.T) {
 	s1, err := open(requiredPropertyFile("response-new-base.json"))
 	require.NoError(t, err)
@@ -412,7 +412,7 @@ func TestBreaking_RespBodyNewRequiredProperty(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: deleting a required property in response body is breaking
+// deleting a required property in response body is breaking
 func TestBreaking_RespBodyDeleteRequiredProperty(t *testing.T) {
 	s1, err := open(requiredPropertyFile("response-new-revision.json"))
 	require.NoError(t, err)
@@ -428,7 +428,7 @@ func TestBreaking_RespBodyDeleteRequiredProperty(t *testing.T) {
 	require.Equal(t, checker.ResponseRequiredPropertyRemovedId, errs[0].GetId())
 }
 
-// BC: adding a new required property under AllOf in response body is not breaking
+// adding a new required property under AllOf in response body is not breaking
 func TestBreaking_RespBodyNewAllOfRequiredProperty(t *testing.T) {
 	s1, err := open(requiredPropertyFile("response-allof-base.json"))
 	require.NoError(t, err)
@@ -442,7 +442,7 @@ func TestBreaking_RespBodyNewAllOfRequiredProperty(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: deleting a required property under AllOf in response body is breaking
+// deleting a required property under AllOf in response body is breaking
 func TestBreaking_RespBodyDeleteAllOfRequiredProperty(t *testing.T) {
 	s1, err := open(requiredPropertyFile("response-allof-revision.json"))
 	require.NoError(t, err)
@@ -458,7 +458,7 @@ func TestBreaking_RespBodyDeleteAllOfRequiredProperty(t *testing.T) {
 	require.Equal(t, checker.ResponseRequiredPropertyRemovedId, errs[0].GetId())
 }
 
-// BC: adding a new required read-only property in request body is not breaking
+// adding a new required read-only property in request body is not breaking
 func TestBreaking_ReadOnlyNewRequiredProperty(t *testing.T) {
 	s1, err := open(requiredPropertyFile("read-only-new-base.yaml"))
 	require.NoError(t, err)
@@ -472,7 +472,7 @@ func TestBreaking_ReadOnlyNewRequiredProperty(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: changing an existing read-only property in request body to required is not breaking
+// changing an existing read-only property in request body to required is not breaking
 func TestBreaking_ReadOnlyPropertyRequiredEnabled(t *testing.T) {
 	s1, err := open(requiredPropertyFile("read-only-base.yaml"))
 	require.NoError(t, err)
@@ -486,7 +486,7 @@ func TestBreaking_ReadOnlyPropertyRequiredEnabled(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: deleting a required write-only property in response body is not breaking
+// deleting a required write-only property in response body is not breaking
 func TestBreaking_WriteOnlyDeleteRequiredProperty(t *testing.T) {
 	s1, err := open(requiredPropertyFile("write-only-delete-base.yaml"))
 	require.NoError(t, err)
@@ -503,7 +503,7 @@ func TestBreaking_WriteOnlyDeleteRequiredProperty(t *testing.T) {
 	require.Equal(t, checker.WARN, errs[0].GetLevel())
 }
 
-// BC: deleting a non-required non-write-only property in response body is breaking with warning
+// deleting a non-required non-write-only property in response body is breaking with warning
 func TestBreaking_WriteOnlyDeleteNonRequiredProperty(t *testing.T) {
 	s1, err := open(requiredPropertyFile("write-only-delete-partial-base.yaml"))
 	require.NoError(t, err)
@@ -524,7 +524,7 @@ func TestBreaking_WriteOnlyDeleteNonRequiredProperty(t *testing.T) {
 	require.Equal(t, checker.WARN, errs[2].GetLevel())
 }
 
-// BC: changing an existing write-only property in response body to optional is not breaking
+// changing an existing write-only property in response body to optional is not breaking
 func TestBreaking_WriteOnlyPropertyRequiredDisabled(t *testing.T) {
 	s1, err := open(requiredPropertyFile("write-only-base.yaml"))
 	require.NoError(t, err)
@@ -538,7 +538,7 @@ func TestBreaking_WriteOnlyPropertyRequiredDisabled(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: changing an existing required property in response body to write-only is not breaking
+// changing an existing required property in response body to write-only is not breaking
 func TestBreaking_RequiredPropertyWriteOnlyEnabled(t *testing.T) {
 	s1, err := open(requiredPropertyFile("write-only-changed-base.yaml"))
 	require.NoError(t, err)
@@ -552,7 +552,7 @@ func TestBreaking_RequiredPropertyWriteOnlyEnabled(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: changing an existing required property in response body to not-write-only is breaking
+// changing an existing required property in response body to not-write-only is breaking
 func TestBreaking_RequiredPropertyWriteOnlyDisabled(t *testing.T) {
 	s1, err := open(requiredPropertyFile("write-only-changed-revision.yaml"))
 	require.NoError(t, err)
@@ -571,7 +571,7 @@ func TestBreaking_RequiredPropertyWriteOnlyDisabled(t *testing.T) {
 	require.Equal(t, checker.WARN, errs[1].GetLevel())
 }
 
-// BC: changing an existing property in request body to required is breaking
+// changing an existing property in request body to required is breaking
 func TestBreaking_Body(t *testing.T) {
 	s1, err := open(requiredPropertyFile("body1.yaml"))
 	require.NoError(t, err)
@@ -588,7 +588,7 @@ func TestBreaking_Body(t *testing.T) {
 	require.Equal(t, []any{"id"}, errs[0].GetArgs())
 }
 
-// BC: changing an existing property in request body items to required is breaking
+// changing an existing property in request body items to required is breaking
 func TestBreaking_Items(t *testing.T) {
 	s1, err := open(requiredPropertyFile("items1.yaml"))
 	require.NoError(t, err)
@@ -605,7 +605,7 @@ func TestBreaking_Items(t *testing.T) {
 	require.Equal(t, []any{"items/id"}, errs[0].GetArgs())
 }
 
-// BC: changing an existing property in request body items to required with a default value is not breaking
+// changing an existing property in request body items to required with a default value is not breaking
 func TestBreaking_ItemsWithDefault(t *testing.T) {
 	s1, err := open(requiredPropertyFile("items1.yaml"))
 	require.NoError(t, err)
@@ -619,7 +619,7 @@ func TestBreaking_ItemsWithDefault(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: changing an existing property in request body anyOf to required is breaking
+// changing an existing property in request body anyOf to required is breaking
 func TestBreaking_AnyOf(t *testing.T) {
 	s1, err := open(requiredPropertyFile("anyOf1.yaml"))
 	require.NoError(t, err)
@@ -635,7 +635,7 @@ func TestBreaking_AnyOf(t *testing.T) {
 	require.Equal(t, checker.RequestPropertyBecameRequiredId, errs[0].GetId())
 }
 
-// BC: changing an existing property under another property in request body to required is breaking
+// changing an existing property under another property in request body to required is breaking
 func TestBreaking_NestedProp(t *testing.T) {
 	s1, err := open(requiredPropertyFile("nested-property1.yaml"))
 	require.NoError(t, err)
@@ -651,7 +651,7 @@ func TestBreaking_NestedProp(t *testing.T) {
 	require.Equal(t, checker.RequestPropertyBecameRequiredId, errs[0].GetId())
 }
 
-// BC: changing a response property to optional under AllOf, AnyOf or OneOf is breaking
+// changing a response property to optional under AllOf, AnyOf or OneOf is breaking
 func TestBreaking_OneOf(t *testing.T) {
 	s1, err := open("../data/x-of/base.json")
 	require.NoError(t, err)

--- a/checker/check_breaking_request_type_changed_test.go
+++ b/checker/check_breaking_request_type_changed_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// BC: changing request's body schema type from string to number is breaking
+// changing request's body schema type from string to number is breaking
 func TestBreaking_ReqTypeStringToNumber(t *testing.T) {
 	file := "../data/type-change/simple-request.yaml"
 
@@ -28,7 +28,7 @@ func TestBreaking_ReqTypeStringToNumber(t *testing.T) {
 	require.Equal(t, "the request's body `type` changed from `string` to `number`", requireChange(t, errs, checker.RequestBodyTypeChangedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: changing request's body schema type from number to string is breaking
+// changing request's body schema type from number to string is breaking
 func TestBreaking_ReqTypeNumberToString(t *testing.T) {
 	file := "../data/type-change/simple-request.yaml"
 
@@ -47,7 +47,7 @@ func TestBreaking_ReqTypeNumberToString(t *testing.T) {
 	require.Equal(t, "the request's body `type` changed from `number` to `string`", requireChange(t, errs, checker.RequestBodyTypeChangedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: changing request's body schema type from number to integer is breaking
+// changing request's body schema type from number to integer is breaking
 func TestBreaking_ReqTypeNumberToInteger(t *testing.T) {
 	file := "../data/type-change/simple-request.yaml"
 
@@ -66,7 +66,7 @@ func TestBreaking_ReqTypeNumberToInteger(t *testing.T) {
 	require.Equal(t, "the request's body `type` changed from `number` to `integer`", requireChange(t, errs, checker.RequestBodyTypeChangedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: changing request's body schema type from integer to number is not breaking
+// changing request's body schema type from integer to number is not breaking
 func TestBreaking_ReqTypeIntegerToNumber(t *testing.T) {
 	file := "../data/type-change/simple-request.yaml"
 
@@ -85,7 +85,7 @@ func TestBreaking_ReqTypeIntegerToNumber(t *testing.T) {
 	require.Equal(t, "the request's body `type` was generalized from `integer` to `number`", requireChange(t, errs, checker.RequestBodyTypeGeneralizedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: narrowing a request's body schema union type is breaking (server rejects previously-valid values)
+// narrowing a request's body schema union type is breaking (server rejects previously-valid values)
 func TestBreaking_ReqTypeUnionNarrowed(t *testing.T) {
 	file := "../data/type-change/simple-request.yaml"
 
@@ -104,7 +104,7 @@ func TestBreaking_ReqTypeUnionNarrowed(t *testing.T) {
 	requireChange(t, errs, checker.RequestBodyTypeChangedId)
 }
 
-// BC: removing request's body schema type is not breaking (server becomes more permissive)
+// removing request's body schema type is not breaking (server becomes more permissive)
 func TestBreaking_ReqTypeStringDeleted(t *testing.T) {
 	file := "../data/type-change/simple-request.yaml"
 
@@ -123,7 +123,7 @@ func TestBreaking_ReqTypeStringDeleted(t *testing.T) {
 	require.Equal(t, "the request's body `type` was generalized from `string` to `any`", requireChange(t, errs, checker.RequestBodyTypeGeneralizedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: changing request's body schema type from number/none to integer/int32 is breaking
+// changing request's body schema type from number/none to integer/int32 is breaking
 func TestBreaking_ReqTypeNumberToInt32(t *testing.T) {
 	file := "../data/type-change/simple-request.yaml"
 

--- a/checker/check_breaking_response_type_changed_test.go
+++ b/checker/check_breaking_response_type_changed_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// BC: changing response's body schema type from string to number is breaking
+// changing response's body schema type from string to number is breaking
 func TestBreaking_RespTypeStringToNumber(t *testing.T) {
 	file := "../data/type-change/simple-response.yaml"
 
@@ -28,7 +28,7 @@ func TestBreaking_RespTypeStringToNumber(t *testing.T) {
 	require.Equal(t, "the response's body `type` changed from `string` to `number` for status `200`", requireChange(t, errs, checker.ResponseBodyTypeChangedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: changing response's body schema type from number to string is breaking
+// changing response's body schema type from number to string is breaking
 func TestBreaking_RespTypeNumberToString(t *testing.T) {
 	file := "../data/type-change/simple-response.yaml"
 
@@ -47,7 +47,7 @@ func TestBreaking_RespTypeNumberToString(t *testing.T) {
 	require.Equal(t, "the response's body `type` changed from `number` to `string` for status `200`", requireChange(t, errs, checker.ResponseBodyTypeChangedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: changing response's body schema type from number to integer is not breaking
+// changing response's body schema type from number to integer is not breaking
 func TestBreaking_RespTypeNumberToInteger(t *testing.T) {
 	file := "../data/type-change/simple-response.yaml"
 
@@ -65,7 +65,7 @@ func TestBreaking_RespTypeNumberToInteger(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: changing response's body schema type from integer to number is breaking
+// changing response's body schema type from integer to number is breaking
 func TestBreaking_RespTypeIntegerToNumber(t *testing.T) {
 	file := "../data/type-change/simple-response.yaml"
 
@@ -84,7 +84,7 @@ func TestBreaking_RespTypeIntegerToNumber(t *testing.T) {
 	require.Equal(t, "the response's body `type` changed from `integer` to `number` for status `200`", requireChange(t, errs, checker.ResponseBodyTypeChangedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: changing response's body schema type from number/none to integer/int32 is not breaking
+// changing response's body schema type from number/none to integer/int32 is not breaking
 func TestBreaking_RespTypeNumberToInt32(t *testing.T) {
 	file := "../data/type-change/simple-response.yaml"
 
@@ -103,7 +103,7 @@ func TestBreaking_RespTypeNumberToInt32(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: changing response's embedded property schema type from string/none to integer/int32 is breaking
+// changing response's embedded property schema type from string/none to integer/int32 is breaking
 func TestBreaking_RespTypeChanged(t *testing.T) {
 	s1, err := open("../data/type-change/base-response.yaml")
 	require.NoError(t, err)

--- a/checker/check_breaking_test.go
+++ b/checker/check_breaking_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// BC: adding a required request body is breaking
+// adding a required request body is breaking
 func TestBreaking_AddingRequiredRequestBody(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -28,7 +28,7 @@ func TestBreaking_AddingRequiredRequestBody(t *testing.T) {
 	require.Equal(t, "added required request body", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: changing an existing request body from optional to required is breaking
+// changing an existing request body from optional to required is breaking
 func TestBreaking_RequestBodyRequiredEnabled(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -50,7 +50,7 @@ func TestBreaking_RequestBodyRequiredEnabled(t *testing.T) {
 	require.Equal(t, "request body became required", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: deleting an enum value is breaking
+// deleting an enum value is breaking
 func TestBreaking_DeletedEnum(t *testing.T) {
 	errs := d(t, diff.NewConfig(), 702, 1)
 	require.NotEmpty(t, errs)
@@ -59,7 +59,7 @@ func TestBreaking_DeletedEnum(t *testing.T) {
 	require.Equal(t, "removed the enum value `removed-value` from the `path` request parameter `domain`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: added an enum value to response breaking
+// added an enum value to response breaking
 func TestBreaking_AddedResponseEnum(t *testing.T) {
 	errs := d(t, diff.NewConfig(), 703, 704)
 	require.NotEmpty(t, errs)
@@ -85,7 +85,7 @@ func deleteParam(op *openapi3.Operation, in string, name string) {
 	op.Parameters = result
 }
 
-// BC: renaming a path parameter is not breaking
+// renaming a path parameter is not breaking
 func TestBreaking_PathParamRename(t *testing.T) {
 	loader := openapi3.NewLoader()
 
@@ -105,7 +105,7 @@ func TestBreaking_PathParamRename(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: new required path param is breaking
+// new required path param is breaking
 func TestBreaking_NewPathParam(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -122,7 +122,7 @@ func TestBreaking_NewPathParam(t *testing.T) {
 	require.Equal(t, "added the new path request parameter `project`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: new required header param is breaking
+// new required header param is breaking
 func TestBreaking_NewRequiredHeaderParam(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -139,7 +139,7 @@ func TestBreaking_NewRequiredHeaderParam(t *testing.T) {
 	require.Equal(t, "added the new required `header` request parameter `network-policies`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: changing an existing header param from optional to required is breaking
+// changing an existing header param from optional to required is breaking
 func TestBreaking_HeaderParamRequiredEnabled(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -163,7 +163,7 @@ func TestBreaking_HeaderParamRequiredEnabled(t *testing.T) {
 	require.Equal(t, "the `header` request parameter `network-policies` became required", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: changing an existing response header from required to optional is breaking
+// changing an existing response header from required to optional is breaking
 func TestBreaking_ResponseHeaderParamRequiredDisabled(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -180,7 +180,7 @@ func TestBreaking_ResponseHeaderParamRequiredDisabled(t *testing.T) {
 	require.Equal(t, "the response header `X-RateLimit-Limit` became optional for the status `default`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: removing an existing required response header is breaking as error
+// removing an existing required response header is breaking as error
 func TestBreaking_ResponseHeaderRemoved(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -200,7 +200,7 @@ func TestBreaking_ResponseHeaderRemoved(t *testing.T) {
 	require.Equal(t, "the mandatory response header `X-RateLimit-Limit` removed for the status `default`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: removing an existing response with successful status is breaking
+// removing an existing response with successful status is breaking
 func TestBreaking_ResponseSuccessStatusUpdated(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -219,7 +219,7 @@ func TestBreaking_ResponseSuccessStatusUpdated(t *testing.T) {
 	require.Equal(t, "removed the success response with the status `200`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: removing an existing response with non-successful status is breaking (optional)
+// removing an existing response with non-successful status is breaking (optional)
 func TestBreaking_ResponseNonSuccessStatusUpdated(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -238,7 +238,7 @@ func TestBreaking_ResponseNonSuccessStatusUpdated(t *testing.T) {
 	require.Equal(t, "removed the non-success response with the status `400`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: removing/updating an operation id is breaking (optional)
+// removing/updating an operation id is breaking (optional)
 func TestBreaking_OperationIdRemoved(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -259,7 +259,7 @@ func TestBreaking_OperationIdRemoved(t *testing.T) {
 	verifyNonBreakingChangeIsChangelogEntry(t, d, osm, checker.APIOperationIdRemovedId)
 }
 
-// BC: removing/updating an enum in request body is breaking (optional)
+// removing/updating an enum in request body is breaking (optional)
 func TestBreaking_RequestBodyEnumRemoved(t *testing.T) {
 	s1, err := open("../data/enums/request-body-enum.yaml")
 	require.NoError(t, err)
@@ -282,7 +282,7 @@ func TestBreaking_RequestBodyEnumRemoved(t *testing.T) {
 	require.Equal(t, "request body enum value removed `VALUE_1`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: removing/updating a property enum in response is breaking (optional)
+// removing/updating a property enum in response is breaking (optional)
 func TestBreaking_ResponsePropertyEnumRemoved(t *testing.T) {
 	s1 := l(t, 704)
 	s2 := l(t, 703)
@@ -300,7 +300,7 @@ func TestBreaking_ResponsePropertyEnumRemoved(t *testing.T) {
 	require.Equal(t, "removed the `QWE` enum value from the `respenum` response property for the response status `default`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: removing/updating a tag is breaking (optional)
+// removing/updating a tag is breaking (optional)
 func TestBreaking_TagRemoved(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -319,7 +319,7 @@ func TestBreaking_TagRemoved(t *testing.T) {
 	require.Equal(t, "api tag `security` removed", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: removing/updating a media type enum in response (optional)
+// removing/updating a media type enum in response (optional)
 func TestBreaking_ResponseMediaTypeEnumRemoved(t *testing.T) {
 	s1, err := open("../data/enums/response-enum.yaml")
 	require.NoError(t, err)
@@ -339,7 +339,7 @@ func TestBreaking_ResponseMediaTypeEnumRemoved(t *testing.T) {
 	require.Equal(t, "response schema `application/json` enum value removed `VALUE_3`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: removing an existing response with unparseable status is not breaking
+// removing an existing response with unparseable status is not breaking
 func TestBreaking_ResponseUnparseableStatusRemoved(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -355,7 +355,7 @@ func TestBreaking_ResponseUnparseableStatusRemoved(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: removing an existing response with error status is not breaking
+// removing an existing response with error status is not breaking
 func TestBreaking_ResponseErrorStatusRemoved(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -371,7 +371,7 @@ func TestBreaking_ResponseErrorStatusRemoved(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: removing an existing optional response header is breaking as warn
+// removing an existing optional response header is breaking as warn
 func TestBreaking_OptionalResponseHeaderRemoved(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -391,7 +391,7 @@ func TestBreaking_OptionalResponseHeaderRemoved(t *testing.T) {
 	require.Equal(t, "the optional response header `X-RateLimit-Limit` removed for the status `default`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: deleting a media-type from response is breaking
+// deleting a media-type from response is breaking
 func TestBreaking_ResponseDeleteMediaType(t *testing.T) {
 	s1, err := open("../data/response-media-type-base.yaml")
 	require.NoError(t, err)
@@ -408,7 +408,7 @@ func TestBreaking_ResponseDeleteMediaType(t *testing.T) {
 	require.Equal(t, "removed the media type `application/json` for the response with the status `200`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: deleting a pattern from a schema is not breaking
+// deleting a pattern from a schema is not breaking
 func TestBreaking_DeletePatten(t *testing.T) {
 	s1, err := open("../data/pattern-base.yaml")
 	require.NoError(t, err)
@@ -422,7 +422,7 @@ func TestBreaking_DeletePatten(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: adding a pattern to a schema is breaking
+// adding a pattern to a schema is breaking
 func TestBreaking_AddPattern(t *testing.T) {
 	s1, err := open("../data/pattern-revision.yaml")
 	require.NoError(t, err)
@@ -439,7 +439,7 @@ func TestBreaking_AddPattern(t *testing.T) {
 	require.Equal(t, "added the pattern `^[a-z]+$` to the request property `created`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: adding a pattern to a schema is breaking for recursive properties
+// adding a pattern to a schema is breaking for recursive properties
 func TestBreaking_AddPatternRecursive(t *testing.T) {
 	s1, err := open("../data/pattern-revision-recursive.yaml")
 	require.NoError(t, err)
@@ -456,7 +456,7 @@ func TestBreaking_AddPatternRecursive(t *testing.T) {
 	require.Equal(t, "added the pattern `^[a-z]+$` to the request property `data/created`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: modifying a pattern in a schema is breaking
+// modifying a pattern in a schema is breaking
 func TestBreaking_ModifyPattern(t *testing.T) {
 	s1, err := open("../data/pattern-base.yaml")
 	require.NoError(t, err)
@@ -474,7 +474,7 @@ func TestBreaking_ModifyPattern(t *testing.T) {
 	require.Equal(t, checker.WARN, errs[0].GetLevel())
 }
 
-// BC: modifying a pattern to .* in a schema is not breaking
+// modifying a pattern to .* in a schema is not breaking
 func TestBreaking_GeneralizedPattern(t *testing.T) {
 	s1, err := open("../data/pattern-base.yaml")
 	require.NoError(t, err)
@@ -488,7 +488,7 @@ func TestBreaking_GeneralizedPattern(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: modifying a pattern in request parameter is breaking
+// modifying a pattern in request parameter is breaking
 func TestBreaking_ModifyParameterPattern(t *testing.T) {
 	s1, err := open("../data/pattern-parameter-base.yaml")
 	require.NoError(t, err)
@@ -505,7 +505,7 @@ func TestBreaking_ModifyParameterPattern(t *testing.T) {
 	require.Equal(t, "changed the pattern of the `path` request parameter `groupId` from `[0-9a-f]+` to `[0-9]+`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: modifying a pattern to ".*" in a schema is not breaking
+// modifying a pattern to ".*" in a schema is not breaking
 func TestBreaking_ModifyPatternToAnyString(t *testing.T) {
 	s1, err := open("../data/pattern-base.yaml")
 	require.NoError(t, err)
@@ -519,7 +519,7 @@ func TestBreaking_ModifyPatternToAnyString(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: modifying the default value of an optional request parameter is breaking
+// modifying the default value of an optional request parameter is breaking
 func TestBreaking_ModifyRequiredOptionalParamDefaultValue(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -537,7 +537,7 @@ func TestBreaking_ModifyRequiredOptionalParamDefaultValue(t *testing.T) {
 	require.Equal(t, "for the `header` request parameter `network-policies`, default value was changed from `X` to `Y`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: setting the default value of an optional request parameter is breaking
+// setting the default value of an optional request parameter is breaking
 func TestBreaking_SettingOptionalParamDefaultValue(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -555,7 +555,7 @@ func TestBreaking_SettingOptionalParamDefaultValue(t *testing.T) {
 	require.Equal(t, "for the `header` request parameter `network-policies`, default value `Y` was added", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: removing the default value of an optional request parameter is breaking
+// removing the default value of an optional request parameter is breaking
 func TestBreaking_RemovingOptionalParamDefaultValue(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -573,7 +573,7 @@ func TestBreaking_RemovingOptionalParamDefaultValue(t *testing.T) {
 	require.Equal(t, "for the `header` request parameter `network-policies`, default value `Y` was removed", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: modifying the default value of a required request parameter is not breaking
+// modifying the default value of a required request parameter is not breaking
 func TestBreaking_ModifyRequiredRequiredParamDefaultValue(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -592,7 +592,7 @@ func TestBreaking_ModifyRequiredRequiredParamDefaultValue(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: removing an schema object from components is breaking (optional)
+// removing an schema object from components is breaking (optional)
 func TestBreaking_SchemaRemoved(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -617,7 +617,7 @@ func TestBreaking_SchemaRemoved(t *testing.T) {
 	require.Equal(t, "removed the schema `rules`", errs[1].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: removing a media type from request body is breaking
+// removing a media type from request body is breaking
 func TestBreaking_RequestBodyMediaTypeRemoved(t *testing.T) {
 	s1, err := open("../data/checker/request_body_media_type_updated_revision.yaml")
 	require.NoError(t, err)
@@ -633,7 +633,7 @@ func TestBreaking_RequestBodyMediaTypeRemoved(t *testing.T) {
 	require.Equal(t, "removed the media type `application/json` from the request body", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: removing 'anyOf' schema from the request body or request body property is breaking
+// removing 'anyOf' schema from the request body or request body property is breaking
 func TestBreaking_RequestPropertyAnyOfRemoved(t *testing.T) {
 	s1, err := open("../data/checker/request_property_any_of_removed_base.yaml")
 	require.NoError(t, err)
@@ -655,7 +655,7 @@ func TestBreaking_RequestPropertyAnyOfRemoved(t *testing.T) {
 	require.Equal(t, "removed `#/components/schemas/Breed3` from the `anyOf[#/components/schemas/Dog]/breed` request property `anyOf` list", errs[1].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: removing 'oneOf' schema from the request body or request body property is breaking
+// removing 'oneOf' schema from the request body or request body property is breaking
 func TestBreaking_RequestPropertyOneOfRemoved(t *testing.T) {
 	s1, err := open("../data/checker/request_property_one_of_removed_base.yaml")
 	require.NoError(t, err)
@@ -676,7 +676,7 @@ func TestBreaking_RequestPropertyOneOfRemoved(t *testing.T) {
 	require.Equal(t, "removed `#/components/schemas/Breed3` from the `oneOf[#/components/schemas/Dog]/breed` request property `oneOf` list", errs[1].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: adding 'allOf' subschema to the request body or request body property is breaking
+// adding 'allOf' subschema to the request body or request body property is breaking
 func TestBreaking_RequestPropertyAllOfAdded(t *testing.T) {
 	s1, err := open("../data/checker/request_property_all_of_added_base.yaml")
 	require.NoError(t, err)
@@ -698,7 +698,7 @@ func TestBreaking_RequestPropertyAllOfAdded(t *testing.T) {
 	require.Equal(t, "added `#/components/schemas/Breed3` to the `allOf[#/components/schemas/Dog]/breed` request property `allOf` list", errs[1].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: removing 'allOf' subschema from the request body or request body property is breaking with warn
+// removing 'allOf' subschema from the request body or request body property is breaking with warn
 func TestBreaking_RequestPropertyAllOfRemoved(t *testing.T) {
 	s1, err := open("../data/checker/request_property_all_of_removed_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_components_security_updated_test.go
+++ b/checker/check_components_security_updated_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: changing security component oauth's url
+// changing security component oauth's url
 func TestComponentSecurityOauthURLUpdated(t *testing.T) {
 	s1, err := open("../data/checker/component_security_updated_base.yaml")
 	require.NoError(t, err)
@@ -30,7 +30,7 @@ func TestComponentSecurityOauthURLUpdated(t *testing.T) {
 	require.Equal(t, "the component security scheme `petstore_auth` oauth url changed from `http://example.org/api/oauth/dialog` to `http://example.new.org/api/oauth/dialog`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: changing security component token url
+// changing security component token url
 func TestComponentSecurityOauthTokenUpdated(t *testing.T) {
 	s1, err := open("../data/checker/component_security_updated_base.yaml")
 	require.NoError(t, err)
@@ -52,7 +52,7 @@ func TestComponentSecurityOauthTokenUpdated(t *testing.T) {
 	require.Equal(t, "the component security scheme `petstore_auth` oauth token url changed from `` to `http://example.new.org/api/oauth/dialog`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: changing security component type
+// changing security component type
 func TestComponentSecurityTypeUpdated(t *testing.T) {
 	s1, err := open("../data/checker/component_security_updated_base.yaml")
 	require.NoError(t, err)
@@ -74,7 +74,7 @@ func TestComponentSecurityTypeUpdated(t *testing.T) {
 	require.Equal(t, "the component security scheme `petstore_auth` type changed from `oauth2` to `http`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: adding a new security component
+// adding a new security component
 func TestComponentSecurityAdded(t *testing.T) {
 	s1, err := open("../data/checker/component_security_updated_base.yaml")
 	require.NoError(t, err)
@@ -94,7 +94,7 @@ func TestComponentSecurityAdded(t *testing.T) {
 	require.Equal(t, "the component security scheme `BasicAuth` was added", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: removing a new security component
+// removing a new security component
 func TestComponentSecurityRemoved(t *testing.T) {
 	s1, err := open("../data/checker/component_security_updated_revision.yaml")
 	require.NoError(t, err)
@@ -114,7 +114,7 @@ func TestComponentSecurityRemoved(t *testing.T) {
 	require.Equal(t, "the component security scheme `BasicAuth` was removed", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: adding a new oauth security scope
+// adding a new oauth security scope
 func TestComponentSecurityOauthScopeAdded(t *testing.T) {
 	s1, err := open("../data/checker/component_security_updated_base.yaml")
 	require.NoError(t, err)
@@ -136,7 +136,7 @@ func TestComponentSecurityOauthScopeAdded(t *testing.T) {
 	require.Equal(t, "the component security scheme `petstore_auth` oauth scope `admin:pets` was added", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: removing a new oauth security scope
+// removing a new oauth security scope
 func TestComponentSecurityOauthScopeRemoved(t *testing.T) {
 	s1, err := open("../data/checker/component_security_updated_base.yaml")
 	require.NoError(t, err)
@@ -159,7 +159,7 @@ func TestComponentSecurityOauthScopeRemoved(t *testing.T) {
 	require.Equal(t, "the component security scheme `petstore_auth` oauth scope `admin:pets` was removed", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: removing a new oauth security scope
+// removing a new oauth security scope
 func TestComponentSecurityOauthScopeUpdated(t *testing.T) {
 	s1, err := open("../data/checker/component_security_updated_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_new_request_non_path_default_parameter_test.go
+++ b/checker/check_new_request_non_path_default_parameter_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// BC: new header, query and cookie required request default param is breaking
+// new header, query and cookie required request default param is breaking
 func TestNewRequestNonPathParameter_DetectsNewRequiredPathsAndNewOperations(t *testing.T) {
 	s1, err := open("../data/request_params/base.yaml")
 	require.NoError(t, err)

--- a/checker/check_new_request_non_path_parameter_test.go
+++ b/checker/check_new_request_non_path_parameter_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: new header, query and cookie request params
+// new header, query and cookie request params
 func TestNewRequestNonPathParameter_DetectsNewPathsAndNewOperations(t *testing.T) {
 	s1, err := open("../data/request_params/base.yaml")
 	require.NoError(t, err)

--- a/checker/check_not_breaking_test.go
+++ b/checker/check_not_breaking_test.go
@@ -24,7 +24,7 @@ func verifyNonBreakingChangeIsChangelogEntry(t *testing.T, d *diff.Diff, osm *di
 	require.Equal(t, changeId, errs[0].GetId())
 }
 
-// BC: no change is not breaking
+// no change is not breaking
 func TestBreaking_Same(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -35,7 +35,7 @@ func TestBreaking_Same(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: adding an optional request body is not breaking
+// adding an optional request body is not breaking
 func TestBreaking_AddingOptionalRequestBody(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -50,7 +50,7 @@ func TestBreaking_AddingOptionalRequestBody(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// CL: changing an existing request body from required to optional
+// changing an existing request body from required to optional
 func TestBreaking_RequestBodyRequiredDisabled(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -68,7 +68,7 @@ func TestBreaking_RequestBodyRequiredDisabled(t *testing.T) {
 	verifyNonBreakingChangeIsChangelogEntry(t, d, osm, checker.RequestBodyBecameOptionalId)
 }
 
-// BC: deleting a tag is not breaking
+// deleting a tag is not breaking
 func TestBreaking_DeletedTag(t *testing.T) {
 	r := d(t, diff.NewConfig(), 1, 5)
 	require.Len(t, r, 5)
@@ -79,7 +79,7 @@ func TestBreaking_DeletedTag(t *testing.T) {
 	require.Equal(t, checker.RequestParameterRemovedId, r[4].GetId())
 }
 
-// BC: adding an enum value is not breaking
+// adding an enum value is not breaking
 func TestBreaking_AddedEnum(t *testing.T) {
 	r := d(t, diff.NewConfig(), 1, 3)
 	require.Len(t, r, 6)
@@ -91,7 +91,7 @@ func TestBreaking_AddedEnum(t *testing.T) {
 	require.Equal(t, checker.RequestParameterRemovedId, r[5].GetId())
 }
 
-// BC: changing extensions is not breaking
+// changing extensions is not breaking
 func TestBreaking_ModifiedExtension(t *testing.T) {
 	r := d(t, diff.NewConfig(), 1, 3)
 	require.Len(t, r, 6)
@@ -103,7 +103,7 @@ func TestBreaking_ModifiedExtension(t *testing.T) {
 	require.Equal(t, checker.RequestParameterRemovedId, r[5].GetId())
 }
 
-// BC: changing comments is not breaking
+// changing comments is not breaking
 func TestBreaking_Comments(t *testing.T) {
 	r := d(t, diff.NewConfig(), 1, 3)
 	require.Len(t, r, 6)
@@ -115,7 +115,7 @@ func TestBreaking_Comments(t *testing.T) {
 	require.Equal(t, checker.RequestParameterRemovedId, r[5].GetId())
 }
 
-// BC: new optional header param is not breaking
+// new optional header param is not breaking
 func TestBreaking_NewOptionalHeaderParam(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -129,7 +129,7 @@ func TestBreaking_NewOptionalHeaderParam(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// CL: changing an existing header param to optional
+// changing an existing header param to optional
 func TestBreaking_HeaderParamRequiredDisabled(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -149,7 +149,7 @@ func deleteResponseHeader(response *openapi3.Response, name string) {
 	delete(response.Headers, name)
 }
 
-// BC: new required response header param is not breaking
+// new required response header param is not breaking
 func TestBreaking_NewRequiredResponseHeader(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -163,7 +163,7 @@ func TestBreaking_NewRequiredResponseHeader(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: changing an operation's operationId is not breaking
+// changing an operation's operationId is not breaking
 func TestBreaking_OperationID(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -176,7 +176,7 @@ func TestBreaking_OperationID(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: changing a link's operationId is not breaking
+// changing a link's operationId is not breaking
 func TestBreaking_LinkOperationID(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -190,7 +190,7 @@ func TestBreaking_LinkOperationID(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: adding a media-type to response is not breaking
+// adding a media-type to response is not breaking
 func TestBreaking_ResponseAddMediaType(t *testing.T) {
 	s1, err := open("../data/response-media-type-revision.yaml")
 	require.NoError(t, err)
@@ -204,7 +204,7 @@ func TestBreaking_ResponseAddMediaType(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// CL: deprecating an operation with sunset greater than min
+// deprecating an operation with sunset greater than min
 func TestBreaking_DeprecatedOperation(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -219,7 +219,7 @@ func TestBreaking_DeprecatedOperation(t *testing.T) {
 	require.Equal(t, errs[0].GetLevel(), checker.INFO)
 }
 
-// BC: deprecating a parameter is not breaking
+// deprecating a parameter is not breaking
 func TestBreaking_DeprecatedParameter(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -232,7 +232,7 @@ func TestBreaking_DeprecatedParameter(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: deprecating a header is not breaking
+// deprecating a header is not breaking
 func TestBreaking_DeprecatedHeader(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -245,7 +245,7 @@ func TestBreaking_DeprecatedHeader(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: deprecating a schema is not breaking
+// deprecating a schema is not breaking
 func TestBreaking_DeprecatedSchema(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -258,7 +258,7 @@ func TestBreaking_DeprecatedSchema(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: changing servers is not breaking
+// changing servers is not breaking
 func TestBreaking_Servers(t *testing.T) {
 	s1, err := open("../data/servers/baseswagger.json")
 	require.NoError(t, err)
@@ -272,7 +272,7 @@ func TestBreaking_Servers(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: adding a tag is not breaking
+// adding a tag is not breaking
 func TestBreaking_TagAdded(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -283,7 +283,7 @@ func TestBreaking_TagAdded(t *testing.T) {
 	verifyNonBreakingChangeIsChangelogEntry(t, d, osm, checker.APITagAddedId)
 }
 
-// BC: adding an operation ID is not breaking
+// adding an operation ID is not breaking
 func TestBreaking_OperationIdAdded(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -295,7 +295,7 @@ func TestBreaking_OperationIdAdded(t *testing.T) {
 	verifyNonBreakingChangeIsChangelogEntry(t, d, osm, checker.APIOperationIdAddId)
 }
 
-// BC: adding a required property to response is not breaking
+// adding a required property to response is not breaking
 func TestBreaking_RequiredResponsePropertyAdded(t *testing.T) {
 	s1, err := open("../data/checker/response_required_property_added_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_body_mediatype_updated_test.go
+++ b/checker/check_request_body_mediatype_updated_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding a new media type to request body
+// adding a new media type to request body
 func TestRequestBodyMediaTypeAdded(t *testing.T) {
 	s1, err := open("../data/checker/request_body_media_type_updated_base.yaml")
 	require.NoError(t, err)
@@ -29,7 +29,7 @@ func TestRequestBodyMediaTypeAdded(t *testing.T) {
 	}, errs)
 }
 
-// CL: removing media type from request body
+// removing media type from request body
 func TestRequestBodyMediaTypeRemoved(t *testing.T) {
 	s1, err := open("../data/checker/request_body_media_type_updated_revision.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_body_removed_test.go
+++ b/checker/check_request_body_removed_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// BC: removing request body is breaking
+// removing request body is breaking
 func TestRequestBodyRemoved(t *testing.T) {
 	s1, err := open("../data/checker/request_body_removed_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_body_required_value_updated_test.go
+++ b/checker/check_request_body_required_value_updated_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: changing request's body to required is breaking
+// changing request's body to required is breaking
 func TestRequestBodyBecameRequired(t *testing.T) {
 	s1, err := open("../data/checker/request_body_became_required_base.yaml")
 	require.NoError(t, err)
@@ -30,7 +30,7 @@ func TestRequestBodyBecameRequired(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing request's body to optional
+// changing request's body to optional
 func TestRequestBodyBecameOptional(t *testing.T) {
 	s1, err := open("../data/checker/request_body_became_optional_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_discriminator_updated_test.go
+++ b/checker/check_request_discriminator_updated_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding discriminator to the request body or request body property
+// adding discriminator to the request body or request body property
 func TestRequestDiscriminatorUpdatedCheckAdded(t *testing.T) {
 	s1, err := open("../data/checker/request_property_discriminator_added_base.yaml")
 	require.NoError(t, err)
@@ -40,7 +40,7 @@ func TestRequestDiscriminatorUpdatedCheckAdded(t *testing.T) {
 		}}, errs)
 }
 
-// CL: removing discriminator from the request body or request body property
+// removing discriminator from the request body or request body property
 func TestRequestDiscriminatorUpdatedCheckRemoved(t *testing.T) {
 	s1, err := open("../data/checker/request_property_discriminator_added_revision.yaml")
 	require.NoError(t, err)
@@ -71,7 +71,7 @@ func TestRequestDiscriminatorUpdatedCheckRemoved(t *testing.T) {
 		}}, errs)
 }
 
-// CL: changing discriminator propertyName in the request body or request body property
+// changing discriminator propertyName in the request body or request body property
 func TestRequestDiscriminatorUpdatedCheckPropertyNameChanging(t *testing.T) {
 	s1, err := open("../data/checker/request_property_discriminator_added_revision.yaml")
 	require.NoError(t, err)
@@ -103,7 +103,7 @@ func TestRequestDiscriminatorUpdatedCheckPropertyNameChanging(t *testing.T) {
 		}}, errs)
 }
 
-// CL: changing discriminator mapping in the request body or request body property
+// changing discriminator mapping in the request body or request body property
 func TestRequestDiscriminatorUpdatedCheckMappingChanging(t *testing.T) {
 	s1, err := open("../data/checker/request_property_discriminator_added_revision.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_parameter_became_enum_test.go
+++ b/checker/check_request_parameter_became_enum_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: changing request parameter type to enum
+// changing request parameter type to enum
 func TestRequestParameterBecameEnum(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_became_enum_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_parameter_deprecation_test.go
+++ b/checker/check_request_parameter_deprecation_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// BC: deprecating a parameter with a deprecation policy and an invalid sunset date is breaking
+// deprecating a parameter with a deprecation policy and an invalid sunset date is breaking
 func TestBreaking_ParameterDeprecationWithInvalidSunset(t *testing.T) {
 
 	s1, err := open(paramDeprecationFile("base.yaml"))
@@ -29,7 +29,7 @@ func TestBreaking_ParameterDeprecationWithInvalidSunset(t *testing.T) {
 	require.Equal(t, "failed to parse sunset date for the `query` request parameter `id`: `sunset date doesn't conform with RFC3339: invalid-date`", requireChange(t, errs, checker.RequestParameterSunsetParseId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: deprecating a parameter without a deprecation policy but without specifying sunset date is not breaking
+// deprecating a parameter without a deprecation policy but without specifying sunset date is not breaking
 func TestBreaking_ParameterDeprecationWithoutSunsetNoPolicy(t *testing.T) {
 
 	s1, err := open(paramDeprecationFile("base.yaml"))
@@ -45,7 +45,7 @@ func TestBreaking_ParameterDeprecationWithoutSunsetNoPolicy(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: deprecating a parameter with a deprecation policy but without specifying sunset date is breaking
+// deprecating a parameter with a deprecation policy but without specifying sunset date is breaking
 func TestBreaking_ParameterDeprecationWithoutSunsetWithPolicy(t *testing.T) {
 
 	s1, err := open(paramDeprecationFile("base.yaml"))
@@ -62,7 +62,7 @@ func TestBreaking_ParameterDeprecationWithoutSunsetWithPolicy(t *testing.T) {
 	require.Equal(t, "`query` request parameter `id` was deprecated without sunset date", requireChange(t, errs, checker.RequestParameterDeprecatedSunsetMissingId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: deprecating a parameter with a default deprecation policy but without specifying sunset date is not breaking
+// deprecating a parameter with a default deprecation policy but without specifying sunset date is not breaking
 func TestBreaking_ParameterDeprecationWithoutSunset(t *testing.T) {
 
 	s1, err := open(paramDeprecationFile("base.yaml"))
@@ -78,7 +78,7 @@ func TestBreaking_ParameterDeprecationWithoutSunset(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: deprecating an operation without a deprecation policy and without specifying sunset date is not breaking for alpha level
+// deprecating an operation without a deprecation policy and without specifying sunset date is not breaking for alpha level
 func TestBreaking_ParameterDeprecationForAlpha(t *testing.T) {
 
 	s1, err := open(paramDeprecationFile("base-alpha-stability.yaml"))
@@ -93,7 +93,7 @@ func TestBreaking_ParameterDeprecationForAlpha(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: deprecating a parameter with a deprecation policy and sunset date before required deprecation period is breaking
+// deprecating a parameter with a deprecation policy and sunset date before required deprecation period is breaking
 func TestBreaking_ParameterDeprecationWithEarlySunset(t *testing.T) {
 	s1, err := open(paramDeprecationFile("base.yaml"))
 	require.NoError(t, err)
@@ -113,7 +113,7 @@ func TestBreaking_ParameterDeprecationWithEarlySunset(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("`query` request parameter `id` sunset date `%s` is too small, must be at least `10` days from now", sunsetDate), requireChange(t, errs, checker.RequestParameterSunsetDateTooSmallId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: deprecating a parameter with a deprecation policy and sunset date after required deprecation period is not breaking
+// deprecating a parameter with a deprecation policy and sunset date after required deprecation period is not breaking
 func TestBreaking_ParameterDeprecationWithProperSunset(t *testing.T) {
 
 	s1, err := open(paramDeprecationFile("base.yaml"))
@@ -135,7 +135,7 @@ func TestBreaking_ParameterDeprecationWithProperSunset(t *testing.T) {
 	require.Contains(t, errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()), "`query` request parameter `id` was deprecated")
 }
 
-// CL: parameters that became deprecated
+// parameters that became deprecated
 func TestParameterDeprecated_DetectsDeprecated(t *testing.T) {
 	s1, err := open(paramDeprecationFile("base.yaml"))
 	require.NoError(t, err)
@@ -158,7 +158,7 @@ func TestParameterDeprecated_DetectsDeprecated(t *testing.T) {
 	require.Contains(t, e0.GetUncolorizedText(checker.NewDefaultLocalizer()), "`query` request parameter `id` was deprecated")
 }
 
-// CL: parameters that were re-activated
+// parameters that were re-activated
 func TestParameterDeprecated_DetectsReactivated(t *testing.T) {
 	s1, err := open(paramDeprecationFile("deprecated-future.yaml"))
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestParameterDeprecated_DetectsReactivated(t *testing.T) {
 	require.Contains(t, e0.GetUncolorizedText(checker.NewDefaultLocalizer()), "`query` request parameter `id` was reactivated")
 }
 
-// CL: message includes sunset details when parameter deprecated with sunset date
+// message includes sunset details when parameter deprecated with sunset date
 func TestParameterDeprecated_MessageIncludesSunset(t *testing.T) {
 	s1, err := open(paramDeprecationFile("base.yaml"))
 	require.NoError(t, err)
@@ -199,7 +199,7 @@ func TestParameterDeprecated_MessageIncludesSunset(t *testing.T) {
 	require.Equal(t, "`query` request parameter `id` was deprecated (sunset: 9999-08-10)", requireChange(t, errs, checker.RequestParameterDeprecatedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: message includes both sunset and stability when parameter deprecated with both
+// message includes both sunset and stability when parameter deprecated with both
 func TestParameterDeprecated_MessageIncludesSunsetAndStability(t *testing.T) {
 	s1, err := open(paramDeprecationFile("base-beta-stability.yaml"))
 	require.NoError(t, err)
@@ -217,7 +217,7 @@ func TestParameterDeprecated_MessageIncludesSunsetAndStability(t *testing.T) {
 	require.Equal(t, "`query` request parameter `id` was deprecated (sunset: 9999-08-10, stability: beta)", requireChange(t, errs, checker.RequestParameterDeprecatedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: message has no details when parameter deprecated without sunset or stability
+// message has no details when parameter deprecated without sunset or stability
 func TestParameterDeprecated_MessageWithoutDetails(t *testing.T) {
 	s1, err := open(paramDeprecationFile("base.yaml"))
 	require.NoError(t, err)
@@ -235,7 +235,7 @@ func TestParameterDeprecated_MessageWithoutDetails(t *testing.T) {
 	require.Equal(t, "`query` request parameter `id` was deprecated", requireChange(t, errs, checker.RequestParameterDeprecatedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: message includes stability when parameter deprecated with stability but no sunset
+// message includes stability when parameter deprecated with stability but no sunset
 func TestParameterDeprecated_MessageIncludesStabilityOnly(t *testing.T) {
 	s1, err := open(paramDeprecationFile("base-beta-stability.yaml"))
 	require.NoError(t, err)

--- a/checker/check_request_parameter_enum_value_updated_test.go
+++ b/checker/check_request_parameter_enum_value_updated_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: removing an enum value from request parameter
+// removing an enum value from request parameter
 func TestRequestParameterEnumValueRemovedCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_enum_value_updated_base.yaml")
 	require.NoError(t, err)
@@ -42,7 +42,7 @@ func TestRequestParameterObjectEnumNoFalseBreakingChange(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// CL: adding an enum value to request parameter
+// adding an enum value to request parameter
 func TestRequestParameterEnumValueAddedCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_enum_value_updated_revision.yaml")
 	require.NoError(t, err)
@@ -63,7 +63,7 @@ func TestRequestParameterEnumValueAddedCheck(t *testing.T) {
 	}, errs)
 }
 
-// CL: removing an enum value from a deepObject request parameter property
+// removing an enum value from a deepObject request parameter property
 func TestRequestParameterPropertyEnumValueRemovedCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_property_enum_value_updated_base.yaml")
 	require.NoError(t, err)
@@ -84,7 +84,7 @@ func TestRequestParameterPropertyEnumValueRemovedCheck(t *testing.T) {
 	}, errs)
 }
 
-// CL: adding an enum value to a deepObject request parameter property
+// adding an enum value to a deepObject request parameter property
 // Swap base/revision to exercise the added-value path
 func TestRequestParameterPropertyEnumValueAddedCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_property_enum_value_updated_revision.yaml")
@@ -106,7 +106,7 @@ func TestRequestParameterPropertyEnumValueAddedCheck(t *testing.T) {
 	}, errs)
 }
 
-// CL: verifying the localized message for parameter property enum value removed
+// verifying the localized message for parameter property enum value removed
 func TestRequestParameterPropertyEnumValueRemovedMessage(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_property_enum_value_updated_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_parameter_pattern_added_or_changed_test.go
+++ b/checker/check_request_parameter_pattern_added_or_changed_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: changing pattern of request parameters
+// changing pattern of request parameters
 func TestRequestParameterPatternChanged(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_pattern_added_or_changed_base.yaml")
 	require.NoError(t, err)
@@ -32,7 +32,7 @@ func TestRequestParameterPatternChanged(t *testing.T) {
 	require.Equal(t, "This is a warning because adding or changing a pattern may restrict the accepted values and break existing clients. For pattern changes, it is difficult to automatically analyze if the new pattern is a superset of the previous pattern (e.g. changed from '[0-9]+' to '[0-9]*')", errs[0].GetComment(checker.NewDefaultLocalizer()))
 }
 
-// CL: generalizing pattern of request parameters
+// generalizing pattern of request parameters
 func TestRequestParameterPatternGeneralized(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_pattern_added_or_changed_base.yaml")
 	require.NoError(t, err)
@@ -53,7 +53,7 @@ func TestRequestParameterPatternGeneralized(t *testing.T) {
 	require.Equal(t, "changed the pattern of the `query` request parameter `category` from `^\\w+$` to a more general pattern `.*`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: adding pattern to request parameters
+// adding pattern to request parameters
 func TestRequestParameterPatternAdded(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_pattern_added_or_changed_revision.yaml")
 	require.NoError(t, err)
@@ -74,7 +74,7 @@ func TestRequestParameterPatternAdded(t *testing.T) {
 	require.Equal(t, "This is a breaking change because adding a pattern restriction to a previously unrestricted parameter will reject values that were previously accepted, breaking existing clients", errs[0].GetComment(checker.NewDefaultLocalizer()))
 }
 
-// CL: removing pattern from request parameters
+// removing pattern from request parameters
 func TestRequestParameterPatternRemoved(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_pattern_added_or_changed_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_parameter_removed_test.go
+++ b/checker/check_request_parameter_removed_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// BC: deleting a parameter without deprecation is breaking
+// deleting a parameter without deprecation is breaking
 func TestBreaking_DeletedParameter(t *testing.T) {
 	s1, err := open(paramDeprecationFile("base.yaml"))
 	require.NoError(t, err)
@@ -24,7 +24,7 @@ func TestBreaking_DeletedParameter(t *testing.T) {
 	require.Equal(t, "This is a warning because some clients may return an error when receiving an unexpected parameter. It is recommended to deprecate the parameter first.", errs[0].GetComment(checker.NewDefaultLocalizer()))
 }
 
-// BC: deleting a parameter after sunset date is not breaking
+// deleting a parameter after sunset date is not breaking
 func TestBreaking_ParameterDeprecationPast(t *testing.T) {
 
 	s1, err := open(paramDeprecationFile("deprecated-past.yaml"))
@@ -39,7 +39,7 @@ func TestBreaking_ParameterDeprecationPast(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: deleting a parameter before sunset date is breaking
+// deleting a parameter before sunset date is breaking
 func TestBreaking_ParameterDeprecationFuture(t *testing.T) {
 
 	s1, err := open(paramDeprecationFile("deprecated-future.yaml"))
@@ -56,7 +56,7 @@ func TestBreaking_ParameterDeprecationFuture(t *testing.T) {
 	require.Equal(t, "deleted the `query` request parameter `id` before the sunset date `9999-08-10`", requireChange(t, errs, checker.ParameterRemovedBeforeSunsetId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: deleting a deprecated parameter without sunset date is not breaking
+// deleting a deprecated parameter without sunset date is not breaking
 func TestBreaking_ParameterDeprecationNoSunset(t *testing.T) {
 
 	s1, err := open(paramDeprecationFile("deprecated-no-sunset.yaml"))
@@ -71,7 +71,7 @@ func TestBreaking_ParameterDeprecationNoSunset(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: removing a parameter without a deprecation policy and without specifying sunset date is not breaking for alpha level
+// removing a parameter without a deprecation policy and without specifying sunset date is not breaking for alpha level
 func TestBreaking_RemovedParameterForAlpha(t *testing.T) {
 	s1, err := open(paramDeprecationFile("base-alpha-stability.yaml"))
 	require.NoError(t, err)
@@ -85,7 +85,7 @@ func TestBreaking_RemovedParameterForAlpha(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: removing a deprecated parameter with an invalid date is breaking
+// removing a deprecated parameter with an invalid date is breaking
 func TestBreaking_RemoveParameterWithInvalidSunset(t *testing.T) {
 
 	s1, err := open(paramDeprecationFile("deprecated-invalid.yaml"))

--- a/checker/check_request_parameter_required_value_updated_test.go
+++ b/checker/check_request_parameter_required_value_updated_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// BC: changing an existing header param from optional to required is breaking
+// changing an existing header param from optional to required is breaking
 func TestBreaking_HeaderParamBecameRequired(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -30,7 +30,7 @@ func TestBreaking_HeaderParamBecameRequired(t *testing.T) {
 	}, errs)
 }
 
-// BC: changing an existing header param from optional to required with source tracking
+// changing an existing header param from optional to required with source tracking
 func TestBreaking_HeaderParamBecameRequired_WithSources(t *testing.T) {
 	s1 := l(t, 1, newLoaderWithOriginTracking())
 	s2 := l(t, 1, newLoaderWithOriginTracking())
@@ -50,7 +50,7 @@ func TestBreaking_HeaderParamBecameRequired_WithSources(t *testing.T) {
 	require.Empty(t, errs[0].GetRevisionSource())
 }
 
-// CL: changing an existing header param from required to optional
+// changing an existing header param from required to optional
 func TestBreaking_HeaderParamBecameOptional(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)

--- a/checker/check_request_parameter_sunset_changed_test.go
+++ b/checker/check_request_parameter_sunset_changed_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// BC: deleting sunset header for a deprecated parameter is breaking
+// deleting sunset header for a deprecated parameter is breaking
 func TestBreaking_SunsetDeletedForDeprecatedParameter(t *testing.T) {
 
 	s1, err := open(paramDeprecationFile("deprecated-with-sunset.yaml"))
@@ -25,7 +25,7 @@ func TestBreaking_SunsetDeletedForDeprecatedParameter(t *testing.T) {
 	require.Equal(t, "`query` request parameter `id` sunset date deleted, but deprecated=true kept", requireChange(t, errs, checker.RequestParameterSunsetDeletedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: deleting sunset header for a deprecated parameter is breaking even if the parameter is renamed
+// deleting sunset header for a deprecated parameter is breaking even if the parameter is renamed
 func TestBreaking_SunsetDeletedForDeprecatedAndRenamedParameter(t *testing.T) {
 
 	s1, err := open(paramDeprecationFile("deprecated-with-sunset-path.yaml"))
@@ -42,7 +42,7 @@ func TestBreaking_SunsetDeletedForDeprecatedAndRenamedParameter(t *testing.T) {
 	require.Equal(t, "`path` request parameter `id` sunset date deleted, but deprecated=true kept", requireChange(t, errs, checker.RequestParameterSunsetDeletedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: changing sunset to an earlier date for a deprecated parameter with a deprecation policy is breaking
+// changing sunset to an earlier date for a deprecated parameter with a deprecation policy is breaking
 func TestBreaking_SunsetModifiedForDeprecatedParameter(t *testing.T) {
 
 	s1, err := open(paramDeprecationFile("deprecated-future.yaml"))
@@ -59,7 +59,7 @@ func TestBreaking_SunsetModifiedForDeprecatedParameter(t *testing.T) {
 	require.Equal(t, "`query` request parameter `id` sunset date changed to an earlier date, from `9999-08-10` to `2022-08-10`, new sunset date must be not earlier than `9999-08-10` and at least `180` days from now", requireChange(t, errs, checker.RequestParameterSunsetDateChangedTooSmallId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: changing sunset to an invalid date for a deprecated parameter is breaking
+// changing sunset to an invalid date for a deprecated parameter is breaking
 func TestBreaking_SunsetModifiedToInvalidForDeprecatedParameter(t *testing.T) {
 
 	s1, err := open(paramDeprecationFile("deprecated-future.yaml"))
@@ -77,7 +77,7 @@ func TestBreaking_SunsetModifiedToInvalidForDeprecatedParameter(t *testing.T) {
 	require.Equal(t, "../data/param-deprecation/deprecated-invalid.yaml", errs[0].GetSource())
 }
 
-// BC: changing sunset from an invalid date for a deprecated parameter is breaking
+// changing sunset from an invalid date for a deprecated parameter is breaking
 func TestBreaking_SunsetModifiedFromInvalidForDeprecatedParameter(t *testing.T) {
 
 	s1, err := open(paramDeprecationFile("deprecated-invalid.yaml"))
@@ -95,7 +95,7 @@ func TestBreaking_SunsetModifiedFromInvalidForDeprecatedParameter(t *testing.T) 
 	require.Equal(t, "../data/param-deprecation/deprecated-invalid.yaml", errs[0].GetSource())
 }
 
-// BC: deleting other extension (not sunset) header for a deprecated parameter is not breaking
+// deleting other extension (not sunset) header for a deprecated parameter is not breaking
 func TestBreaking_NonSunsetDeletedForDeprecatedParameter(t *testing.T) {
 
 	s1, err := open(paramDeprecationFile("deprecated-with-other-extension.yaml"))
@@ -110,7 +110,7 @@ func TestBreaking_NonSunsetDeletedForDeprecatedParameter(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: no change to headers for a deprecated parameter is not breaking
+// no change to headers for a deprecated parameter is not breaking
 func TestBreaking_NoChangeToSunsetDeprecatedParameter(t *testing.T) {
 
 	s1, err := open(paramDeprecationFile("deprecated-future.yaml"))

--- a/checker/check_request_parameter_x_extensible_enum_value_removed_test.go
+++ b/checker/check_request_parameter_x_extensible_enum_value_removed_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// BC: Deleting a value from an x-extensible-enum parameter is breaking
+// Deleting a value from an x-extensible-enum parameter is breaking
 func TestRequestParameterXExtensibleEnumValueRemoved(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_extensible_enum_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_parameters_default_value_changed_test.go
+++ b/checker/check_request_parameters_default_value_changed_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: changing request parameter default value
+// changing request parameter default value
 func TestRequestParameterDefaultValueChanged(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_default_value_changed_base.yaml")
 	require.NoError(t, err)
@@ -29,7 +29,7 @@ func TestRequestParameterDefaultValueChanged(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing request parameter default value, while the param is also renamed
+// changing request parameter default value, while the param is also renamed
 func TestRequestParameterDefaultValueChangedAndRenamedParameter(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_default_value_changed_base_renamed.yaml")
 	require.NoError(t, err)
@@ -49,7 +49,7 @@ func TestRequestParameterDefaultValueChangedAndRenamedParameter(t *testing.T) {
 	}, errs)
 }
 
-// CL: adding request parameter default value
+// adding request parameter default value
 func TestRequestParameterDefaultValueAdded(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_default_value_changed_base.yaml")
 	require.NoError(t, err)
@@ -71,7 +71,7 @@ func TestRequestParameterDefaultValueAdded(t *testing.T) {
 	}, errs)
 }
 
-// CL: removing request parameter default value
+// removing request parameter default value
 func TestRequestParameterDefaultValueRemoved(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_default_value_changed_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_parameters_exclusive_min_max_test.go
+++ b/checker/check_request_parameters_exclusive_min_max_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: request parameter exclusiveMinimum increased
+// request parameter exclusiveMinimum increased
 func TestRequestParameterExclusiveMinIncreased(t *testing.T) {
 	s1, err := open("../data/checker/exclusive_min_max_base.yaml")
 	require.NoError(t, err)
@@ -27,7 +27,7 @@ func TestRequestParameterExclusiveMinIncreased(t *testing.T) {
 	require.True(t, ids[checker.RequestParameterExclusiveMinIncreasedId], "expected request-parameter-exclusive-min-increased")
 }
 
-// CL: request parameter exclusiveMaximum decreased
+// request parameter exclusiveMaximum decreased
 func TestRequestParameterExclusiveMaxDecreased(t *testing.T) {
 	s1, err := open("../data/checker/exclusive_min_max_base.yaml")
 	require.NoError(t, err)
@@ -46,7 +46,7 @@ func TestRequestParameterExclusiveMaxDecreased(t *testing.T) {
 	require.True(t, ids[checker.RequestParameterExclusiveMaxDecreasedId], "expected request-parameter-exclusive-max-decreased")
 }
 
-// CL: request parameter exclusiveMinimum set
+// request parameter exclusiveMinimum set
 func TestRequestParameterExclusiveMinSet(t *testing.T) {
 	s1, err := open("../data/checker/exclusive_min_max_set_base.yaml")
 	require.NoError(t, err)
@@ -65,7 +65,7 @@ func TestRequestParameterExclusiveMinSet(t *testing.T) {
 	require.True(t, ids[checker.RequestParameterExclusiveMinSetId], "expected request-parameter-exclusive-min-set")
 }
 
-// CL: request parameter exclusiveMaximum set
+// request parameter exclusiveMaximum set
 func TestRequestParameterExclusiveMaxSet(t *testing.T) {
 	s1, err := open("../data/checker/exclusive_min_max_set_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_parameters_max_items_updated_test.go
+++ b/checker/check_request_parameters_max_items_updated_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: increasing maxItems of request parameters
+// increasing maxItems of request parameters
 func TestRequestParameterMaxItemsIncreased(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_max_items_updated_base.yaml")
 	require.NoError(t, err)
@@ -30,7 +30,7 @@ func TestRequestParameterMaxItemsIncreased(t *testing.T) {
 	}, errs)
 }
 
-// CL: decreasing maxItems of request parameters
+// decreasing maxItems of request parameters
 func TestRequestParameterMaxItemsDecreased(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_max_items_updated_revision.yaml")
 	require.NoError(t, err)
@@ -50,7 +50,7 @@ func TestRequestParameterMaxItemsDecreased(t *testing.T) {
 	}, errs)
 }
 
-// BC: decreasing maxItems of common request parameters without --flatten-params is not breaking
+// decreasing maxItems of common request parameters without --flatten-params is not breaking
 func TestBreaking_RequestParameterMaxItemsWithoutFlatten(t *testing.T) {
 
 	s1, err := open("../data/checker/common_request_parameter_max_items_updated_revision.yaml")
@@ -65,7 +65,7 @@ func TestBreaking_RequestParameterMaxItemsWithoutFlatten(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: decreasing maxItems of common request parameters with --flatten-params is breaking
+// decreasing maxItems of common request parameters with --flatten-params is breaking
 func TestBreaking_RequestParameterMaxItemsWithFlatten(t *testing.T) {
 	loader := openapi3.NewLoader()
 
@@ -89,7 +89,7 @@ func TestBreaking_RequestParameterMaxItemsWithFlatten(t *testing.T) {
 	}, errs)
 }
 
-// BC: decreasing maxItems on array parameter schema itself (issue #760)
+// decreasing maxItems on array parameter schema itself (issue #760)
 func TestRequestParameterArrayMaxItemsDecreased(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_array_max_items_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_parameters_max_length_set_test.go
+++ b/checker/check_request_parameters_max_length_set_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: setting maxLength of request parameters
+// setting maxLength of request parameters
 func TestRequestParameterMaxLengthSetCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_max_length_set_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_parameters_max_length_updated_test.go
+++ b/checker/check_request_parameters_max_length_updated_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: increasing maxLength of request parameters
+// increasing maxLength of request parameters
 func TestRequestParameterMaxLengthIncreasedCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_max_length_updated_base.yaml")
 	require.NoError(t, err)
@@ -28,7 +28,7 @@ func TestRequestParameterMaxLengthIncreasedCheck(t *testing.T) {
 	}, errs)
 }
 
-// CL: decreasing maxLength of request parameters
+// decreasing maxLength of request parameters
 func TestRequestParameterMaxLengthDecreasedCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_max_length_updated_revision.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_parameters_max_updated_test.go
+++ b/checker/check_request_parameters_max_updated_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: increasing maximum value of request parameter
+// increasing maximum value of request parameter
 func TestRequestParameterMaxIncreased(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_max_updated_base.yaml")
 	require.NoError(t, err)
@@ -29,7 +29,7 @@ func TestRequestParameterMaxIncreased(t *testing.T) {
 	}, errs)
 }
 
-// CL: decreasing maximum value of request parameter
+// decreasing maximum value of request parameter
 func TestRequestParameterMaxDecreased(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_max_updated_revision.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_parameters_min_items_updated_test.go
+++ b/checker/check_request_parameters_min_items_updated_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: increasing minItems value of request parameter
+// increasing minItems value of request parameter
 func TestRequestParameterMinItemsIncreased(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_min_items_increased_base.yaml")
 	require.NoError(t, err)
@@ -29,7 +29,7 @@ func TestRequestParameterMinItemsIncreased(t *testing.T) {
 	}, errs)
 }
 
-// CL: decreasing minItems value of request parameter
+// decreasing minItems value of request parameter
 func TestRequestParameterMinItemsDecreased(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_min_items_increased_revision.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_parameters_min_length_updated_test.go
+++ b/checker/check_request_parameters_min_length_updated_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: increasing minLength value of request parameter
+// increasing minLength value of request parameter
 func TestRequestParameterMinLengthIncreasedCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_min_length_increased_base.yaml")
 	require.NoError(t, err)
@@ -30,7 +30,7 @@ func TestRequestParameterMinLengthIncreasedCheck(t *testing.T) {
 	}, errs)
 }
 
-// CL: decreasing minLength value of request parameter
+// decreasing minLength value of request parameter
 func TestRequestParameterMinLengthDecreasedCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_min_length_increased_revision.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_parameters_min_updated_test.go
+++ b/checker/check_request_parameters_min_updated_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: increasing minimum value of request parameter
+// increasing minimum value of request parameter
 func TestRequestParameterMinIncreased(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_min_increased_base.yaml")
 	require.NoError(t, err)
@@ -29,7 +29,7 @@ func TestRequestParameterMinIncreased(t *testing.T) {
 	}, errs)
 }
 
-// CL: decreasing minimum value of request parameter
+// decreasing minimum value of request parameter
 func TestRequestParameterMinDecreased(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_min_increased_revision.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_parameters_type_changed_test.go
+++ b/checker/check_request_parameters_type_changed_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: changing request path parameter type
+// changing request path parameter type
 func TestRequestPathParamTypeChanged(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_type_changed_base.yaml")
 	require.NoError(t, err)
@@ -32,7 +32,7 @@ func TestRequestPathParamTypeChanged(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing request query parameter type
+// changing request query parameter type
 func TestRequestQueryParamTypeChanged(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_type_changed_base.yaml")
 	require.NoError(t, err)
@@ -54,7 +54,7 @@ func TestRequestQueryParamTypeChanged(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing request header parameter type
+// changing request header parameter type
 func TestRequestQueryHeaderTypeChanged(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_type_changed_base.yaml")
 	require.NoError(t, err)
@@ -76,7 +76,7 @@ func TestRequestQueryHeaderTypeChanged(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing request path parameter format
+// changing request path parameter format
 func TestRequestPathParamFormatChanged(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_type_changed_base.yaml")
 	require.NoError(t, err)
@@ -98,7 +98,7 @@ func TestRequestPathParamFormatChanged(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing request query parameter format
+// changing request query parameter format
 func TestRequestQueryParamFormatChanged(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_type_changed_base.yaml")
 	require.NoError(t, err)
@@ -120,7 +120,7 @@ func TestRequestQueryParamFormatChanged(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing request header parameter format
+// changing request header parameter format
 func TestRequestQueryHeaderFormatChanged(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_type_changed_base.yaml")
 	require.NoError(t, err)
@@ -142,7 +142,7 @@ func TestRequestQueryHeaderFormatChanged(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing request path parameter type by adding "string"
+// changing request path parameter type by adding "string"
 func TestRequestPathParamTypeAddString(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_type_changed_base.yaml")
 	require.NoError(t, err)
@@ -165,7 +165,7 @@ func TestRequestPathParamTypeAddString(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing request path parameter type by replacing "integer" with "number"
+// changing request path parameter type by replacing "integer" with "number"
 func TestRequestPathParamTypeIntegerToNumber(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_type_changed_base.yaml")
 	require.NoError(t, err)
@@ -188,7 +188,7 @@ func TestRequestPathParamTypeIntegerToNumber(t *testing.T) {
 	}, errs)
 }
 
-// CL: a query parameter changing from a single type to a oneOf list of types is
+// a query parameter changing from a single type to a oneOf list of types is
 // reported once, by the list-of-types checker. RequestParameterTypeChangedCheck
 // suppresses its own report for the same change so it is not duplicated when both
 // checks run together.
@@ -218,7 +218,7 @@ func TestRequestQueryParamSingleToListOfTypesNotDuplicated(t *testing.T) {
 	requireChange(t, errs, checker.RequestParameterListOfTypesWidenedId)
 }
 
-// BC: changing request's query param property type from number to string is breaking
+// changing request's query param property type from number to string is breaking
 func TestBreaking_ReqQueryParamTypeNumberToString(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_property_type_changed_base_num.yaml")
 	require.NoError(t, err)
@@ -234,7 +234,7 @@ func TestBreaking_ReqQueryParamTypeNumberToString(t *testing.T) {
 	require.Equal(t, checker.WARN, errs[0].GetLevel())
 }
 
-// BC: specializing request's query param property type from string to number is breaking
+// specializing request's query param property type from string to number is breaking
 func TestBreaking_ReqQueryParamTypeStringToNumber(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_property_type_changed_revision.yaml")
 	require.NoError(t, err)
@@ -250,7 +250,7 @@ func TestBreaking_ReqQueryParamTypeStringToNumber(t *testing.T) {
 	require.Equal(t, checker.ERR, errs[0].GetLevel())
 }
 
-// CL: generalizing request's query param property type from integer to number
+// generalizing request's query param property type from integer to number
 func TestBreaking_ReqQueryParamTypeIntegerToNumber(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_property_type_changed_base_int.yaml")
 	require.NoError(t, err)
@@ -266,7 +266,7 @@ func TestBreaking_ReqQueryParamTypeIntegerToNumber(t *testing.T) {
 	require.Equal(t, checker.INFO, errs[0].GetLevel())
 }
 
-// CL: widening a query parameter from a scalar to a form/explode array of the
+// widening a query parameter from a scalar to a form/explode array of the
 // same type is backwards-compatible (one-element array on the wire), so it
 // should be reported as a generalization rather than a breaking change.
 // Reproduces issue #689.
@@ -294,7 +294,7 @@ func TestRequestQueryParamScalarToFormExplodeArray(t *testing.T) {
 	require.Equal(t, checker.INFO, errs[0].GetLevel())
 }
 
-// CL: widening a path parameter from scalar to array stays breaking, since
+// widening a path parameter from scalar to array stays breaking, since
 // path parameters use simple style (not form), so a single value on the wire
 // no longer matches the new array schema.
 func TestRequestPathParamScalarToArrayStillBreaking(t *testing.T) {
@@ -317,7 +317,7 @@ func TestRequestPathParamScalarToArrayStillBreaking(t *testing.T) {
 	require.Equal(t, checker.ERR, errs[0].GetLevel())
 }
 
-// CL: removing the format constraint of a request path parameter is a generalization, not breaking
+// removing the format constraint of a request path parameter is a generalization, not breaking
 func TestRequestPathParamFormatRemoved(t *testing.T) {
 	s1, err := open("../data/checker/request_parameter_type_changed_base.yaml")
 	require.NoError(t, err)
@@ -340,7 +340,7 @@ func TestRequestPathParamFormatRemoved(t *testing.T) {
 	}, errs)
 }
 
-// BC: removing the format constraint of a response property is breaking,
+// removing the format constraint of a response property is breaking,
 // since clients may depend on the declared format for parsing.
 func TestResponsePropertyFormatRemovedCheck(t *testing.T) {
 	s1, err := open("../data/checker/response_schema_format_changed_base.yaml")
@@ -358,7 +358,7 @@ func TestResponsePropertyFormatRemovedCheck(t *testing.T) {
 	require.Equal(t, checker.ERR, errs[0].GetLevel())
 }
 
-// CL: under OpenAPI 3.1, widening a nullable scalar query parameter to a
+// under OpenAPI 3.1, widening a nullable scalar query parameter to a
 // nullable form/explode array of the same scalar is still backwards-compatible
 // (#918). "null" is stripped from both sides before the scalar-to-array check,
 // so preserving or adding nullability does not turn a safe widening into a
@@ -391,7 +391,7 @@ func TestRequestQueryParamScalarToFormExplodeArray_31Nullable(t *testing.T) {
 	}
 }
 
-// CL: widening a weakly-typed (query) parameter from a union of scalar types to a
+// widening a weakly-typed (query) parameter from a union of scalar types to a
 // form/explode array is safe when the item type accepts every value the base did.
 // A query value is a string on the wire, so [string, integer] -> array<string> is
 // a generalization: the string branch already accepted every wire value, and a
@@ -414,7 +414,7 @@ func TestRequestQueryParamMultiTypeToFormExplodeArraySafe(t *testing.T) {
 	require.Equal(t, "This parameter uses form/explode serialization, where a single value is a valid one-element array, so widening it to an array whose items still accept the previous values does not break existing clients.", errs[0].GetComment(checker.NewDefaultLocalizer()))
 }
 
-// CL (guard): the widening is only safe when the item type accepts every base
+// (guard): the widening is only safe when the item type accepts every base
 // value. [string, integer] -> array<integer> drops the string branch, so a value
 // like ?token=abc that validated under the base (string) is rejected by the
 // integer item. It must stay breaking.
@@ -433,7 +433,7 @@ func TestRequestQueryParamWideningToNarrowerItemTypeStillBreaking(t *testing.T) 
 	require.Equal(t, checker.ERR, errs[0].GetLevel())
 }
 
-// CL (soundness): a scalar -> form/explode array is only safe when the array
+// (soundness): a scalar -> form/explode array is only safe when the array
 // items accept every value the base scalar accepted. Adding an item constraint
 // (here a pattern that excludes digits) rejects previously-valid values like
 // "5", so it must be breaking, not a generalization (#1024 follow-up).
@@ -452,7 +452,7 @@ func TestRequestQueryParamScalarToConstrainedArrayBreaking(t *testing.T) {
 	require.Equal(t, checker.ERR, errs[0].GetLevel())
 }
 
-// CL (soundness): the two safety axes are independent. Here the type axis passes
+// (soundness): the two safety axes are independent. Here the type axis passes
 // via weak typing ([string,integer] is accepted as string on the wire), but the
 // item adds a pattern that rejects previously-valid values like "5", so the
 // constraint axis fails and the widening is breaking. Guards that the "anything

--- a/checker/check_request_property_all_of_updated_test.go
+++ b/checker/check_request_property_all_of_updated_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding 'allOf' subschema to the request body or request body property
+// adding 'allOf' subschema to the request body or request body property
 func TestRequestPropertyAllOfAdded(t *testing.T) {
 	s1, err := open("../data/checker/request_property_all_of_added_base.yaml")
 	require.NoError(t, err)
@@ -41,7 +41,7 @@ func TestRequestPropertyAllOfAdded(t *testing.T) {
 		}}, errs)
 }
 
-// CL: adding 'allOf' subschema ($ref) with source tracking verifies source points to component definition
+// adding 'allOf' subschema ($ref) with source tracking verifies source points to component definition
 func TestRequestPropertyAllOfAdded_WithSources_Ref(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
 	s1, err := open("../data/checker/request_property_all_of_added_base.yaml", loader)
@@ -65,7 +65,7 @@ func TestRequestPropertyAllOfAdded_WithSources_Ref(t *testing.T) {
 	}
 }
 
-// CL: adding inline 'allOf' subschema with source tracking verifies source points to inline subschema
+// adding inline 'allOf' subschema with source tracking verifies source points to inline subschema
 func TestRequestPropertyAllOfAdded_WithSources_Inline(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
 	s1, err := open("../data/checker/request_property_all_of_inline_added_base.yaml", loader)
@@ -87,7 +87,7 @@ func TestRequestPropertyAllOfAdded_WithSources_Inline(t *testing.T) {
 	require.Greater(t, errs[0].GetRevisionSource().Line, 14)
 }
 
-// CL: removing 'allOf' subschema from the request body or request body property
+// removing 'allOf' subschema from the request body or request body property
 func TestRequestPropertyAllOfRemoved(t *testing.T) {
 	s1, err := open("../data/checker/request_property_all_of_removed_base.yaml")
 	require.NoError(t, err)
@@ -119,7 +119,7 @@ func TestRequestPropertyAllOfRemoved(t *testing.T) {
 		}}, errs)
 }
 
-// CL: adding an allOf subschema whose body is annotation-only (title,
+// adding an allOf subschema whose body is annotation-only (title,
 // description, examples, default, externalDocs, $comment) is a wire-
 // contract no-op. We don't emit it at the original ERR severity (that
 // would be a false positive on the breaking-change view), but we do
@@ -147,7 +147,7 @@ func TestRequestPropertyAllOfAdded_AnnotationOnly_EmitsInfo(t *testing.T) {
 	require.NotEqual(t, checker.RequestBodyAllOfAddedId, errs[0].GetId())
 }
 
-// CL: same as above but the annotation-only allOf lives on a nested
+// same as above but the annotation-only allOf lives on a nested
 // property's schema, not on the body. Covers the info.walkProperties
 // code path; the body-level test only exercises the outer walker.
 func TestRequestPropertyAllOfAdded_AnnotationOnly_AtProperty_EmitsInfo(t *testing.T) {

--- a/checker/check_request_property_any_of_updated_test.go
+++ b/checker/check_request_property_any_of_updated_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding 'anyOf' schema to the request body or request body property
+// adding 'anyOf' schema to the request body or request body property
 func TestRequestPropertyAnyOfAdded(t *testing.T) {
 	s1, err := open("../data/checker/request_property_any_of_added_base.yaml")
 	require.NoError(t, err)
@@ -41,7 +41,7 @@ func TestRequestPropertyAnyOfAdded(t *testing.T) {
 		}}, errs)
 }
 
-// CL: adding 'anyOf' subschema ($ref) with source tracking
+// adding 'anyOf' subschema ($ref) with source tracking
 func TestRequestPropertyAnyOfAdded_WithSources(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
 	s1, err := open("../data/checker/request_property_any_of_added_base.yaml", loader)
@@ -64,7 +64,7 @@ func TestRequestPropertyAnyOfAdded_WithSources(t *testing.T) {
 	}
 }
 
-// CL: removing 'anyOf' schema from the request body or request body property
+// removing 'anyOf' schema from the request body or request body property
 func TestRequestPropertyAnyOfRemoved(t *testing.T) {
 	s1, err := open("../data/checker/request_property_any_of_removed_base.yaml")
 	require.NoError(t, err)
@@ -96,7 +96,7 @@ func TestRequestPropertyAnyOfRemoved(t *testing.T) {
 		}}, errs)
 }
 
-// BC: refactoring an anyOf branch from inline enum to an equivalent $ref is not breaking
+// refactoring an anyOf branch from inline enum to an equivalent $ref is not breaking
 func TestRequestPropertyAnyOfInlineEnumRefactorToRef(t *testing.T) {
 	s1, err := open("../data/checker/request_property_any_of_ref_inline_enum_base.yaml")
 	require.NoError(t, err)
@@ -115,7 +115,7 @@ func TestRequestPropertyAnyOfInlineEnumRefactorToRef(t *testing.T) {
 	require.Empty(t, anyOfChanges)
 }
 
-// CL: body-level anyOf added/removed changes carry media-type details so
+// body-level anyOf added/removed changes carry media-type details so
 // reports can tell which media type each change belongs to when a request
 // body has more than one. Without WithDetails the entries are identical
 // and visitors can't tell apart "added Rabbit on application/json" from
@@ -151,7 +151,7 @@ func TestRequestBodyAnyOfMultiMediaTypeDetails(t *testing.T) {
 	}, removedDetails)
 }
 
-// CL: no changes when paths diff is nil
+// no changes when paths diff is nil
 func TestRequestPropertyAnyOfNoPathsDiff(t *testing.T) {
 	config := &checker.Config{}
 	d := &diff.Diff{}
@@ -161,7 +161,7 @@ func TestRequestPropertyAnyOfNoPathsDiff(t *testing.T) {
 	require.Len(t, errs, 0)
 }
 
-// CL: no changes when operations diff is nil
+// no changes when operations diff is nil
 func TestRequestPropertyAnyOfNoOperationsDiff(t *testing.T) {
 	config := &checker.Config{}
 	d := &diff.Diff{
@@ -177,7 +177,7 @@ func TestRequestPropertyAnyOfNoOperationsDiff(t *testing.T) {
 	require.Len(t, errs, 0)
 }
 
-// CL: no changes when request body diff is nil
+// no changes when request body diff is nil
 func TestRequestPropertyAnyOfNoRequestBodyDiff(t *testing.T) {
 	config := &checker.Config{}
 	d := &diff.Diff{
@@ -199,7 +199,7 @@ func TestRequestPropertyAnyOfNoRequestBodyDiff(t *testing.T) {
 	require.Len(t, errs, 0)
 }
 
-// CL: no changes when schema diff is nil
+// no changes when schema diff is nil
 func TestRequestPropertyAnyOfNoSchemaDiff(t *testing.T) {
 	config := &checker.Config{}
 	d := &diff.Diff{

--- a/checker/check_request_property_became_not_nuallable_test.go
+++ b/checker/check_request_property_became_not_nuallable_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: changing request property to not nullable
+// changing request property to not nullable
 func TestRequestPropertyBecameNotNullable(t *testing.T) {
 	s1, err := open("../data/checker/request_property_became_nullable_revision.yaml")
 	require.NoError(t, err)
@@ -29,7 +29,7 @@ func TestRequestPropertyBecameNotNullable(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing request property to nullable
+// changing request property to nullable
 func TestRequestPropertyBecameNullable(t *testing.T) {
 	s1, err := open("../data/checker/request_property_became_nullable_base.yaml")
 	require.NoError(t, err)
@@ -50,7 +50,7 @@ func TestRequestPropertyBecameNullable(t *testing.T) {
 
 }
 
-// CL: changing request body to nullable
+// changing request body to nullable
 func TestRequestBodyBecameNullable(t *testing.T) {
 	s1, err := open("../data/checker/request_property_became_nullable_base.yaml")
 	require.NoError(t, err)
@@ -72,7 +72,7 @@ func TestRequestBodyBecameNullable(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing request property to nullable via type array (OpenAPI 3.1)
+// changing request property to nullable via type array (OpenAPI 3.1)
 func TestRequestPropertyBecameNullable31(t *testing.T) {
 	s1, err := open("../data/checker/request_property_became_nullable_31_base.yaml")
 	require.NoError(t, err)
@@ -92,7 +92,7 @@ func TestRequestPropertyBecameNullable31(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing request property to not nullable via type array (OpenAPI 3.1)
+// changing request property to not nullable via type array (OpenAPI 3.1)
 func TestRequestPropertyBecameNotNullable31(t *testing.T) {
 	s1, err := open("../data/checker/request_property_became_nullable_31_revision.yaml")
 	require.NoError(t, err)
@@ -112,7 +112,7 @@ func TestRequestPropertyBecameNotNullable31(t *testing.T) {
 	}, errs)
 }
 
-// CL: type checker does NOT fire for null-only type changes (OpenAPI 3.1)
+// type checker does NOT fire for null-only type changes (OpenAPI 3.1)
 func TestTypeCheckerSuppressedForNullOnly31(t *testing.T) {
 	s1, err := open("../data/checker/request_property_became_nullable_31_base.yaml")
 	require.NoError(t, err)
@@ -125,7 +125,7 @@ func TestTypeCheckerSuppressedForNullOnly31(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// CL: changing request body to not nullable
+// changing request body to not nullable
 func TestRequestBodyBecameNotNullable(t *testing.T) {
 	s1, err := open("../data/checker/request_property_became_nullable_base.yaml")
 	require.NoError(t, err)
@@ -147,7 +147,7 @@ func TestRequestBodyBecameNotNullable(t *testing.T) {
 	}, errs)
 }
 
-// CL: response property became nullable via type array (OpenAPI 3.1)
+// response property became nullable via type array (OpenAPI 3.1)
 func TestResponsePropertyBecameNullable31(t *testing.T) {
 	s1, err := open("../data/checker/request_property_became_nullable_31_base.yaml")
 	require.NoError(t, err)
@@ -167,7 +167,7 @@ func TestResponsePropertyBecameNullable31(t *testing.T) {
 	}, errs)
 }
 
-// CL: request body became nullable via type array (OpenAPI 3.1)
+// request body became nullable via type array (OpenAPI 3.1)
 func TestRequestBodyBecameNullable31(t *testing.T) {
 	s1, err := open("../data/checker/request_body_nullable_31_base.yaml")
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestRequestBodyBecameNullable31(t *testing.T) {
 	require.True(t, containsId(errs, checker.RequestBodyBecomeNullableId), "expected request-body-became-nullable")
 }
 
-// CL: request body became not-nullable via type array (OpenAPI 3.1)
+// request body became not-nullable via type array (OpenAPI 3.1)
 func TestRequestBodyBecameNotNullable31(t *testing.T) {
 	s1, err := open("../data/checker/request_body_nullable_31_revision.yaml")
 	require.NoError(t, err)
@@ -195,7 +195,7 @@ func TestRequestBodyBecameNotNullable31(t *testing.T) {
 	require.True(t, containsId(errs, checker.RequestBodyBecomeNotNullableId), "expected request-body-became-not-nullable")
 }
 
-// CL: response body became nullable via type array (OpenAPI 3.1)
+// response body became nullable via type array (OpenAPI 3.1)
 func TestResponseBodyBecameNullable31(t *testing.T) {
 	s1, err := open("../data/checker/request_body_nullable_31_base.yaml")
 	require.NoError(t, err)
@@ -209,7 +209,7 @@ func TestResponseBodyBecameNullable31(t *testing.T) {
 	require.True(t, containsId(errs, checker.ResponseBodyBecameNullableId), "expected response-body-became-nullable")
 }
 
-// CL: response property became nullable via type array (OpenAPI 3.1) — property level check in response
+// response property became nullable via type array (OpenAPI 3.1) — property level check in response
 func TestResponsePropertyBecameNullable31Property(t *testing.T) {
 	s1, err := open("../data/checker/request_property_became_nullable_31_base.yaml")
 	require.NoError(t, err)
@@ -223,7 +223,7 @@ func TestResponsePropertyBecameNullable31Property(t *testing.T) {
 	require.True(t, containsId(errs, checker.ResponsePropertyBecameNullableId), "expected response-property-became-nullable")
 }
 
-// CL: response type checker does NOT fire for null-only type changes (OpenAPI 3.1)
+// response type checker does NOT fire for null-only type changes (OpenAPI 3.1)
 func TestResponseTypeCheckerSuppressedForNullOnly31(t *testing.T) {
 	s1, err := open("../data/checker/request_property_became_nullable_31_base.yaml")
 	require.NoError(t, err)
@@ -236,7 +236,7 @@ func TestResponseTypeCheckerSuppressedForNullOnly31(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// CL: removing the type keyword entirely (3.1) must NOT report became-not-nullable.
+// removing the type keyword entirely (3.1) must NOT report became-not-nullable.
 // An untyped schema accepts any value, including null, so the body is still
 // nullable; only narrowing to a non-null type set removes null. (#1004)
 func TestRequestBodyTypeRemovedEntirelyStaysNullable(t *testing.T) {
@@ -254,7 +254,7 @@ func TestRequestBodyTypeRemovedEntirelyStaysNullable(t *testing.T) {
 		"removing the type entirely leaves the schema nullable (untyped accepts null); must not report became-not-nullable")
 }
 
-// CL: adding an explicit type (including null) to a previously untyped body must
+// adding an explicit type (including null) to a previously untyped body must
 // NOT report became-nullable. An untyped schema already accepts null, so adding
 // [object, null] does not introduce nullability. Mirror of the type-removed case. (#1004)
 func TestRequestBodyTypeAddedFromUntypedStaysNullable(t *testing.T) {

--- a/checker/check_request_property_const_changed_test.go
+++ b/checker/check_request_property_const_changed_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: changing request body const value
+// changing request body const value
 func TestRequestBodyConstChanged(t *testing.T) {
 	s1, err := open("../data/checker/request_body_const_changed_base.yaml")
 	require.NoError(t, err)
@@ -29,7 +29,7 @@ func TestRequestBodyConstChanged(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing request property const value
+// changing request property const value
 func TestRequestPropertyConstChanged(t *testing.T) {
 	s1, err := open("../data/checker/request_body_const_changed_base.yaml")
 	require.NoError(t, err)
@@ -51,7 +51,7 @@ func TestRequestPropertyConstChanged(t *testing.T) {
 	}, errs)
 }
 
-// CL: adding request body const value or request property const value
+// adding request body const value or request property const value
 func TestRequestBodyConstAdded(t *testing.T) {
 	s1, err := open("../data/checker/request_body_const_changed_base.yaml")
 	require.NoError(t, err)
@@ -83,7 +83,7 @@ func TestRequestBodyConstAdded(t *testing.T) {
 	}}, errs)
 }
 
-// CL: removing request body const value or request property const value
+// removing request body const value or request property const value
 func TestRequestBodyConstRemoved(t *testing.T) {
 	s1, err := open("../data/checker/request_body_const_changed_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_property_contains_updated_test.go
+++ b/checker/check_request_property_contains_updated_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding contains constraint to request body
+// adding contains constraint to request body
 func TestRequestBodyContainsAdded(t *testing.T) {
 	s1, err := open("../data/checker/contains_added_base.yaml")
 	require.NoError(t, err)
@@ -30,7 +30,7 @@ func TestRequestBodyContainsAdded(t *testing.T) {
 	require.True(t, found, "expected request-body-contains-added")
 }
 
-// CL: removing contains constraint from request body
+// removing contains constraint from request body
 func TestRequestBodyContainsRemoved(t *testing.T) {
 	s1, err := open("../data/checker/contains_added_revision.yaml")
 	require.NoError(t, err)
@@ -52,7 +52,7 @@ func TestRequestBodyContainsRemoved(t *testing.T) {
 	require.True(t, found, "expected request-body-contains-removed")
 }
 
-// CL: increasing minContains on request body
+// increasing minContains on request body
 func TestRequestBodyMinContainsIncreased(t *testing.T) {
 	s1, err := open("../data/checker/contains_min_max_base.yaml")
 	require.NoError(t, err)
@@ -65,7 +65,7 @@ func TestRequestBodyMinContainsIncreased(t *testing.T) {
 	requireChange(t, errs, checker.RequestBodyMinContainsIncreasedId)
 }
 
-// CL: decreasing minContains on request body
+// decreasing minContains on request body
 func TestRequestBodyMinContainsDecreased(t *testing.T) {
 	s1, err := open("../data/checker/contains_min_max_revision.yaml")
 	require.NoError(t, err)
@@ -78,7 +78,7 @@ func TestRequestBodyMinContainsDecreased(t *testing.T) {
 	requireChange(t, errs, checker.RequestBodyMinContainsDecreasedId)
 }
 
-// CL: increasing maxContains on request body
+// increasing maxContains on request body
 func TestRequestBodyMaxContainsIncreased(t *testing.T) {
 	s1, err := open("../data/checker/contains_min_max_base.yaml")
 	require.NoError(t, err)
@@ -91,7 +91,7 @@ func TestRequestBodyMaxContainsIncreased(t *testing.T) {
 	requireChange(t, errs, checker.RequestBodyMaxContainsIncreasedId)
 }
 
-// CL: decreasing maxContains on request body
+// decreasing maxContains on request body
 func TestRequestBodyMaxContainsDecreased(t *testing.T) {
 	s1, err := open("../data/checker/contains_min_max_revision.yaml")
 	require.NoError(t, err)
@@ -104,7 +104,7 @@ func TestRequestBodyMaxContainsDecreased(t *testing.T) {
 	requireChange(t, errs, checker.RequestBodyMaxContainsDecreasedId)
 }
 
-// CL: adding contains constraint to request property
+// adding contains constraint to request property
 func TestRequestPropertyContainsAdded(t *testing.T) {
 	s1, err := open("../data/checker/contains_property_base.yaml")
 	require.NoError(t, err)
@@ -117,7 +117,7 @@ func TestRequestPropertyContainsAdded(t *testing.T) {
 	requireChange(t, errs, checker.RequestPropertyContainsAddedId)
 }
 
-// CL: removing contains constraint from request property
+// removing contains constraint from request property
 func TestRequestPropertyContainsRemoved(t *testing.T) {
 	s1, err := open("../data/checker/contains_property_revision.yaml")
 	require.NoError(t, err)
@@ -130,7 +130,7 @@ func TestRequestPropertyContainsRemoved(t *testing.T) {
 	requireChange(t, errs, checker.RequestPropertyContainsRemovedId)
 }
 
-// CL: increasing minContains on request property
+// increasing minContains on request property
 func TestRequestPropertyMinContainsIncreased(t *testing.T) {
 	s1, err := open("../data/checker/contains_property_min_max_base.yaml")
 	require.NoError(t, err)
@@ -143,7 +143,7 @@ func TestRequestPropertyMinContainsIncreased(t *testing.T) {
 	requireChange(t, errs, checker.RequestPropertyMinContainsIncreasedId)
 }
 
-// CL: decreasing minContains on request property
+// decreasing minContains on request property
 func TestRequestPropertyMinContainsDecreased(t *testing.T) {
 	s1, err := open("../data/checker/contains_property_min_max_revision.yaml")
 	require.NoError(t, err)
@@ -156,7 +156,7 @@ func TestRequestPropertyMinContainsDecreased(t *testing.T) {
 	requireChange(t, errs, checker.RequestPropertyMinContainsDecreasedId)
 }
 
-// CL: increasing maxContains on request property
+// increasing maxContains on request property
 func TestRequestPropertyMaxContainsIncreased(t *testing.T) {
 	s1, err := open("../data/checker/contains_property_min_max_base.yaml")
 	require.NoError(t, err)
@@ -169,7 +169,7 @@ func TestRequestPropertyMaxContainsIncreased(t *testing.T) {
 	requireChange(t, errs, checker.RequestPropertyMaxContainsIncreasedId)
 }
 
-// CL: decreasing maxContains on request property
+// decreasing maxContains on request property
 func TestRequestPropertyMaxContainsDecreased(t *testing.T) {
 	s1, err := open("../data/checker/contains_property_min_max_revision.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_property_content_updated_test.go
+++ b/checker/check_request_property_content_updated_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding contentSchema and changing contentMediaType/contentEncoding in request property
+// adding contentSchema and changing contentMediaType/contentEncoding in request property
 func TestRequestPropertyContentUpdated(t *testing.T) {
 	s1, err := open("../data/checker/content_schema_base.yaml")
 	require.NoError(t, err)
@@ -29,7 +29,7 @@ func TestRequestPropertyContentUpdated(t *testing.T) {
 	require.True(t, ids[checker.RequestPropertyContentEncodingChangedId], "expected request-property-content-encoding-changed")
 }
 
-// CL: adding contentSchema to request body
+// adding contentSchema to request body
 func TestRequestBodyContentSchemaAdded(t *testing.T) {
 	s1, err := open("../data/checker/content_schema_body_base.yaml")
 	require.NoError(t, err)
@@ -43,7 +43,7 @@ func TestRequestBodyContentSchemaAdded(t *testing.T) {
 	require.True(t, containsId(errs, checker.RequestBodyContentSchemaAddedId), "expected request-body-content-schema-added")
 }
 
-// CL: removing contentSchema from request body
+// removing contentSchema from request body
 func TestRequestBodyContentSchemaRemoved(t *testing.T) {
 	s1, err := open("../data/checker/content_schema_body_revision.yaml")
 	require.NoError(t, err)
@@ -57,7 +57,7 @@ func TestRequestBodyContentSchemaRemoved(t *testing.T) {
 	require.True(t, containsId(errs, checker.RequestBodyContentSchemaRemovedId), "expected request-body-content-schema-removed")
 }
 
-// CL: adding/changing content fields on request property
+// adding/changing content fields on request property
 func TestRequestPropertyContentUpdatedProp(t *testing.T) {
 	s1, err := open("../data/checker/content_schema_prop_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_property_default_value_changed_test.go
+++ b/checker/check_request_property_default_value_changed_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: changing request body default value
+// changing request body default value
 func TestRequestBodyDefaultValueChanged(t *testing.T) {
 	s1, err := open("../data/checker/request_body_default_value_changed_base.yaml")
 	require.NoError(t, err)
@@ -29,7 +29,7 @@ func TestRequestBodyDefaultValueChanged(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing request property default value
+// changing request property default value
 func TestRequestPropertyDefaultValueChanged(t *testing.T) {
 	s1, err := open("../data/checker/request_property_default_value_changed_base.yaml")
 	require.NoError(t, err)
@@ -51,7 +51,7 @@ func TestRequestPropertyDefaultValueChanged(t *testing.T) {
 	}, errs)
 }
 
-// CL: adding request body default value or request property default value
+// adding request body default value or request property default value
 func TestRequestBodyDefaultValueAdded(t *testing.T) {
 	s1, err := open("../data/checker/request_body_default_value_changed_base.yaml")
 	require.NoError(t, err)
@@ -83,7 +83,7 @@ func TestRequestBodyDefaultValueAdded(t *testing.T) {
 	}}, errs)
 }
 
-// CL: removing request body default value or request property default value
+// removing request body default value or request property default value
 func TestRequestBodyDefaultValueRemoving(t *testing.T) {
 	s1, err := open("../data/checker/request_body_default_value_changed_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_property_dependent_required_changed_test.go
+++ b/checker/check_request_property_dependent_required_changed_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding dependentRequired to request body
+// adding dependentRequired to request body
 func TestRequestBodyDependentRequiredAdded(t *testing.T) {
 	s1, err := open("../data/checker/dependent_required_base.yaml")
 	require.NoError(t, err)
@@ -30,7 +30,7 @@ func TestRequestBodyDependentRequiredAdded(t *testing.T) {
 	require.True(t, found, "expected request-body-dependent-required-added")
 }
 
-// CL: changing dependentRequired on request body
+// changing dependentRequired on request body
 func TestRequestBodyDependentRequiredChanged(t *testing.T) {
 	s1, err := open("../data/checker/dependent_required_revision.yaml")
 	require.NoError(t, err)
@@ -43,7 +43,7 @@ func TestRequestBodyDependentRequiredChanged(t *testing.T) {
 	requireChange(t, errs, checker.RequestBodyDependentRequiredChangedId)
 }
 
-// CL: adding dependentRequired to request property
+// adding dependentRequired to request property
 func TestRequestPropertyDependentRequiredAdded(t *testing.T) {
 	s1, err := open("../data/checker/dependent_required_property_base.yaml")
 	require.NoError(t, err)
@@ -56,7 +56,7 @@ func TestRequestPropertyDependentRequiredAdded(t *testing.T) {
 	requireChange(t, errs, checker.RequestPropertyDependentRequiredAddedId)
 }
 
-// CL: removing dependentRequired from request property
+// removing dependentRequired from request property
 func TestRequestPropertyDependentRequiredRemoved(t *testing.T) {
 	s1, err := open("../data/checker/dependent_required_property_revision.yaml")
 	require.NoError(t, err)
@@ -69,7 +69,7 @@ func TestRequestPropertyDependentRequiredRemoved(t *testing.T) {
 	requireChange(t, errs, checker.RequestPropertyDependentRequiredRemovedId)
 }
 
-// CL: changing dependentRequired on request property
+// changing dependentRequired on request property
 func TestRequestPropertyDependentRequiredChanged(t *testing.T) {
 	s1, err := open("../data/checker/dependent_required_property_changed_base.yaml")
 	require.NoError(t, err)
@@ -82,7 +82,7 @@ func TestRequestPropertyDependentRequiredChanged(t *testing.T) {
 	requireChange(t, errs, checker.RequestPropertyDependentRequiredChangedId)
 }
 
-// CL: removing dependentRequired from request body
+// removing dependentRequired from request body
 func TestRequestBodyDependentRequiredRemoved(t *testing.T) {
 	s1, err := open("../data/checker/dependent_required_revision.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_property_dependent_schemas_updated_test.go
+++ b/checker/check_request_property_dependent_schemas_updated_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding dependent schema to request body
+// adding dependent schema to request body
 func TestRequestBodyDependentSchemaAdded(t *testing.T) {
 	s1, err := open("../data/checker/dependent_schemas_base.yaml")
 	require.NoError(t, err)
@@ -30,7 +30,7 @@ func TestRequestBodyDependentSchemaAdded(t *testing.T) {
 	require.True(t, found, "expected request-body-dependent-schema-added")
 }
 
-// CL: removing dependent schema from request body
+// removing dependent schema from request body
 func TestRequestBodyDependentSchemaRemoved(t *testing.T) {
 	s1, err := open("../data/checker/dependent_schemas_revision.yaml")
 	require.NoError(t, err)
@@ -52,7 +52,7 @@ func TestRequestBodyDependentSchemaRemoved(t *testing.T) {
 	require.True(t, found, "expected request-body-dependent-schema-removed")
 }
 
-// CL: adding dependent schema to request property
+// adding dependent schema to request property
 func TestRequestPropertyDependentSchemaAdded(t *testing.T) {
 	s1, err := open("../data/checker/dependent_schemas_prop_base.yaml")
 	require.NoError(t, err)
@@ -66,7 +66,7 @@ func TestRequestPropertyDependentSchemaAdded(t *testing.T) {
 	require.True(t, containsId(errs, checker.RequestPropertyDependentSchemaAddedId), "expected request-property-dependent-schema-added")
 }
 
-// CL: removing dependent schema from request property
+// removing dependent schema from request property
 func TestRequestPropertyDependentSchemaRemoved(t *testing.T) {
 	s1, err := open("../data/checker/dependent_schemas_prop_revision.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_property_deprecation_test.go
+++ b/checker/check_request_property_deprecation_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: detecting deprecated request properties with sunset date
+// detecting deprecated request properties with sunset date
 func TestRequestPropertyDeprecationCheck(t *testing.T) {
 	s1, err := open(deprecationFile("request_property_deprecation_base.yaml"))
 	require.NoError(t, err)
@@ -30,7 +30,7 @@ func TestRequestPropertyDeprecationCheck(t *testing.T) {
 	require.Contains(t, errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()), "request property `oldField` deprecated")
 }
 
-// CL: detecting deprecated request properties in allOf schemas with multiple media types
+// detecting deprecated request properties in allOf schemas with multiple media types
 func TestRequestPropertyDeprecationCheck_AllOf(t *testing.T) {
 	s1, err := open(deprecationFile("request_property_deprecation_allof_base.yaml"))
 	require.NoError(t, err)
@@ -54,7 +54,7 @@ func TestRequestPropertyDeprecationCheck_AllOf(t *testing.T) {
 	require.NotEqual(t, msg0, msg1)
 }
 
-// CL: each media type gets its own report with distinct details (issue #594)
+// each media type gets its own report with distinct details (issue #594)
 func TestRequestPropertyDeprecationCheck_MediaTypeContext(t *testing.T) {
 	s1, err := open(deprecationFile("request_property_deprecation_allof_base.yaml"))
 	require.NoError(t, err)
@@ -81,7 +81,7 @@ func TestRequestPropertyDeprecationCheck_MediaTypeContext(t *testing.T) {
 	require.True(t, mediaTypes["application/xml"], "should have application/xml media type")
 }
 
-// BC: deprecating a property with a deprecation policy but without specifying sunset date is breaking
+// deprecating a property with a deprecation policy but without specifying sunset date is breaking
 func TestRequestPropertyDeprecation_WithoutSunsetWithPolicy(t *testing.T) {
 	s1, err := open(deprecationFile("property_base_stable.yaml"))
 	require.NoError(t, err)
@@ -98,7 +98,7 @@ func TestRequestPropertyDeprecation_WithoutSunsetWithPolicy(t *testing.T) {
 	require.Equal(t, "request property `oldField` deprecated without sunset date", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: deprecating a property without a deprecation policy and without specifying sunset date is not breaking for alpha level
+// deprecating a property without a deprecation policy and without specifying sunset date is not breaking for alpha level
 func TestRequestPropertyDeprecation_ForAlpha(t *testing.T) {
 	s1, err := open(deprecationFile("property_base_alpha.yaml"))
 	require.NoError(t, err)
@@ -112,7 +112,7 @@ func TestRequestPropertyDeprecation_ForAlpha(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: deprecating a property with a deprecation policy and sunset date before required deprecation period is breaking
+// deprecating a property with a deprecation policy and sunset date before required deprecation period is breaking
 func TestRequestPropertyDeprecation_WithEarlySunset(t *testing.T) {
 	s1, err := open(deprecationFile("property_base_stable.yaml"))
 	require.NoError(t, err)
@@ -133,7 +133,7 @@ func TestRequestPropertyDeprecation_WithEarlySunset(t *testing.T) {
 
 }
 
-// BC: deprecating a property with a deprecation policy and sunset date after required deprecation period is not breaking
+// deprecating a property with a deprecation policy and sunset date after required deprecation period is not breaking
 func TestRequestPropertyDeprecation_WithProperSunset(t *testing.T) {
 	s1, err := open(deprecationFile("property_base_stable.yaml"))
 	require.NoError(t, err)
@@ -154,7 +154,7 @@ func TestRequestPropertyDeprecation_WithProperSunset(t *testing.T) {
 	require.Contains(t, errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()), "request property `oldField` deprecated")
 }
 
-// CL: properties that were re-activated
+// properties that were re-activated
 func TestRequestPropertyDeprecation_DetectsReactivated(t *testing.T) {
 	s1, err := open(deprecationFile("property_deprecated_future.yaml"))
 	require.NoError(t, err)
@@ -176,7 +176,7 @@ func TestRequestPropertyDeprecation_DetectsReactivated(t *testing.T) {
 	require.Contains(t, e0.GetUncolorizedText(checker.NewDefaultLocalizer()), "request property `oldField` reactivated")
 }
 
-// BC: deprecating a property with an invalid sunset date format is breaking
+// deprecating a property with an invalid sunset date format is breaking
 func TestRequestPropertyDeprecation_WithInvalidSunset(t *testing.T) {
 	s1, err := open(deprecationFile("property_base_stable.yaml"))
 	require.NoError(t, err)
@@ -192,7 +192,7 @@ func TestRequestPropertyDeprecation_WithInvalidSunset(t *testing.T) {
 	require.Equal(t, checker.RequestPropertyDeprecatedInvalidId, errs[0].GetId())
 }
 
-// CL: deprecating a request property with invalid stability level is skipped (handled in CheckBackwardCompatibility)
+// deprecating a request property with invalid stability level is skipped (handled in CheckBackwardCompatibility)
 func TestRequestPropertyDeprecation_WithInvalidStability(t *testing.T) {
 	s1, err := open(deprecationFile("property_base_stable.yaml"))
 	require.NoError(t, err)
@@ -210,7 +210,7 @@ func TestRequestPropertyDeprecation_WithInvalidStability(t *testing.T) {
 	require.Empty(t, changes)
 }
 
-// CL: message has no details when request property deprecated without sunset or stability
+// message has no details when request property deprecated without sunset or stability
 func TestRequestPropertyDeprecation_MessageWithoutDetails(t *testing.T) {
 	s1, err := open(deprecationFile("property_base.yaml"))
 	require.NoError(t, err)
@@ -227,7 +227,7 @@ func TestRequestPropertyDeprecation_MessageWithoutDetails(t *testing.T) {
 	require.Equal(t, "request property `oldField` deprecated", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: message includes sunset date when request property deprecated with valid sunset
+// message includes sunset date when request property deprecated with valid sunset
 func TestRequestPropertyDeprecation_MessageWithSunsetDate(t *testing.T) {
 	s1, err := open(deprecationFile("property_base_stable.yaml"))
 	require.NoError(t, err)
@@ -248,7 +248,7 @@ func TestRequestPropertyDeprecation_MessageWithSunsetDate(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("request property `oldField` deprecated with sunset date `%s` (stability: stable)", sunsetDate), errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: source location points to the deprecated field, not the operation level
+// source location points to the deprecated field, not the operation level
 func TestRequestPropertyDeprecationCheck_SourceLocation(t *testing.T) {
 	loader := openapi3.NewLoader()
 	loader.IncludeOrigin = true

--- a/checker/check_request_property_enum_value_updated_test.go
+++ b/checker/check_request_property_enum_value_updated_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: removing request property enum values
+// removing request property enum values
 func TestRequestPropertyEnumValueRemovedCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_property_enum_value_updated_base.yaml")
 	require.NoError(t, err)
@@ -35,7 +35,7 @@ func TestRequestPropertyEnumValueRemovedCheck(t *testing.T) {
 	require.Equal(t, "removed the enum value `bird` of the request property `category`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: removing request read-only property enum values
+// removing request read-only property enum values
 func TestRequestReadOnlyPropertyEnumValueRemovedCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_property_enum_value_updated_base.yaml")
 	require.NoError(t, err)
@@ -62,7 +62,7 @@ func TestRequestReadOnlyPropertyEnumValueRemovedCheck(t *testing.T) {
 	require.Equal(t, "removed the enum value `bird` of the request read-only property `category`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: adding request property enum values
+// adding request property enum values
 func TestRequestPropertyEnumValueAddedCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_property_enum_value_updated_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_property_exclusive_min_max_test.go
+++ b/checker/check_request_property_exclusive_min_max_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: request body/property exclusiveMinimum increased, exclusiveMaximum decreased
+// request body/property exclusiveMinimum increased, exclusiveMaximum decreased
 func TestRequestPropertyExclusiveMinIncreased(t *testing.T) {
 	s1, err := open("../data/checker/exclusive_min_max_base.yaml")
 	require.NoError(t, err)
@@ -28,7 +28,7 @@ func TestRequestPropertyExclusiveMinIncreased(t *testing.T) {
 	require.True(t, ids[checker.RequestPropertyExclusiveMinIncreasedId], "expected request-property-exclusive-min-increased")
 }
 
-// CL: request body/property exclusiveMaximum decreased
+// request body/property exclusiveMaximum decreased
 func TestRequestPropertyExclusiveMaxDecreased(t *testing.T) {
 	s1, err := open("../data/checker/exclusive_min_max_base.yaml")
 	require.NoError(t, err)
@@ -48,7 +48,7 @@ func TestRequestPropertyExclusiveMaxDecreased(t *testing.T) {
 	require.True(t, ids[checker.RequestPropertyExclusiveMaxDecreasedId], "expected request-property-exclusive-max-decreased")
 }
 
-// CL: request body/property exclusiveMinimum decreased (swap base/revision)
+// request body/property exclusiveMinimum decreased (swap base/revision)
 func TestRequestPropertyExclusiveMinDecreased(t *testing.T) {
 	s1, err := open("../data/checker/exclusive_min_max_revision.yaml")
 	require.NoError(t, err)
@@ -64,7 +64,7 @@ func TestRequestPropertyExclusiveMinDecreased(t *testing.T) {
 	require.True(t, containsId(errs, checker.RequestPropertyExclusiveMinDecreasedId), "expected request-property-exclusive-min-decreased")
 }
 
-// CL: request body/property exclusiveMaximum increased (swap base/revision)
+// request body/property exclusiveMaximum increased (swap base/revision)
 func TestRequestPropertyExclusiveMaxIncreased(t *testing.T) {
 	s1, err := open("../data/checker/exclusive_min_max_revision.yaml")
 	require.NoError(t, err)
@@ -80,7 +80,7 @@ func TestRequestPropertyExclusiveMaxIncreased(t *testing.T) {
 	require.True(t, containsId(errs, checker.RequestPropertyExclusiveMaxIncreasedId), "expected request-property-exclusive-max-increased")
 }
 
-// CL: request body/property exclusiveMinimum set
+// request body/property exclusiveMinimum set
 func TestRequestPropertyExclusiveMinSet(t *testing.T) {
 	s1, err := open("../data/checker/exclusive_min_max_set_base.yaml")
 	require.NoError(t, err)
@@ -100,7 +100,7 @@ func TestRequestPropertyExclusiveMinSet(t *testing.T) {
 	require.True(t, ids[checker.RequestPropertyExclusiveMinSetId], "expected request-property-exclusive-min-set")
 }
 
-// CL: request body/property exclusiveMaximum set
+// request body/property exclusiveMaximum set
 func TestRequestPropertyExclusiveMaxSet(t *testing.T) {
 	s1, err := open("../data/checker/exclusive_min_max_set_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_property_if_updated_test.go
+++ b/checker/check_request_property_if_updated_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding if/then/else to request body
+// adding if/then/else to request body
 func TestRequestBodyIfAdded(t *testing.T) {
 	s1, err := open("../data/checker/if_added_base.yaml")
 	require.NoError(t, err)
@@ -29,7 +29,7 @@ func TestRequestBodyIfAdded(t *testing.T) {
 	require.True(t, ids[checker.RequestBodyElseAddedId], "expected request-body-else-added")
 }
 
-// CL: removing if/then/else from request body
+// removing if/then/else from request body
 func TestRequestBodyIfRemoved(t *testing.T) {
 	s1, err := open("../data/checker/if_added_revision.yaml")
 	require.NoError(t, err)
@@ -50,7 +50,7 @@ func TestRequestBodyIfRemoved(t *testing.T) {
 	require.True(t, ids[checker.RequestBodyElseRemovedId], "expected request-body-else-removed")
 }
 
-// CL: adding if/then/else to request property
+// adding if/then/else to request property
 func TestRequestPropertyIfAdded(t *testing.T) {
 	s1, err := open("../data/checker/if_added_prop_base.yaml")
 	require.NoError(t, err)
@@ -71,7 +71,7 @@ func TestRequestPropertyIfAdded(t *testing.T) {
 	require.True(t, ids[checker.RequestPropertyElseAddedId], "expected request-property-else-added")
 }
 
-// CL: removing if/then/else from request property
+// removing if/then/else from request property
 func TestRequestPropertyIfRemoved(t *testing.T) {
 	s1, err := open("../data/checker/if_added_prop_revision.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_property_max_length_set_test.go
+++ b/checker/check_request_property_max_length_set_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: setting maxLength of request body
+// setting maxLength of request body
 func TestRequestBodyMaxLengthSetCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_body_max_length_set_base.yaml")
 	require.NoError(t, err)
@@ -30,7 +30,7 @@ func TestRequestBodyMaxLengthSetCheck(t *testing.T) {
 	}, errs)
 }
 
-// CL: setting maxLength of request propreties
+// setting maxLength of request propreties
 func TestRequestPropertyMaxLengthSetCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_property_max_length_set_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_property_max_length_updated_test.go
+++ b/checker/check_request_property_max_length_updated_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: increasing max length of request body
+// increasing max length of request body
 func TestRequestBodyMaxLengthDecreasedCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_body_max_length_decreased_base.yaml")
 	require.NoError(t, err)
@@ -35,7 +35,7 @@ func TestRequestBodyMaxLengthDecreasedCheck(t *testing.T) {
 	}, errs)
 }
 
-// CL: decreasing max length of request body
+// decreasing max length of request body
 func TestRequestBodyMaxLengthIncreasedCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_body_max_length_decreased_base.yaml")
 	require.NoError(t, err)
@@ -61,7 +61,7 @@ func TestRequestBodyMaxLengthIncreasedCheck(t *testing.T) {
 	}, errs)
 }
 
-// CL: decreasing max length of request property
+// decreasing max length of request property
 func TestRequestPropertyMaxLengthDecreasedCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_body_max_length_decreased_base.yaml")
 	require.NoError(t, err)
@@ -87,7 +87,7 @@ func TestRequestPropertyMaxLengthDecreasedCheck(t *testing.T) {
 	require.Equal(t, "the `description` request property's maxLength was decreased to `50`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: decreasing max length of request read-only property
+// decreasing max length of request read-only property
 func TestRequestReadOnlyPropertyMaxLengthDecreasedCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_body_max_length_decreased_base.yaml")
 	require.NoError(t, err)
@@ -115,7 +115,7 @@ func TestRequestReadOnlyPropertyMaxLengthDecreasedCheck(t *testing.T) {
 	require.Equal(t, "the `description` request read-only property's maxLength was decreased to `50`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: increasing max length of request property
+// increasing max length of request property
 func TestRequestPropertyMaxLengthIncreasedCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_body_max_length_decreased_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_property_max_set_test.go
+++ b/checker/check_request_property_max_set_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: setting max of request body
+// setting max of request body
 func TestRequestBodyMaxSetCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_body_max_set_base.yaml")
 	require.NoError(t, err)
@@ -30,7 +30,7 @@ func TestRequestBodyMaxSetCheck(t *testing.T) {
 	}, errs)
 }
 
-// CL: setting max of request propreties
+// setting max of request propreties
 func TestRequestPropertyMaxSetCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_property_max_set_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_property_max_updated_test.go
+++ b/checker/check_request_property_max_updated_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: decreasing request property maximum value
+// decreasing request property maximum value
 func TestRequestPropertyMaxDecreasedCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_property_max_decreased_base.yaml")
 	require.NoError(t, err)
@@ -33,7 +33,7 @@ func TestRequestPropertyMaxDecreasedCheck(t *testing.T) {
 	}, errs)
 }
 
-// CL: decreasing request read-only property maximum value
+// decreasing request read-only property maximum value
 func TestRequestReadOnlyPropertyMaxDecreasedCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_property_max_decreased_base.yaml")
 	require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestRequestReadOnlyPropertyMaxDecreasedCheck(t *testing.T) {
 	}, errs)
 }
 
-// CL: increasing request property maximum value
+// increasing request property maximum value
 func TestRequestPropertyMaxIncreasingCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_property_max_decreased_base.yaml")
 	require.NoError(t, err)
@@ -82,7 +82,7 @@ func TestRequestPropertyMaxIncreasingCheck(t *testing.T) {
 	}, errs)
 }
 
-// CL: increasing request body maximum value
+// increasing request body maximum value
 func TestRequestBodyMaxIncreasingCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_property_max_decreased_base.yaml")
 	require.NoError(t, err)
@@ -108,7 +108,7 @@ func TestRequestBodyMaxIncreasingCheck(t *testing.T) {
 	}, errs)
 }
 
-// CL: decreasing request body maximum value
+// decreasing request body maximum value
 func TestRequestBodyMaxDecreasedCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_property_max_decreased_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_property_min_items_increased_test.go
+++ b/checker/check_request_property_min_items_increased_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// BC: inclreasing request body min items is breaking
+// inclreasing request body min items is breaking
 func TestRequestBodyMinItemsIncreased(t *testing.T) {
 	s1, err := open("../data/checker/request_property_min_items_increased_base.yaml")
 	require.NoError(t, err)
@@ -30,7 +30,7 @@ func TestRequestBodyMinItemsIncreased(t *testing.T) {
 	}, errs)
 }
 
-// BC: descreasing request body min items is not breaking
+// descreasing request body min items is not breaking
 func TestRequestBodyMinItemsDecreased(t *testing.T) {
 	s1, err := open("../data/checker/request_property_min_items_increased_revision.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_property_min_length_updated_test.go
+++ b/checker/check_request_property_min_length_updated_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: decreasing minLength of request property
+// decreasing minLength of request property
 func TestRequestPropertyMinLengthDecreased(t *testing.T) {
 	s1, err := open("../data/checker/request_property_min_length_decreased_base.yaml")
 	require.NoError(t, err)
@@ -31,7 +31,7 @@ func TestRequestPropertyMinLengthDecreased(t *testing.T) {
 	}, errs)
 }
 
-// CL: increasing minLength of request property
+// increasing minLength of request property
 func TestRequestPropertyMinLengthIncreased(t *testing.T) {
 	s1, err := open("../data/checker/request_property_min_length_decreased_base.yaml")
 	require.NoError(t, err)
@@ -53,7 +53,7 @@ func TestRequestPropertyMinLengthIncreased(t *testing.T) {
 	}, errs)
 }
 
-// CL: increasing minLength of request body
+// increasing minLength of request body
 func TestRequestBodyMinLengthIncreased(t *testing.T) {
 	s1, err := open("../data/checker/request_property_min_length_decreased_base.yaml")
 	require.NoError(t, err)
@@ -75,7 +75,7 @@ func TestRequestBodyMinLengthIncreased(t *testing.T) {
 	}, errs)
 }
 
-// CL: decreasing minLength of request body
+// decreasing minLength of request body
 func TestRequestBodyMinLengthDecreased(t *testing.T) {
 	s1, err := open("../data/checker/request_property_min_length_decreased_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_property_min_updated_test.go
+++ b/checker/check_request_property_min_updated_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: increasing minimum value of request property
+// increasing minimum value of request property
 func TestRequestPropertyMinIncreasedCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_property_min_increased_base.yaml")
 	require.NoError(t, err)
@@ -30,7 +30,7 @@ func TestRequestPropertyMinIncreasedCheck(t *testing.T) {
 	}, errs)
 }
 
-// CL: increasing minimum value of request read-only property
+// increasing minimum value of request read-only property
 func TestRequestReadOnlyPropertyMinIncreasedCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_property_min_increased_base.yaml")
 	require.NoError(t, err)
@@ -53,7 +53,7 @@ func TestRequestReadOnlyPropertyMinIncreasedCheck(t *testing.T) {
 	}, errs)
 }
 
-// CL: decreasing minimum value of request property
+// decreasing minimum value of request property
 func TestRequestPropertyMinDecreasedCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_property_min_increased_revision.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_property_one_of_updated_test.go
+++ b/checker/check_request_property_one_of_updated_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding 'oneOf' schema to the request body or request body property
+// adding 'oneOf' schema to the request body or request body property
 func TestRequestPropertyOneOfAdded(t *testing.T) {
 	s1, err := open("../data/checker/request_property_one_of_added_base.yaml")
 	require.NoError(t, err)
@@ -41,7 +41,7 @@ func TestRequestPropertyOneOfAdded(t *testing.T) {
 		}}, errs)
 }
 
-// CL: adding 'oneOf' subschema ($ref) with source tracking
+// adding 'oneOf' subschema ($ref) with source tracking
 func TestRequestPropertyOneOfAdded_WithSources(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
 	s1, err := open("../data/checker/request_property_one_of_added_base.yaml", loader)
@@ -64,7 +64,7 @@ func TestRequestPropertyOneOfAdded_WithSources(t *testing.T) {
 	}
 }
 
-// CL: removing 'oneOf' schema from the request body or request body property
+// removing 'oneOf' schema from the request body or request body property
 func TestRequestPropertyOneOfRemoved(t *testing.T) {
 	s1, err := open("../data/checker/request_property_one_of_removed_base.yaml")
 	require.NoError(t, err)
@@ -96,7 +96,7 @@ func TestRequestPropertyOneOfRemoved(t *testing.T) {
 		}}, errs)
 }
 
-// CL: no changes when paths diff is nil
+// no changes when paths diff is nil
 func TestRequestPropertyOneOfNoPathsDiff(t *testing.T) {
 	config := &checker.Config{}
 	d := &diff.Diff{}
@@ -106,7 +106,7 @@ func TestRequestPropertyOneOfNoPathsDiff(t *testing.T) {
 	require.Len(t, errs, 0)
 }
 
-// CL: no changes when operations diff is nil
+// no changes when operations diff is nil
 func TestRequestPropertyOneOfNoOperationsDiff(t *testing.T) {
 	config := &checker.Config{}
 	d := &diff.Diff{
@@ -122,7 +122,7 @@ func TestRequestPropertyOneOfNoOperationsDiff(t *testing.T) {
 	require.Len(t, errs, 0)
 }
 
-// CL: no changes when request body diff is nil
+// no changes when request body diff is nil
 func TestRequestPropertyOneOfNoRequestBodyDiff(t *testing.T) {
 	config := &checker.Config{}
 	d := &diff.Diff{
@@ -144,7 +144,7 @@ func TestRequestPropertyOneOfNoRequestBodyDiff(t *testing.T) {
 	require.Len(t, errs, 0)
 }
 
-// CL: no changes when schema diff is nil
+// no changes when schema diff is nil
 func TestRequestPropertyOneOfNoSchemaDiff(t *testing.T) {
 	config := &checker.Config{}
 	d := &diff.Diff{

--- a/checker/check_request_property_pattern_added_or_changed_test.go
+++ b/checker/check_request_property_pattern_added_or_changed_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: changing request property pattern
+// changing request property pattern
 func TestRequestPropertyPatternChanged(t *testing.T) {
 	s1, err := open("../data/checker/request_property_pattern_added_or_changed_base.yaml")
 	require.NoError(t, err)
@@ -32,7 +32,7 @@ func TestRequestPropertyPatternChanged(t *testing.T) {
 	require.Equal(t, "This is a warning because adding or changing a pattern may restrict the accepted values and break existing clients. For pattern changes, it is difficult to automatically analyze if the new pattern is a superset of the previous pattern (e.g. changed from '[0-9]+' to '[0-9]*')", errs[0].GetComment(checker.NewDefaultLocalizer()))
 }
 
-// CL: generalizing request property pattern
+// generalizing request property pattern
 func TestRequestPropertyPatternGeneralized(t *testing.T) {
 	s1, err := open("../data/checker/request_property_pattern_added_or_changed_base.yaml")
 	require.NoError(t, err)
@@ -53,7 +53,7 @@ func TestRequestPropertyPatternGeneralized(t *testing.T) {
 	}, errs)
 }
 
-// CL: adding request property pattern
+// adding request property pattern
 func TestRequestPropertyPatternAdded(t *testing.T) {
 	s1, err := open("../data/checker/request_property_pattern_added_or_changed_revision.yaml")
 	require.NoError(t, err)
@@ -74,7 +74,7 @@ func TestRequestPropertyPatternAdded(t *testing.T) {
 	require.Equal(t, "This is a breaking change because adding a pattern restriction to a previously unrestricted parameter will reject values that were previously accepted, breaking existing clients", errs[0].GetComment(checker.NewDefaultLocalizer()))
 }
 
-// CL: removing request property pattern
+// removing request property pattern
 func TestRequestPropertyPatternRemoved(t *testing.T) {
 	s1, err := open("../data/checker/request_property_pattern_added_or_changed_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_property_pattern_properties_updated_test.go
+++ b/checker/check_request_property_pattern_properties_updated_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding pattern property to request body
+// adding pattern property to request body
 func TestRequestBodyPatternPropertyAdded(t *testing.T) {
 	s1, err := open("../data/checker/pattern_properties_base.yaml")
 	require.NoError(t, err)
@@ -30,7 +30,7 @@ func TestRequestBodyPatternPropertyAdded(t *testing.T) {
 	require.True(t, found, "expected request-body-pattern-property-added")
 }
 
-// CL: removing pattern property from request body
+// removing pattern property from request body
 func TestRequestBodyPatternPropertyRemoved(t *testing.T) {
 	s1, err := open("../data/checker/pattern_properties_revision.yaml")
 	require.NoError(t, err)
@@ -52,7 +52,7 @@ func TestRequestBodyPatternPropertyRemoved(t *testing.T) {
 	require.True(t, found, "expected request-body-pattern-property-removed")
 }
 
-// CL: adding pattern property to request property
+// adding pattern property to request property
 func TestRequestPropertyPatternPropertyAdded(t *testing.T) {
 	s1, err := open("../data/checker/pattern_properties_prop_base.yaml")
 	require.NoError(t, err)
@@ -66,7 +66,7 @@ func TestRequestPropertyPatternPropertyAdded(t *testing.T) {
 	require.True(t, containsId(errs, checker.RequestPropertyPatternPropertyAddedId), "expected request-property-pattern-property-added")
 }
 
-// CL: removing pattern property from request property
+// removing pattern property from request property
 func TestRequestPropertyPatternPropertyRemoved(t *testing.T) {
 	s1, err := open("../data/checker/pattern_properties_prop_revision.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_property_prefix_items_updated_test.go
+++ b/checker/check_request_property_prefix_items_updated_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding prefixItems to request body
+// adding prefixItems to request body
 func TestRequestBodyPrefixItemsAdded(t *testing.T) {
 	s1, err := open("../data/checker/prefix_items_added_base.yaml")
 	require.NoError(t, err)
@@ -30,7 +30,7 @@ func TestRequestBodyPrefixItemsAdded(t *testing.T) {
 	require.True(t, found, "expected request-body-prefix-items-added")
 }
 
-// CL: removing prefixItems from request body (reverse)
+// removing prefixItems from request body (reverse)
 func TestRequestBodyPrefixItemsRemoved(t *testing.T) {
 	s1, err := open("../data/checker/prefix_items_added_revision.yaml")
 	require.NoError(t, err)
@@ -52,7 +52,7 @@ func TestRequestBodyPrefixItemsRemoved(t *testing.T) {
 	require.True(t, found, "expected request-body-prefix-items-removed")
 }
 
-// CL: adding prefixItems to request property
+// adding prefixItems to request property
 func TestRequestPropertyPrefixItemsAdded(t *testing.T) {
 	s1, err := open("../data/checker/prefix_items_prop_base.yaml")
 	require.NoError(t, err)
@@ -66,7 +66,7 @@ func TestRequestPropertyPrefixItemsAdded(t *testing.T) {
 	require.True(t, containsId(errs, checker.RequestPropertyPrefixItemsAddedId), "expected request-property-prefix-items-added")
 }
 
-// CL: removing prefixItems from request property
+// removing prefixItems from request property
 func TestRequestPropertyPrefixItemsRemoved(t *testing.T) {
 	s1, err := open("../data/checker/prefix_items_prop_revision.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_property_property_names_updated_test.go
+++ b/checker/check_request_property_property_names_updated_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding propertyNames to request body
+// adding propertyNames to request body
 func TestRequestBodyPropertyNamesAdded(t *testing.T) {
 	s1, err := open("../data/checker/property_names_base.yaml")
 	require.NoError(t, err)
@@ -30,7 +30,7 @@ func TestRequestBodyPropertyNamesAdded(t *testing.T) {
 	require.True(t, found, "expected request-body-property-names-added")
 }
 
-// CL: removing propertyNames from request body
+// removing propertyNames from request body
 func TestRequestBodyPropertyNamesRemoved(t *testing.T) {
 	s1, err := open("../data/checker/property_names_revision.yaml")
 	require.NoError(t, err)
@@ -52,7 +52,7 @@ func TestRequestBodyPropertyNamesRemoved(t *testing.T) {
 	require.True(t, found, "expected request-body-property-names-removed")
 }
 
-// CL: adding propertyNames to request property
+// adding propertyNames to request property
 func TestRequestPropertyPropertyNamesAdded(t *testing.T) {
 	s1, err := open("../data/checker/property_names_prop_base.yaml")
 	require.NoError(t, err)
@@ -66,7 +66,7 @@ func TestRequestPropertyPropertyNamesAdded(t *testing.T) {
 	require.True(t, containsId(errs, checker.RequestPropertyPropertyNamesAddedId), "expected request-property-property-names-added")
 }
 
-// CL: removing propertyNames from request property
+// removing propertyNames from request property
 func TestRequestPropertyPropertyNamesRemoved(t *testing.T) {
 	s1, err := open("../data/checker/property_names_prop_revision.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_property_required_updated_test.go
+++ b/checker/check_request_property_required_updated_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: changing request property required value to true
+// changing request property required value to true
 func TestRequestPropertyMarkedRequired(t *testing.T) {
 	s1, err := open("../data/checker/request_property_became_required_base.yaml")
 	require.NoError(t, err)
@@ -30,7 +30,7 @@ func TestRequestPropertyMarkedRequired(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing request property required value to false
+// changing request property required value to false
 func TestRequestPropertyMarkedOptional(t *testing.T) {
 	s1, err := open("../data/checker/request_property_became_required_base.yaml")
 	require.NoError(t, err)
@@ -51,7 +51,7 @@ func TestRequestPropertyMarkedOptional(t *testing.T) {
 	}, errs)
 }
 
-// CL: making request property required, while also giving it a default value
+// making request property required, while also giving it a default value
 func TestRequestPropertyWithDefaultMarkedRequired(t *testing.T) {
 	s1, err := open("../data/checker/request_property_became_required_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_property_type_changed_test.go
+++ b/checker/check_request_property_type_changed_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: changing request body type
+// changing request body type
 func TestRequestBodyTypeChangedCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_property_type_changed_base.yaml")
 	require.NoError(t, err)
@@ -33,7 +33,7 @@ func TestRequestBodyTypeChangedCheck(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing request body type
+// changing request body type
 func TestRequestBodyFormatChangedCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_property_type_changed_base.yaml")
 	require.NoError(t, err)
@@ -56,7 +56,7 @@ func TestRequestBodyFormatChangedCheck(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing request property type
+// changing request property type
 func TestRequestPropertyTypeChangedCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_property_type_changed_base.yaml")
 	require.NoError(t, err)
@@ -77,7 +77,7 @@ func TestRequestPropertyTypeChangedCheck(t *testing.T) {
 	}, errs)
 }
 
-// CL: narrowing a request property union type is breaking
+// narrowing a request property union type is breaking
 func TestRequestPropertyTypeUnionNarrowedCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_property_type_changed_base.yaml")
 	require.NoError(t, err)
@@ -97,7 +97,7 @@ func TestRequestPropertyTypeUnionNarrowedCheck(t *testing.T) {
 	require.Equal(t, checker.RequestPropertyTypeChangedId, errs[0].GetId())
 }
 
-// CL: removing a request property type constraint is not breaking
+// removing a request property type constraint is not breaking
 func TestRequestPropertyTypeDeletedCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_property_type_changed_base.yaml")
 	require.NoError(t, err)
@@ -117,7 +117,7 @@ func TestRequestPropertyTypeDeletedCheck(t *testing.T) {
 	require.Equal(t, checker.RequestPropertyTypeGeneralizedId, errs[0].GetId())
 }
 
-// CL: changing request body and property types from array to object
+// changing request body and property types from array to object
 func TestRequestBodyAndPropertyTypesChangedCheckArrayToObject(t *testing.T) {
 	s1, err := open("../data/checker/request_property_type_changed_base_array_to_object.yaml")
 	require.NoError(t, err)
@@ -148,7 +148,7 @@ func TestRequestBodyAndPropertyTypesChangedCheckArrayToObject(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing request body and property types from object to array
+// changing request body and property types from object to array
 func TestRequestBodyAndPropertyTypesChangedCheckObjectToArray(t *testing.T) {
 	s1, err := open("../data/checker/request_property_type_changed_revision_array_to_object.yaml")
 	require.NoError(t, err)
@@ -179,7 +179,7 @@ func TestRequestBodyAndPropertyTypesChangedCheckObjectToArray(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing request property format
+// changing request property format
 func TestRequestPropertyFormatChangedCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_property_type_changed_base.yaml")
 	require.NoError(t, err)
@@ -202,7 +202,7 @@ func TestRequestPropertyFormatChangedCheck(t *testing.T) {
 	}, errs)
 }
 
-// CL: generalizing request property format
+// generalizing request property format
 func TestRequestPropertyFormatChangedCheckNonBreaking(t *testing.T) {
 	s1, err := open("../data/checker/request_property_type_changed_base.yaml")
 	require.NoError(t, err)
@@ -226,7 +226,7 @@ func TestRequestPropertyFormatChangedCheckNonBreaking(t *testing.T) {
 	}, errs)
 }
 
-// CL: no changes when paths diff is nil
+// no changes when paths diff is nil
 func TestRequestPropertyTypeChangedNoPathsDiff(t *testing.T) {
 	config := &checker.Config{}
 	d := &diff.Diff{}
@@ -236,7 +236,7 @@ func TestRequestPropertyTypeChangedNoPathsDiff(t *testing.T) {
 	require.Len(t, errs, 0)
 }
 
-// CL: no changes when operations diff is nil
+// no changes when operations diff is nil
 func TestRequestPropertyTypeChangedNoOperationsDiff(t *testing.T) {
 	config := &checker.Config{}
 	d := &diff.Diff{
@@ -252,7 +252,7 @@ func TestRequestPropertyTypeChangedNoOperationsDiff(t *testing.T) {
 	require.Len(t, errs, 0)
 }
 
-// CL: no changes when request body diff is nil
+// no changes when request body diff is nil
 func TestRequestPropertyTypeChangedNoRequestBodyDiff(t *testing.T) {
 	config := &checker.Config{}
 	d := &diff.Diff{
@@ -274,7 +274,7 @@ func TestRequestPropertyTypeChangedNoRequestBodyDiff(t *testing.T) {
 	require.Len(t, errs, 0)
 }
 
-// CL: no changes when schema diff is nil
+// no changes when schema diff is nil
 func TestRequestPropertyTypeChangedNoSchemaDiff(t *testing.T) {
 	config := &checker.Config{}
 	d := &diff.Diff{
@@ -304,7 +304,7 @@ func TestRequestPropertyTypeChangedNoSchemaDiff(t *testing.T) {
 	require.Len(t, errs, 0)
 }
 
-// CL: no changes when property is read-only
+// no changes when property is read-only
 func TestRequestPropertyTypeChangedReadOnlyProperty(t *testing.T) {
 	s1, err := open("../data/checker/request_property_type_changed_base.yaml")
 	require.NoError(t, err)
@@ -328,7 +328,7 @@ func setRequestBodyType(t *testing.T, s *load.SpecInfo, types *openapi3.Types) {
 	s.Spec.Paths.Value("/test").Post.RequestBody.Value.Content["application/json"].Schema.Value.Type = types
 }
 
-// BC: widening a request type set ([string] -> [string, integer]) is not
+// widening a request type set ([string] -> [string, integer]) is not
 // breaking; the server accepts every type it did before plus more. Mirror of the
 // response narrowing case.
 func TestRequestBodyTypeWideningMultiTypeNotBreaking(t *testing.T) {
@@ -346,7 +346,7 @@ func TestRequestBodyTypeWideningMultiTypeNotBreaking(t *testing.T) {
 		"widening a request type set is non-breaking; must not report request-body-type-changed")
 }
 
-// BC: removing the type entirely from a request ([string] -> no type) is not
+// removing the type entirely from a request ([string] -> no type) is not
 // breaking; the server now accepts any value (a generalization).
 func TestRequestBodyTypeRemovedNotBreaking(t *testing.T) {
 	s1, err := open("../data/type-change/simple-request.yaml")
@@ -363,7 +363,7 @@ func TestRequestBodyTypeRemovedNotBreaking(t *testing.T) {
 		"removing the type from a request accepts any value; non-breaking")
 }
 
-// BC: narrowing a request type set ([string, integer] -> [string]) is breaking
+// narrowing a request type set ([string, integer] -> [string]) is breaking
 // under a strongly-typed media type; a client sending integer is now rejected.
 func TestRequestBodyTypeNarrowingStillBreaking(t *testing.T) {
 	s1, err := open("../data/type-change/simple-request.yaml")
@@ -380,7 +380,7 @@ func TestRequestBodyTypeNarrowingStillBreaking(t *testing.T) {
 		"narrowing a request type set is breaking")
 }
 
-// BC: adding a type constraint to a previously untyped request (no type ->
+// adding a type constraint to a previously untyped request (no type ->
 // [string]) is breaking; it restricts the accepted values.
 func TestRequestBodyTypeAddedFromUntypedStillBreaking(t *testing.T) {
 	s1, err := open("../data/type-change/simple-request.yaml")
@@ -397,7 +397,7 @@ func TestRequestBodyTypeAddedFromUntypedStillBreaking(t *testing.T) {
 		"constraining a previously untyped request is breaking")
 }
 
-// BC: a request type widening that co-occurs with a breaking format change is
+// a request type widening that co-occurs with a breaking format change is
 // breaking; the safe type axis must not mask the format axis. [integer] ->
 // [integer, string] widens the type (not breaking on its own), but int64 ->
 // int32 narrows the format (a client sending an int64 value is now rejected),

--- a/checker/check_request_property_unevaluated_updated_test.go
+++ b/checker/check_request_property_unevaluated_updated_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding unevaluated constraints to request body
+// adding unevaluated constraints to request body
 func TestRequestBodyUnevaluatedAdded(t *testing.T) {
 	s1, err := open("../data/checker/unevaluated_base.yaml")
 	require.NoError(t, err)
@@ -28,7 +28,7 @@ func TestRequestBodyUnevaluatedAdded(t *testing.T) {
 	require.True(t, ids[checker.RequestBodyUnevaluatedPropertiesAddedId], "expected request-body-unevaluated-properties-added")
 }
 
-// CL: adding unevaluated constraints to request property
+// adding unevaluated constraints to request property
 func TestRequestPropertyUnevaluatedAdded(t *testing.T) {
 	s1, err := open("../data/checker/unevaluated_property_base.yaml")
 	require.NoError(t, err)
@@ -42,7 +42,7 @@ func TestRequestPropertyUnevaluatedAdded(t *testing.T) {
 	requireChange(t, errs, checker.RequestPropertyUnevaluatedPropertiesAddedId)
 }
 
-// CL: removing unevaluated constraints from request property
+// removing unevaluated constraints from request property
 func TestRequestPropertyUnevaluatedRemoved(t *testing.T) {
 	s1, err := open("../data/checker/unevaluated_property_revision.yaml")
 	require.NoError(t, err)
@@ -56,7 +56,7 @@ func TestRequestPropertyUnevaluatedRemoved(t *testing.T) {
 	requireChange(t, errs, checker.RequestPropertyUnevaluatedPropertiesRemovedId)
 }
 
-// CL: removing unevaluated constraints from request body
+// removing unevaluated constraints from request body
 func TestRequestBodyUnevaluatedRemoved(t *testing.T) {
 	s1, err := open("../data/checker/unevaluated_revision.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_property_updated_test.go
+++ b/checker/check_request_property_updated_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding a new required request property
+// adding a new required request property
 func TestRequiredRequestPropertyAdded(t *testing.T) {
 	s1, err := open("../data/checker/request_property_added_base.yaml")
 	require.NoError(t, err)
@@ -29,7 +29,7 @@ func TestRequiredRequestPropertyAdded(t *testing.T) {
 	}, errs)
 }
 
-// CL: adding two new request properties, one required, one optional
+// adding two new request properties, one required, one optional
 func TestRequiredRequestPropertiesAdded(t *testing.T) {
 	s1, err := open("../data/checker/request_property_added_base.yaml")
 	require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestRequiredRequestPropertiesAdded(t *testing.T) {
 		}}, errs)
 }
 
-// CL: adding a new required request property with source tracking
+// adding a new required request property with source tracking
 func TestRequiredRequestPropertyAdded_WithSources(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
 	s1, err := open("../data/checker/request_property_added_base.yaml", loader)
@@ -79,7 +79,7 @@ func TestRequiredRequestPropertyAdded_WithSources(t *testing.T) {
 	require.NotZero(t, errs[0].GetRevisionSource().Line)
 }
 
-// CL: adding a new optional request property
+// adding a new optional request property
 func TestRequiredOptionalPropertyAdded(t *testing.T) {
 	s1, err := open("../data/checker/request_property_added_base.yaml")
 	require.NoError(t, err)
@@ -100,7 +100,7 @@ func TestRequiredOptionalPropertyAdded(t *testing.T) {
 	}, errs)
 }
 
-// CL: removing a required request property
+// removing a required request property
 func TestRequiredRequestPropertyRemoved(t *testing.T) {
 	s1, err := open("../data/checker/request_property_added_revision.yaml")
 	require.NoError(t, err)
@@ -120,7 +120,7 @@ func TestRequiredRequestPropertyRemoved(t *testing.T) {
 	}, errs)
 }
 
-// CL: adding a new required request property with a default value
+// adding a new required request property with a default value
 func TestRequiredRequestPropertyAddedWithDefault(t *testing.T) {
 	s1, err := open("../data/checker/request_property_added_base.yaml")
 	require.NoError(t, err)
@@ -140,7 +140,7 @@ func TestRequiredRequestPropertyAddedWithDefault(t *testing.T) {
 	}, errs)
 }
 
-// BC: wrapping a concrete request body object into a oneOf of object
+// wrapping a concrete request body object into a oneOf of object
 // alternatives is a breaking restructuring (#702): under oneOf a previously
 // valid payload can match multiple overlapping alternatives and be rejected.
 // The moved properties must not be reported as removed, and the wrapping must

--- a/checker/check_request_property_write_only_read_only_test.go
+++ b/checker/check_request_property_write_only_read_only_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: changing optional request property to write-only
+// changing optional request property to write-only
 func TestRequestOptionalPropertyBecameWriteOnly(t *testing.T) {
 	s1, err := open("../data/checker/request_optional_property_write_only_read_only_base.yaml")
 	require.NoError(t, err)
@@ -32,7 +32,7 @@ func TestRequestOptionalPropertyBecameWriteOnly(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing optional request property to not write-only
+// changing optional request property to not write-only
 func TestRequestOptionalPropertyBecameNotWriteOnly(t *testing.T) {
 	s1, err := open("../data/checker/request_optional_property_write_only_read_only_base.yaml")
 	require.NoError(t, err)
@@ -55,7 +55,7 @@ func TestRequestOptionalPropertyBecameNotWriteOnly(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing optional request property to read-only
+// changing optional request property to read-only
 func TestRequestOptionalPropertyBecameReadOnly(t *testing.T) {
 	s1, err := open("../data/checker/request_optional_property_write_only_read_only_base.yaml")
 	require.NoError(t, err)
@@ -78,7 +78,7 @@ func TestRequestOptionalPropertyBecameReadOnly(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing optional request property to not read-only
+// changing optional request property to not read-only
 func TestRequestOptionalPropertyBecameNonReadOnly(t *testing.T) {
 	s1, err := open("../data/checker/request_optional_property_write_only_read_only_base.yaml")
 	require.NoError(t, err)
@@ -101,7 +101,7 @@ func TestRequestOptionalPropertyBecameNonReadOnly(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing required request property to write-only
+// changing required request property to write-only
 func TestRequestRequiredPropertyBecameWriteOnly(t *testing.T) {
 	s1, err := open("../data/checker/request_optional_property_write_only_read_only_base.yaml")
 	require.NoError(t, err)
@@ -124,7 +124,7 @@ func TestRequestRequiredPropertyBecameWriteOnly(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing required request property to not write-only
+// changing required request property to not write-only
 func TestRequestRequiredPropertyBecameNotWriteOnly(t *testing.T) {
 	s1, err := open("../data/checker/request_optional_property_write_only_read_only_base.yaml")
 	require.NoError(t, err)
@@ -147,7 +147,7 @@ func TestRequestRequiredPropertyBecameNotWriteOnly(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing required request property to read-only
+// changing required request property to read-only
 func TestRequestRequiredPropertyBecameReadOnly(t *testing.T) {
 	s1, err := open("../data/checker/request_optional_property_write_only_read_only_base.yaml")
 	require.NoError(t, err)
@@ -170,7 +170,7 @@ func TestRequestRequiredPropertyBecameReadOnly(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing required request property to not read-only
+// changing required request property to not read-only
 func TestRequestRequiredPropertyBecameNonReadOnly(t *testing.T) {
 	s1, err := open("../data/checker/request_optional_property_write_only_read_only_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_request_property_x_extensible_enum_value_removed_test.go
+++ b/checker/check_request_property_x_extensible_enum_value_removed_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// BC: Deleting a value from an x-extensible-enum property is breaking
+// Deleting a value from an x-extensible-enum property is breaking
 func TestRequestPropertyXExtensibleEnumValueRemovedCheck(t *testing.T) {
 	s1, err := open("../data/checker/request_property_extensible_enum_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_response_discriminator_updated_test.go
+++ b/checker/check_response_discriminator_updated_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding discriminator to the response body or response property
+// adding discriminator to the response body or response property
 func TestResponseDiscriminatorUpdatedCheckAdded(t *testing.T) {
 	s1, err := open("../data/checker/response_property_discriminator_added_base.yaml")
 	require.NoError(t, err)
@@ -41,7 +41,7 @@ func TestResponseDiscriminatorUpdatedCheckAdded(t *testing.T) {
 		}}, errs)
 }
 
-// CL: removing discriminator from the response body or response property
+// removing discriminator from the response body or response property
 func TestResponseDiscriminatorUpdatedCheckRemoved(t *testing.T) {
 	s1, err := open("../data/checker/response_property_discriminator_added_revision.yaml")
 	require.NoError(t, err)
@@ -73,7 +73,7 @@ func TestResponseDiscriminatorUpdatedCheckRemoved(t *testing.T) {
 		}}, errs)
 }
 
-// CL: changing discriminator propertyName in the response body or response property
+// changing discriminator propertyName in the response body or response property
 func TestResponseDiscriminatorUpdatedCheckPropertyNameChanging(t *testing.T) {
 	s1, err := open("../data/checker/response_property_discriminator_added_revision.yaml")
 	require.NoError(t, err)
@@ -105,7 +105,7 @@ func TestResponseDiscriminatorUpdatedCheckPropertyNameChanging(t *testing.T) {
 		}}, errs)
 }
 
-// CL: changing discriminator mapping in the response body or response property
+// changing discriminator mapping in the response body or response property
 func TestResponseDiscriminatorUpdatedCheckMappingChanging(t *testing.T) {
 	s1, err := open("../data/checker/response_property_discriminator_added_revision.yaml")
 	require.NoError(t, err)

--- a/checker/check_response_mediatype_name_updated_test.go
+++ b/checker/check_response_mediatype_name_updated_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// BC: changing parameters of a media type is not breaking
+// changing parameters of a media type is not breaking
 func TestChangeMediaTypeParameters(t *testing.T) {
 	s1, err := open("../data/checker/add_new_media_type_revision.yaml")
 	require.NoError(t, err)
@@ -23,7 +23,7 @@ func TestChangeMediaTypeParameters(t *testing.T) {
 	require.Equal(t, "media type `application/json` was changed to `application/problem+json;q=1` for the response status `200`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: modifying a media type name in response to make it more specific is not breaking
+// modifying a media type name in response to make it more specific is not breaking
 func TestSpecializeMediaTypeName(t *testing.T) {
 	s1, err := open("../data/checker/add_new_media_type_revision.yaml")
 	require.NoError(t, err)
@@ -38,7 +38,7 @@ func TestSpecializeMediaTypeName(t *testing.T) {
 	require.Equal(t, "media type `application/json` was changed to a more specific media type `application/problem+json` for the response status `200`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: modifying a media type name in response to make it more general is breaking
+// modifying a media type name in response to make it more general is breaking
 func TestGeneralizeMediaTypeName(t *testing.T) {
 	s1, err := open("../data/checker/add_new_media_type_name_modified.yaml")
 	require.NoError(t, err)

--- a/checker/check_response_mediatype_updated_test.go
+++ b/checker/check_response_mediatype_updated_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding a new media type to response
+// adding a new media type to response
 func TestAddNewMediaType(t *testing.T) {
 	s1, err := open("../data/checker/add_new_media_type_base.yaml")
 	require.NoError(t, err)
@@ -29,7 +29,7 @@ func TestAddNewMediaType(t *testing.T) {
 	}, errs)
 }
 
-// CL: removing a media type from response
+// removing a media type from response
 func TestDeleteNewMediaType(t *testing.T) {
 	s1, err := open("../data/checker/add_new_media_type_revision.yaml")
 	require.NoError(t, err)

--- a/checker/check_response_optional_property_updated_test.go
+++ b/checker/check_response_optional_property_updated_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: removing an optional write-only property from a response
+// removing an optional write-only property from a response
 func TestResponseOptionalPropertyUpdatedCheck(t *testing.T) {
 	s1, err := open("../data/checker/response_optional_property_removed_base.yaml")
 	require.NoError(t, err)
@@ -29,7 +29,7 @@ func TestResponseOptionalPropertyUpdatedCheck(t *testing.T) {
 	}, errs)
 }
 
-// CL: adding an optional write-only property to a response
+// adding an optional write-only property to a response
 func TestResponseOptionalPropertyAddedCheck(t *testing.T) {
 	s1, err := open("../data/checker/response_optional_property_removed_revision.yaml")
 	require.NoError(t, err)
@@ -50,7 +50,7 @@ func TestResponseOptionalPropertyAddedCheck(t *testing.T) {
 	}, errs)
 }
 
-// CL: removing an optional write-only property from a response
+// removing an optional write-only property from a response
 func TestResponseOptionalWriteOnlyPropertyRemovedCheck(t *testing.T) {
 	s1, err := open("../data/checker/response_optional_property_removed_base.yaml")
 	require.NoError(t, err)
@@ -71,7 +71,7 @@ func TestResponseOptionalWriteOnlyPropertyRemovedCheck(t *testing.T) {
 	}, errs)
 }
 
-// CL: adding an optional write-only property to a response
+// adding an optional write-only property to a response
 func TestResponseOptionalWriteOnlyPropertyAddedCheck(t *testing.T) {
 	s1, err := open("../data/checker/response_optional_property_removed_revision.yaml")
 	require.NoError(t, err)

--- a/checker/check_response_optional_property_write_only_read_only_test.go
+++ b/checker/check_response_optional_property_write_only_read_only_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: changing optional response property to write-only
+// changing optional response property to write-only
 func TestResponseOptionalPropertyBecameWriteOnly(t *testing.T) {
 	s1, err := open("../data/checker/response_optional_property_write_only_read_only_base.yaml")
 	require.NoError(t, err)
@@ -32,7 +32,7 @@ func TestResponseOptionalPropertyBecameWriteOnly(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing optional response property to not write-only
+// changing optional response property to not write-only
 func TestResponseOptionalPropertyBecameNotWriteOnly(t *testing.T) {
 	s1, err := open("../data/checker/response_optional_property_write_only_read_only_base.yaml")
 	require.NoError(t, err)
@@ -55,7 +55,7 @@ func TestResponseOptionalPropertyBecameNotWriteOnly(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing optional response property to read-only
+// changing optional response property to read-only
 func TestResponseOptionalPropertyBecameReadOnly(t *testing.T) {
 	s1, err := open("../data/checker/response_optional_property_write_only_read_only_base.yaml")
 	require.NoError(t, err)
@@ -78,7 +78,7 @@ func TestResponseOptionalPropertyBecameReadOnly(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing optional response property to not read-only
+// changing optional response property to not read-only
 func TestResponseOptionalPropertyBecameNonReadOnly(t *testing.T) {
 	s1, err := open("../data/checker/response_optional_property_write_only_read_only_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_response_pattern_added_or_changed_test.go
+++ b/checker/check_response_pattern_added_or_changed_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: changing response property pattern
+// changing response property pattern
 func TestResponsePropertyPatternChanged(t *testing.T) {
 	s1, err := open("../data/checker/response_pattern_added_or_changed_base.yaml")
 	require.NoError(t, err)
@@ -32,7 +32,7 @@ func TestResponsePropertyPatternChanged(t *testing.T) {
 	require.Equal(t, "the `data/created` response's property pattern was changed from `^[a-z]+$` to `^(?:([a-z]+-)*([a-z]+)?)$` for the status `200`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: adding response property pattern
+// adding response property pattern
 func TestResponsePropertyPatternAdded(t *testing.T) {
 	s1, err := open("../data/checker/response_pattern_added_or_changed_base.yaml")
 	require.NoError(t, err)
@@ -55,7 +55,7 @@ func TestResponsePropertyPatternAdded(t *testing.T) {
 	require.Equal(t, "the `data/created` response's property pattern `^[a-z]+$` was added for the status `200`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: removing response property pattern
+// removing response property pattern
 func TestResponsePropertyPatternRemoved(t *testing.T) {
 	s1, err := open("../data/checker/response_pattern_added_or_changed_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_response_property_all_of_updated_test.go
+++ b/checker/check_response_property_all_of_updated_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding 'allOf' subschema to the response body or response body property
+// adding 'allOf' subschema to the response body or response body property
 func TestResponsePropertyAllOfAdded(t *testing.T) {
 	s1, err := open("../data/checker/response_property_all_of_added_base.yaml")
 	require.NoError(t, err)
@@ -41,7 +41,7 @@ func TestResponsePropertyAllOfAdded(t *testing.T) {
 		}}, errs)
 }
 
-// CL: adding 'allOf' subschema ($ref) with source tracking
+// adding 'allOf' subschema ($ref) with source tracking
 func TestResponsePropertyAllOfAdded_WithSources_Ref(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
 	s1, err := open("../data/checker/response_property_all_of_added_base.yaml", loader)
@@ -64,7 +64,7 @@ func TestResponsePropertyAllOfAdded_WithSources_Ref(t *testing.T) {
 	}
 }
 
-// CL: adding inline 'allOf' subschema to the response body with source tracking
+// adding inline 'allOf' subschema to the response body with source tracking
 func TestResponsePropertyAllOfAdded_WithSources_Inline(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
 	s1, err := open("../data/checker/response_property_all_of_inline_added_base.yaml", loader)
@@ -86,7 +86,7 @@ func TestResponsePropertyAllOfAdded_WithSources_Inline(t *testing.T) {
 	require.Greater(t, errs[0].GetRevisionSource().Line, 17)
 }
 
-// CL: removing 'allOf' subschema from the response body or response body property
+// removing 'allOf' subschema from the response body or response body property
 func TestResponsePropertyAllOfRemoved(t *testing.T) {
 	s1, err := open("../data/checker/response_property_all_of_removed_base.yaml")
 	require.NoError(t, err)
@@ -118,7 +118,7 @@ func TestResponsePropertyAllOfRemoved(t *testing.T) {
 		}}, errs)
 }
 
-// CL: adding an allOf subschema to a response body whose body is
+// adding an allOf subschema to a response body whose body is
 // annotation-only is emitted as a distinct INFO change instead of the
 // original allOf-added INFO. The response-side severity is unchanged
 // (INFO either way), but the new ID makes the wire-contract-neutral

--- a/checker/check_response_property_any_of_updated_test.go
+++ b/checker/check_response_property_any_of_updated_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding 'anyOf' schema to the response body or response body property
+// adding 'anyOf' schema to the response body or response body property
 func TestResponsePropertyAnyOfAdded(t *testing.T) {
 	s1, err := open("../data/checker/response_property_any_of_added_base.yaml")
 	require.NoError(t, err)
@@ -41,7 +41,7 @@ func TestResponsePropertyAnyOfAdded(t *testing.T) {
 		}}, errs)
 }
 
-// CL: adding 'anyOf' subschema ($ref) with source tracking
+// adding 'anyOf' subschema ($ref) with source tracking
 func TestResponsePropertyAnyOfAdded_WithSources(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
 	s1, err := open("../data/checker/response_property_any_of_added_base.yaml", loader)
@@ -64,7 +64,7 @@ func TestResponsePropertyAnyOfAdded_WithSources(t *testing.T) {
 	}
 }
 
-// CL: removing 'anyOf' schema from the response body or response body property
+// removing 'anyOf' schema from the response body or response body property
 func TestResponsePropertyAnyOfRemoved(t *testing.T) {
 	s1, err := open("../data/checker/response_property_any_of_removed_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_response_property_became_optional_test.go
+++ b/checker/check_response_property_became_optional_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: changing required response property to optional
+// changing required response property to optional
 func TestResponsePropertyBecameOptionalCheck(t *testing.T) {
 	s1, err := open("../data/checker/response_property_became_optional_base.yaml")
 	require.NoError(t, err)
@@ -29,7 +29,7 @@ func TestResponsePropertyBecameOptionalCheck(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing required response property to optional — schema defined in an external $ref file.
+// changing required response property to optional — schema defined in an external $ref file.
 // Verifies that source tracking (base source) points to the correct line in the $ref'd file.
 // This exercises the yaml3 root-mapping origin fix: previously, schemas loaded from $ref'd files
 // had Origin==nil because document() in yaml3 never injected __origin__ for the root mapping.
@@ -68,7 +68,7 @@ func TestResponsePropertyBecameOptionalCheck_ExternalRef(t *testing.T) {
 	require.Equal(t, 3, base.Line, "base source line must point to '- id' in pet.yaml")
 }
 
-// CL: changing write-only required response property to optional
+// changing write-only required response property to optional
 func TestResponseWriteOnlyPropertyBecameOptionalCheck(t *testing.T) {
 	s1, err := open("../data/checker/response_property_became_optional_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_response_property_became_required_test.go
+++ b/checker/check_response_property_became_required_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: changing optional response property to required
+// changing optional response property to required
 func TestResponsePropertyBecameRequiredlCheck(t *testing.T) {
 	s1, err := open("../data/checker/response_property_became_optional_revision.yaml")
 	require.NoError(t, err)
@@ -28,7 +28,7 @@ func TestResponsePropertyBecameRequiredlCheck(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing optional response property to required with source tracking
+// changing optional response property to required with source tracking
 func TestResponsePropertyBecameRequired_WithSources(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
 	s1, err := open("../data/checker/response_property_became_optional_revision.yaml", loader)
@@ -48,7 +48,7 @@ func TestResponsePropertyBecameRequired_WithSources(t *testing.T) {
 	require.Equal(t, "../data/checker/response_property_became_optional_base.yaml", errs[0].GetRevisionSource().File)
 }
 
-// CL: changing optional response write-only property to required
+// changing optional response write-only property to required
 func TestResponseWriteOnlyPropertyBecameRequiredCheck(t *testing.T) {
 	s1, err := open("../data/checker/response_property_became_optional_revision.yaml")
 	require.NoError(t, err)

--- a/checker/check_response_property_const_changed_test.go
+++ b/checker/check_response_property_const_changed_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: changing response body const value and response property const value
+// changing response body const value and response property const value
 func TestResponsePropertyConstChanged(t *testing.T) {
 	s1, err := open("../data/checker/response_property_const_changed_base.yaml")
 	require.NoError(t, err)
@@ -35,7 +35,7 @@ func TestResponsePropertyConstChanged(t *testing.T) {
 	}}, errs)
 }
 
-// CL: adding response body const value or response property const value
+// adding response body const value or response property const value
 func TestResponsePropertyConstAdded(t *testing.T) {
 	s1, err := open("../data/checker/response_property_const_changed_base.yaml")
 	require.NoError(t, err)
@@ -65,7 +65,7 @@ func TestResponsePropertyConstAdded(t *testing.T) {
 	}}, errs)
 }
 
-// CL: removing response body const value or response property const value
+// removing response body const value or response property const value
 func TestResponsePropertyConstRemoved(t *testing.T) {
 	s1, err := open("../data/checker/response_property_const_changed_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_response_property_contains_updated_test.go
+++ b/checker/check_response_property_contains_updated_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding contains constraint to response body
+// adding contains constraint to response body
 func TestResponseBodyContainsAdded(t *testing.T) {
 	s1, err := open("../data/checker/contains_added_base.yaml")
 	require.NoError(t, err)
@@ -21,7 +21,7 @@ func TestResponseBodyContainsAdded(t *testing.T) {
 	requireChange(t, errs, checker.ResponseBodyContainsAddedId)
 }
 
-// CL: removing contains constraint from response body
+// removing contains constraint from response body
 func TestResponseBodyContainsRemoved(t *testing.T) {
 	s1, err := open("../data/checker/contains_added_revision.yaml")
 	require.NoError(t, err)
@@ -34,7 +34,7 @@ func TestResponseBodyContainsRemoved(t *testing.T) {
 	requireChange(t, errs, checker.ResponseBodyContainsRemovedId)
 }
 
-// CL: increasing minContains on response body
+// increasing minContains on response body
 func TestResponseBodyMinContainsIncreased(t *testing.T) {
 	s1, err := open("../data/checker/contains_min_max_base.yaml")
 	require.NoError(t, err)
@@ -47,7 +47,7 @@ func TestResponseBodyMinContainsIncreased(t *testing.T) {
 	requireChange(t, errs, checker.ResponseBodyMinContainsIncreasedId)
 }
 
-// CL: decreasing minContains on response body
+// decreasing minContains on response body
 func TestResponseBodyMinContainsDecreased(t *testing.T) {
 	s1, err := open("../data/checker/contains_min_max_revision.yaml")
 	require.NoError(t, err)
@@ -60,7 +60,7 @@ func TestResponseBodyMinContainsDecreased(t *testing.T) {
 	requireChange(t, errs, checker.ResponseBodyMinContainsDecreasedId)
 }
 
-// CL: increasing maxContains on response body
+// increasing maxContains on response body
 func TestResponseBodyMaxContainsIncreased(t *testing.T) {
 	s1, err := open("../data/checker/contains_min_max_base.yaml")
 	require.NoError(t, err)
@@ -73,7 +73,7 @@ func TestResponseBodyMaxContainsIncreased(t *testing.T) {
 	requireChange(t, errs, checker.ResponseBodyMaxContainsIncreasedId)
 }
 
-// CL: decreasing maxContains on response body
+// decreasing maxContains on response body
 func TestResponseBodyMaxContainsDecreased(t *testing.T) {
 	s1, err := open("../data/checker/contains_min_max_revision.yaml")
 	require.NoError(t, err)
@@ -86,7 +86,7 @@ func TestResponseBodyMaxContainsDecreased(t *testing.T) {
 	requireChange(t, errs, checker.ResponseBodyMaxContainsDecreasedId)
 }
 
-// CL: adding contains constraint to response property
+// adding contains constraint to response property
 func TestResponsePropertyContainsAdded(t *testing.T) {
 	s1, err := open("../data/checker/contains_property_base.yaml")
 	require.NoError(t, err)
@@ -99,7 +99,7 @@ func TestResponsePropertyContainsAdded(t *testing.T) {
 	requireChange(t, errs, checker.ResponsePropertyContainsAddedId)
 }
 
-// CL: removing contains constraint from response property
+// removing contains constraint from response property
 func TestResponsePropertyContainsRemoved(t *testing.T) {
 	s1, err := open("../data/checker/contains_property_revision.yaml")
 	require.NoError(t, err)
@@ -112,7 +112,7 @@ func TestResponsePropertyContainsRemoved(t *testing.T) {
 	requireChange(t, errs, checker.ResponsePropertyContainsRemovedId)
 }
 
-// CL: increasing minContains on response property
+// increasing minContains on response property
 func TestResponsePropertyMinContainsIncreased(t *testing.T) {
 	s1, err := open("../data/checker/contains_property_min_max_base.yaml")
 	require.NoError(t, err)
@@ -125,7 +125,7 @@ func TestResponsePropertyMinContainsIncreased(t *testing.T) {
 	requireChange(t, errs, checker.ResponsePropertyMinContainsIncreasedId)
 }
 
-// CL: decreasing minContains on response property
+// decreasing minContains on response property
 func TestResponsePropertyMinContainsDecreased(t *testing.T) {
 	s1, err := open("../data/checker/contains_property_min_max_revision.yaml")
 	require.NoError(t, err)
@@ -138,7 +138,7 @@ func TestResponsePropertyMinContainsDecreased(t *testing.T) {
 	requireChange(t, errs, checker.ResponsePropertyMinContainsDecreasedId)
 }
 
-// CL: increasing maxContains on response property
+// increasing maxContains on response property
 func TestResponsePropertyMaxContainsIncreased(t *testing.T) {
 	s1, err := open("../data/checker/contains_property_min_max_base.yaml")
 	require.NoError(t, err)
@@ -151,7 +151,7 @@ func TestResponsePropertyMaxContainsIncreased(t *testing.T) {
 	requireChange(t, errs, checker.ResponsePropertyMaxContainsIncreasedId)
 }
 
-// CL: decreasing maxContains on response property
+// decreasing maxContains on response property
 func TestResponsePropertyMaxContainsDecreased(t *testing.T) {
 	s1, err := open("../data/checker/contains_property_min_max_revision.yaml")
 	require.NoError(t, err)

--- a/checker/check_response_property_content_updated_test.go
+++ b/checker/check_response_property_content_updated_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding contentSchema and changing contentMediaType/contentEncoding in response property
+// adding contentSchema and changing contentMediaType/contentEncoding in response property
 func TestResponsePropertyContentUpdated(t *testing.T) {
 	s1, err := open("../data/checker/content_schema_base.yaml")
 	require.NoError(t, err)
@@ -29,7 +29,7 @@ func TestResponsePropertyContentUpdated(t *testing.T) {
 	require.True(t, ids[checker.ResponsePropertyContentEncodingChangedId], "expected response-property-content-encoding-changed")
 }
 
-// CL: adding contentSchema to response body
+// adding contentSchema to response body
 func TestResponseBodyContentSchemaAdded(t *testing.T) {
 	s1, err := open("../data/checker/content_schema_body_base.yaml")
 	require.NoError(t, err)
@@ -43,7 +43,7 @@ func TestResponseBodyContentSchemaAdded(t *testing.T) {
 	require.True(t, containsId(errs, checker.ResponseBodyContentSchemaAddedId), "expected response-body-content-schema-added")
 }
 
-// CL: removing contentSchema from response body
+// removing contentSchema from response body
 func TestResponseBodyContentSchemaRemoved(t *testing.T) {
 	s1, err := open("../data/checker/content_schema_body_revision.yaml")
 	require.NoError(t, err)
@@ -57,7 +57,7 @@ func TestResponseBodyContentSchemaRemoved(t *testing.T) {
 	require.True(t, containsId(errs, checker.ResponseBodyContentSchemaRemovedId), "expected response-body-content-schema-removed")
 }
 
-// CL: adding/changing content fields on response property
+// adding/changing content fields on response property
 func TestResponsePropertyContentUpdatedProp(t *testing.T) {
 	s1, err := open("../data/checker/content_schema_prop_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_response_property_default_value_changed_test.go
+++ b/checker/check_response_property_default_value_changed_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: changing response body property default value
+// changing response body property default value
 func TestResponsePropertyDefaultValueUpdatedCheck(t *testing.T) {
 	s1, err := open("../data/checker/response_property_default_value_changed_base.yaml")
 	require.NoError(t, err)
@@ -35,7 +35,7 @@ func TestResponsePropertyDefaultValueUpdatedCheck(t *testing.T) {
 	}}, errs)
 }
 
-// CL: changing response body default value
+// changing response body default value
 func TestResponseSchemaDefaultValueUpdatedCheck(t *testing.T) {
 	s1, err := open("../data/checker/response_property_default_value_changed_base.yaml")
 	require.NoError(t, err)
@@ -56,7 +56,7 @@ func TestResponseSchemaDefaultValueUpdatedCheck(t *testing.T) {
 	}, errs)
 }
 
-// CL: adding response body default value or response body property default value
+// adding response body default value or response body property default value
 func TestResponsePropertyDefaultValueAddedCheck(t *testing.T) {
 	s1, err := open("../data/checker/response_property_default_value_changed_base.yaml")
 	require.NoError(t, err)
@@ -86,7 +86,7 @@ func TestResponsePropertyDefaultValueAddedCheck(t *testing.T) {
 	}}, errs)
 }
 
-// CL: removing response body default value or response body property default value
+// removing response body default value or response body property default value
 func TestResponsePropertyDefaultValueRemovedCheck(t *testing.T) {
 	s1, err := open("../data/checker/response_property_default_value_changed_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_response_property_dependent_required_changed_test.go
+++ b/checker/check_response_property_dependent_required_changed_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding dependentRequired to response body
+// adding dependentRequired to response body
 func TestResponseBodyDependentRequiredAdded(t *testing.T) {
 	s1, err := open("../data/checker/dependent_required_base.yaml")
 	require.NoError(t, err)
@@ -21,7 +21,7 @@ func TestResponseBodyDependentRequiredAdded(t *testing.T) {
 	requireChange(t, errs, checker.ResponseBodyDependentRequiredAddedId)
 }
 
-// CL: removing dependentRequired from response body
+// removing dependentRequired from response body
 func TestResponseBodyDependentRequiredRemoved(t *testing.T) {
 	s1, err := open("../data/checker/dependent_required_revision.yaml")
 	require.NoError(t, err)
@@ -34,7 +34,7 @@ func TestResponseBodyDependentRequiredRemoved(t *testing.T) {
 	requireChange(t, errs, checker.ResponseBodyDependentRequiredRemovedId)
 }
 
-// CL: changing dependentRequired on response body
+// changing dependentRequired on response body
 func TestResponseBodyDependentRequiredChanged(t *testing.T) {
 	s1, err := open("../data/checker/dependent_required_revision.yaml")
 	require.NoError(t, err)
@@ -47,7 +47,7 @@ func TestResponseBodyDependentRequiredChanged(t *testing.T) {
 	requireChange(t, errs, checker.ResponseBodyDependentRequiredChangedId)
 }
 
-// CL: changing dependentRequired on response property
+// changing dependentRequired on response property
 func TestResponsePropertyDependentRequiredChanged(t *testing.T) {
 	s1, err := open("../data/checker/dependent_required_property_changed_base.yaml")
 	require.NoError(t, err)
@@ -60,7 +60,7 @@ func TestResponsePropertyDependentRequiredChanged(t *testing.T) {
 	requireChange(t, errs, checker.ResponsePropertyDependentRequiredChangedId)
 }
 
-// CL: adding dependentRequired to response property
+// adding dependentRequired to response property
 func TestResponsePropertyDependentRequiredAdded(t *testing.T) {
 	s1, err := open("../data/checker/dependent_required_property_base.yaml")
 	require.NoError(t, err)
@@ -73,7 +73,7 @@ func TestResponsePropertyDependentRequiredAdded(t *testing.T) {
 	requireChange(t, errs, checker.ResponsePropertyDependentRequiredAddedId)
 }
 
-// CL: removing dependentRequired from response property
+// removing dependentRequired from response property
 func TestResponsePropertyDependentRequiredRemoved(t *testing.T) {
 	s1, err := open("../data/checker/dependent_required_property_revision.yaml")
 	require.NoError(t, err)

--- a/checker/check_response_property_dependent_schemas_updated_test.go
+++ b/checker/check_response_property_dependent_schemas_updated_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding dependent schema to response body
+// adding dependent schema to response body
 func TestResponseBodyDependentSchemaAdded(t *testing.T) {
 	s1, err := open("../data/checker/dependent_schemas_base.yaml")
 	require.NoError(t, err)
@@ -30,7 +30,7 @@ func TestResponseBodyDependentSchemaAdded(t *testing.T) {
 	require.True(t, found, "expected response-body-dependent-schema-added")
 }
 
-// CL: removing dependent schema from response body
+// removing dependent schema from response body
 func TestResponseBodyDependentSchemaRemoved(t *testing.T) {
 	s1, err := open("../data/checker/dependent_schemas_revision.yaml")
 	require.NoError(t, err)
@@ -44,7 +44,7 @@ func TestResponseBodyDependentSchemaRemoved(t *testing.T) {
 	require.True(t, containsId(errs, checker.ResponseBodyDependentSchemaRemovedId), "expected response-body-dependent-schema-removed")
 }
 
-// CL: adding dependent schema to response property
+// adding dependent schema to response property
 func TestResponsePropertyDependentSchemaAdded(t *testing.T) {
 	s1, err := open("../data/checker/dependent_schemas_prop_base.yaml")
 	require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestResponsePropertyDependentSchemaAdded(t *testing.T) {
 	require.True(t, containsId(errs, checker.ResponsePropertyDependentSchemaAddedId), "expected response-property-dependent-schema-added")
 }
 
-// CL: removing dependent schema from response property
+// removing dependent schema from response property
 func TestResponsePropertyDependentSchemaRemoved(t *testing.T) {
 	s1, err := open("../data/checker/dependent_schemas_prop_revision.yaml")
 	require.NoError(t, err)

--- a/checker/check_response_property_deprecation_test.go
+++ b/checker/check_response_property_deprecation_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: detecting deprecated response properties with sunset date
+// detecting deprecated response properties with sunset date
 func TestResponsePropertyDeprecationCheck(t *testing.T) {
 	s1, err := open(deprecationFile("response_property_deprecation_base.yaml"))
 	require.NoError(t, err)
@@ -30,7 +30,7 @@ func TestResponsePropertyDeprecationCheck(t *testing.T) {
 	require.Contains(t, errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()), "response property `legacyField` deprecated")
 }
 
-// CL: detecting deprecated response properties in allOf schemas with multiple media types
+// detecting deprecated response properties in allOf schemas with multiple media types
 func TestResponsePropertyDeprecationCheck_AllOf(t *testing.T) {
 	s1, err := open(deprecationFile("response_property_deprecation_allof_base.yaml"))
 	require.NoError(t, err)
@@ -54,7 +54,7 @@ func TestResponsePropertyDeprecationCheck_AllOf(t *testing.T) {
 	require.NotEqual(t, msg0, msg1)
 }
 
-// CL: each media type gets its own report with distinct details (issue #594)
+// each media type gets its own report with distinct details (issue #594)
 func TestResponsePropertyDeprecationCheck_MediaTypeContext(t *testing.T) {
 	s1, err := open(deprecationFile("response_property_deprecation_allof_base.yaml"))
 	require.NoError(t, err)
@@ -81,7 +81,7 @@ func TestResponsePropertyDeprecationCheck_MediaTypeContext(t *testing.T) {
 	require.True(t, mediaTypes["application/xml"], "should have application/xml media type")
 }
 
-// BC: deprecating a response property with a deprecation policy but without specifying sunset date is breaking
+// deprecating a response property with a deprecation policy but without specifying sunset date is breaking
 func TestResponsePropertyDeprecation_WithoutSunsetWithPolicy(t *testing.T) {
 	s1, err := open(deprecationFile("property_base_stable.yaml"))
 	require.NoError(t, err)
@@ -98,7 +98,7 @@ func TestResponsePropertyDeprecation_WithoutSunsetWithPolicy(t *testing.T) {
 	require.Equal(t, "response property `legacyField` deprecated without sunset date", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: deprecating a response property without a deprecation policy and without specifying sunset date is not breaking for alpha level
+// deprecating a response property without a deprecation policy and without specifying sunset date is not breaking for alpha level
 func TestResponsePropertyDeprecation_ForAlpha(t *testing.T) {
 	s1, err := open(deprecationFile("property_base_alpha.yaml"))
 	require.NoError(t, err)
@@ -112,7 +112,7 @@ func TestResponsePropertyDeprecation_ForAlpha(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// BC: deprecating a response property with a deprecation policy and sunset date before required deprecation period is breaking
+// deprecating a response property with a deprecation policy and sunset date before required deprecation period is breaking
 func TestResponsePropertyDeprecation_WithEarlySunset(t *testing.T) {
 	s1, err := open(deprecationFile("property_base_stable.yaml"))
 	require.NoError(t, err)
@@ -132,7 +132,7 @@ func TestResponsePropertyDeprecation_WithEarlySunset(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("response property `legacyField` sunset date `%s` is too small, must be at least `10` days from now", sunsetDate), errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// BC: deprecating a response property with a deprecation policy and sunset date after required deprecation period is not breaking
+// deprecating a response property with a deprecation policy and sunset date after required deprecation period is not breaking
 func TestResponsePropertyDeprecation_WithProperSunset(t *testing.T) {
 	s1, err := open(deprecationFile("property_base_stable.yaml"))
 	require.NoError(t, err)
@@ -153,7 +153,7 @@ func TestResponsePropertyDeprecation_WithProperSunset(t *testing.T) {
 	require.Contains(t, errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()), "response property `legacyField` deprecated")
 }
 
-// CL: response properties that were re-activated
+// response properties that were re-activated
 func TestResponsePropertyDeprecation_DetectsReactivated(t *testing.T) {
 	s1, err := open(deprecationFile("property_deprecated.yaml"))
 	require.NoError(t, err)
@@ -175,7 +175,7 @@ func TestResponsePropertyDeprecation_DetectsReactivated(t *testing.T) {
 	require.Contains(t, e0.GetUncolorizedText(checker.NewDefaultLocalizer()), "response property `legacyField` reactivated")
 }
 
-// BC: deprecating a response property with an invalid sunset date format is breaking
+// deprecating a response property with an invalid sunset date format is breaking
 func TestResponsePropertyDeprecation_WithInvalidSunset(t *testing.T) {
 	s1, err := open(deprecationFile("property_base_stable.yaml"))
 	require.NoError(t, err)
@@ -191,7 +191,7 @@ func TestResponsePropertyDeprecation_WithInvalidSunset(t *testing.T) {
 	require.Equal(t, checker.ResponsePropertyDeprecatedInvalidId, errs[0].GetId())
 }
 
-// CL: deprecating a response property with invalid stability level is skipped (handled in CheckBackwardCompatibility)
+// deprecating a response property with invalid stability level is skipped (handled in CheckBackwardCompatibility)
 func TestResponsePropertyDeprecation_WithInvalidStability(t *testing.T) {
 	s1, err := open(deprecationFile("property_base_stable.yaml"))
 	require.NoError(t, err)
@@ -209,7 +209,7 @@ func TestResponsePropertyDeprecation_WithInvalidStability(t *testing.T) {
 	require.Empty(t, changes)
 }
 
-// CL: message has no details when response property deprecated without sunset or stability
+// message has no details when response property deprecated without sunset or stability
 func TestResponsePropertyDeprecation_MessageWithoutDetails(t *testing.T) {
 	s1, err := open(deprecationFile("property_base.yaml"))
 	require.NoError(t, err)
@@ -226,7 +226,7 @@ func TestResponsePropertyDeprecation_MessageWithoutDetails(t *testing.T) {
 	require.Equal(t, "response property `legacyField` deprecated", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: message includes sunset date when response property deprecated with valid sunset
+// message includes sunset date when response property deprecated with valid sunset
 func TestResponsePropertyDeprecation_MessageWithSunsetDate(t *testing.T) {
 	s1, err := open(deprecationFile("property_base_stable.yaml"))
 	require.NoError(t, err)
@@ -247,7 +247,7 @@ func TestResponsePropertyDeprecation_MessageWithSunsetDate(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("response property `legacyField` deprecated with sunset date `%s` (stability: stable)", sunsetDate), errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: source location points to the deprecated field, not the operation or response level
+// source location points to the deprecated field, not the operation or response level
 func TestResponsePropertyDeprecationCheck_SourceLocation(t *testing.T) {
 	loader := openapi3.NewLoader()
 	loader.IncludeOrigin = true

--- a/checker/check_response_property_enum_value_added_test.go
+++ b/checker/check_response_property_enum_value_added_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding an enum value to a response property
+// adding an enum value to a response property
 func TestResponsePropertyEnumValueAdded(t *testing.T) {
 	s1, err := open("../data/checker/response_property_enum_added_base.yaml")
 	require.NoError(t, err)
@@ -33,7 +33,7 @@ func TestResponsePropertyEnumValueAdded(t *testing.T) {
 	require.Equal(t, "Adding new enum values to a response can be unexpected for clients; use x-extensible-enum instead.", errs[0].GetComment(checker.NewDefaultLocalizer()))
 }
 
-// CL: adding an enum value to a response write-only property
+// adding an enum value to a response write-only property
 func TestResponseWriteOnlyPropertyEnumValueAdded(t *testing.T) {
 	s1, err := open("../data/checker/response_property_enum_added_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_response_property_enum_value_removed_test.go
+++ b/checker/check_response_property_enum_value_removed_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: removing an enum value from a response property
+// removing an enum value from a response property
 func TestResponsePropertyEnumValueRemoved(t *testing.T) {
 	s1, err := open("../data/checker/response_property_enum_added_base.yaml")
 	require.NoError(t, err)
@@ -31,7 +31,7 @@ func TestResponsePropertyEnumValueRemoved(t *testing.T) {
 	}, errs)
 }
 
-// CL: removing an enum value from a response write-only property
+// removing an enum value from a response write-only property
 func TestResponseWriteOnlyPropertyEnumValueRemoved(t *testing.T) {
 	s1, err := open("../data/checker/response_property_enum_added_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_response_property_exclusive_min_max_test.go
+++ b/checker/check_response_property_exclusive_min_max_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: response body/property exclusiveMaximum increased
+// response body/property exclusiveMaximum increased
 func TestResponsePropertyExclusiveMaxIncreased(t *testing.T) {
 	s1, err := open("../data/checker/exclusive_min_max_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_response_property_if_updated_test.go
+++ b/checker/check_response_property_if_updated_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding if/then/else to response body
+// adding if/then/else to response body
 func TestResponseBodyIfAdded(t *testing.T) {
 	s1, err := open("../data/checker/if_added_base.yaml")
 	require.NoError(t, err)
@@ -29,7 +29,7 @@ func TestResponseBodyIfAdded(t *testing.T) {
 	require.True(t, ids[checker.ResponseBodyElseAddedId], "expected response-body-else-added")
 }
 
-// CL: removing if/then/else from response body
+// removing if/then/else from response body
 func TestResponseBodyIfRemoved(t *testing.T) {
 	s1, err := open("../data/checker/if_added_revision.yaml")
 	require.NoError(t, err)
@@ -50,7 +50,7 @@ func TestResponseBodyIfRemoved(t *testing.T) {
 	require.True(t, ids[checker.ResponseBodyElseRemovedId], "expected response-body-else-removed")
 }
 
-// CL: adding if/then/else to response property
+// adding if/then/else to response property
 func TestResponsePropertyIfAdded(t *testing.T) {
 	s1, err := open("../data/checker/if_added_prop_base.yaml")
 	require.NoError(t, err)
@@ -71,7 +71,7 @@ func TestResponsePropertyIfAdded(t *testing.T) {
 	require.True(t, ids[checker.ResponsePropertyElseAddedId], "expected response-property-else-added")
 }
 
-// CL: removing if/then/else from response property
+// removing if/then/else from response property
 func TestResponsePropertyIfRemoved(t *testing.T) {
 	s1, err := open("../data/checker/if_added_prop_revision.yaml")
 	require.NoError(t, err)

--- a/checker/check_response_property_min_decreased_test.go
+++ b/checker/check_response_property_min_decreased_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: decreasing min in response body
+// decreasing min in response body
 func TestResponseBodyMinDecreased(t *testing.T) {
 	s1, err := open("../data/checker/response_min_decreased_base.yaml")
 	require.NoError(t, err)
@@ -22,7 +22,7 @@ func TestResponseBodyMinDecreased(t *testing.T) {
 	require.True(t, containsId(errs, checker.ResponseBodyMinDecreasedId), "expected response-body-min-decreased")
 }
 
-// CL: decreasing min in response property
+// decreasing min in response property
 func TestResponsePropertyMinDecreased(t *testing.T) {
 	s1, err := open("../data/checker/response_min_decreased_base.yaml")
 	require.NoError(t, err)
@@ -36,7 +36,7 @@ func TestResponsePropertyMinDecreased(t *testing.T) {
 	require.True(t, containsId(errs, checker.ResponsePropertyMinDecreasedId), "expected response-property-min-decreased")
 }
 
-// CL: decreasing exclusiveMinimum in response body
+// decreasing exclusiveMinimum in response body
 func TestResponseBodyExclusiveMinDecreased(t *testing.T) {
 	s1, err := open("../data/checker/response_min_decreased_base.yaml")
 	require.NoError(t, err)
@@ -50,7 +50,7 @@ func TestResponseBodyExclusiveMinDecreased(t *testing.T) {
 	require.True(t, containsId(errs, checker.ResponseBodyExclusiveMinDecreasedId), "expected response-body-exclusive-min-decreased")
 }
 
-// CL: decreasing exclusiveMinimum in response property
+// decreasing exclusiveMinimum in response property
 func TestResponsePropertyExclusiveMinDecreased(t *testing.T) {
 	s1, err := open("../data/checker/response_min_decreased_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_response_property_one_of_updated_test.go
+++ b/checker/check_response_property_one_of_updated_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// BC: adding 'oneOf' schema to the response body or response body property is breaking
+// adding 'oneOf' schema to the response body or response body property is breaking
 func TestResponsePropertyOneOfAdded(t *testing.T) {
 	s1, err := open("../data/checker/response_property_one_of_added_base.yaml")
 	require.NoError(t, err)
@@ -49,7 +49,7 @@ func TestResponsePropertyOneOfAdded(t *testing.T) {
 		}}, errs)
 }
 
-// CL: adding 'oneOf' subschema ($ref) with source tracking
+// adding 'oneOf' subschema ($ref) with source tracking
 func TestResponsePropertyOneOfAdded_WithSources(t *testing.T) {
 	loader := newLoaderWithOriginTracking()
 	s1, err := open("../data/checker/response_property_one_of_added_base.yaml", loader)
@@ -72,7 +72,7 @@ func TestResponsePropertyOneOfAdded_WithSources(t *testing.T) {
 	}
 }
 
-// CL: removing 'oneOf' schema from the response body or response body property
+// removing 'oneOf' schema from the response body or response body property
 func TestResponsePropertyOneOfRemoved(t *testing.T) {
 	s1, err := open("../data/checker/response_property_one_of_removed_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_response_property_pattern_properties_updated_test.go
+++ b/checker/check_response_property_pattern_properties_updated_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding pattern property to response body
+// adding pattern property to response body
 func TestResponseBodyPatternPropertyAdded(t *testing.T) {
 	s1, err := open("../data/checker/pattern_properties_base.yaml")
 	require.NoError(t, err)
@@ -30,7 +30,7 @@ func TestResponseBodyPatternPropertyAdded(t *testing.T) {
 	require.True(t, found, "expected response-body-pattern-property-added")
 }
 
-// CL: removing pattern property from response body
+// removing pattern property from response body
 func TestResponseBodyPatternPropertyRemoved(t *testing.T) {
 	s1, err := open("../data/checker/pattern_properties_revision.yaml")
 	require.NoError(t, err)
@@ -44,7 +44,7 @@ func TestResponseBodyPatternPropertyRemoved(t *testing.T) {
 	require.True(t, containsId(errs, checker.ResponseBodyPatternPropertyRemovedId), "expected response-body-pattern-property-removed")
 }
 
-// CL: adding pattern property to response property
+// adding pattern property to response property
 func TestResponsePropertyPatternPropertyAdded(t *testing.T) {
 	s1, err := open("../data/checker/pattern_properties_prop_base.yaml")
 	require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestResponsePropertyPatternPropertyAdded(t *testing.T) {
 	require.True(t, containsId(errs, checker.ResponsePropertyPatternPropertyAddedId), "expected response-property-pattern-property-added")
 }
 
-// CL: removing pattern property from response property
+// removing pattern property from response property
 func TestResponsePropertyPatternPropertyRemoved(t *testing.T) {
 	s1, err := open("../data/checker/pattern_properties_prop_revision.yaml")
 	require.NoError(t, err)

--- a/checker/check_response_property_prefix_items_updated_test.go
+++ b/checker/check_response_property_prefix_items_updated_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding prefixItems to response body
+// adding prefixItems to response body
 func TestResponseBodyPrefixItemsAdded(t *testing.T) {
 	s1, err := open("../data/checker/prefix_items_added_base.yaml")
 	require.NoError(t, err)
@@ -30,7 +30,7 @@ func TestResponseBodyPrefixItemsAdded(t *testing.T) {
 	require.True(t, found, "expected response-body-prefix-items-added")
 }
 
-// CL: removing prefixItems from response body
+// removing prefixItems from response body
 func TestResponseBodyPrefixItemsRemoved(t *testing.T) {
 	s1, err := open("../data/checker/prefix_items_added_revision.yaml")
 	require.NoError(t, err)
@@ -44,7 +44,7 @@ func TestResponseBodyPrefixItemsRemoved(t *testing.T) {
 	require.True(t, containsId(errs, checker.ResponseBodyPrefixItemsRemovedId), "expected response-body-prefix-items-removed")
 }
 
-// CL: adding prefixItems to response property
+// adding prefixItems to response property
 func TestResponsePropertyPrefixItemsAdded(t *testing.T) {
 	s1, err := open("../data/checker/prefix_items_prop_base.yaml")
 	require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestResponsePropertyPrefixItemsAdded(t *testing.T) {
 	require.True(t, containsId(errs, checker.ResponsePropertyPrefixItemsAddedId), "expected response-property-prefix-items-added")
 }
 
-// CL: removing prefixItems from response property
+// removing prefixItems from response property
 func TestResponsePropertyPrefixItemsRemoved(t *testing.T) {
 	s1, err := open("../data/checker/prefix_items_prop_revision.yaml")
 	require.NoError(t, err)

--- a/checker/check_response_property_property_names_updated_test.go
+++ b/checker/check_response_property_property_names_updated_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding propertyNames to response body
+// adding propertyNames to response body
 func TestResponseBodyPropertyNamesAdded(t *testing.T) {
 	s1, err := open("../data/checker/property_names_base.yaml")
 	require.NoError(t, err)
@@ -30,7 +30,7 @@ func TestResponseBodyPropertyNamesAdded(t *testing.T) {
 	require.True(t, found, "expected response-body-property-names-added")
 }
 
-// CL: removing propertyNames from response body
+// removing propertyNames from response body
 func TestResponseBodyPropertyNamesRemoved(t *testing.T) {
 	s1, err := open("../data/checker/property_names_revision.yaml")
 	require.NoError(t, err)
@@ -44,7 +44,7 @@ func TestResponseBodyPropertyNamesRemoved(t *testing.T) {
 	require.True(t, containsId(errs, checker.ResponseBodyPropertyNamesRemovedId), "expected response-body-property-names-removed")
 }
 
-// CL: adding propertyNames to response property
+// adding propertyNames to response property
 func TestResponsePropertyPropertyNamesAdded(t *testing.T) {
 	s1, err := open("../data/checker/property_names_prop_base.yaml")
 	require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestResponsePropertyPropertyNamesAdded(t *testing.T) {
 	require.True(t, containsId(errs, checker.ResponsePropertyPropertyNamesAddedId), "expected response-property-property-names-added")
 }
 
-// CL: removing propertyNames from response property
+// removing propertyNames from response property
 func TestResponsePropertyPropertyNamesRemoved(t *testing.T) {
 	s1, err := open("../data/checker/property_names_prop_revision.yaml")
 	require.NoError(t, err)

--- a/checker/check_response_property_type_changed_test.go
+++ b/checker/check_response_property_type_changed_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: changing a response schema type
+// changing a response schema type
 func TestResponseSchemaTypeChangedCheck(t *testing.T) {
 	s1, err := open("../data/checker/response_schema_type_changed_base.yaml")
 	require.NoError(t, err)
@@ -30,7 +30,7 @@ func TestResponseSchemaTypeChangedCheck(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing a response property schema type from string to integer
+// changing a response property schema type from string to integer
 func TestResponsePropertyTypeChangedCheck(t *testing.T) {
 	s1, err := open("../data/checker/response_schema_type_changed_revision.yaml")
 	require.NoError(t, err)
@@ -52,7 +52,7 @@ func TestResponsePropertyTypeChangedCheck(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing a response property schema format
+// changing a response property schema format
 func TestResponsePropertyFormatChangedCheck(t *testing.T) {
 	s1, err := open("../data/checker/response_schema_format_changed_base.yaml")
 	require.NoError(t, err)
@@ -74,7 +74,7 @@ func TestResponsePropertyFormatChangedCheck(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing properties of subschemas under allOf
+// changing properties of subschemas under allOf
 func TestResponsePropertyAnyOfModified(t *testing.T) {
 	s1, err := open("../data/checker/response_property_any_of_complex_base.yaml")
 	require.NoError(t, err)
@@ -112,7 +112,7 @@ func TestResponsePropertyAnyOfModified(t *testing.T) {
 		}}, errs)
 }
 
-// CL: changing a response property schema type from a single value to to multiple types
+// changing a response property schema type from a single value to to multiple types
 func TestResponseSchemaTypeMultiCheck(t *testing.T) {
 	s1, err := open("../data/checker/response_schema_type_changed_revision.yaml")
 	require.NoError(t, err)
@@ -134,7 +134,7 @@ func TestResponseSchemaTypeMultiCheck(t *testing.T) {
 	}, errs)
 }
 
-// BC: changing an additionalResponse property schema type from integer to string is breaking
+// changing an additionalResponse property schema type from integer to string is breaking
 func TestResponseAdditionalPropertyTypeChangedCheck(t *testing.T) {
 	s1, err := open("../data/additional-properties/base.yaml")
 	require.NoError(t, err)
@@ -154,7 +154,7 @@ func TestResponseAdditionalPropertyTypeChangedCheck(t *testing.T) {
 	}, errs)
 }
 
-// BC: changing an embedded additionalResponse property schema type from integer to string is breaking
+// changing an embedded additionalResponse property schema type from integer to string is breaking
 func TestResponseEmbeddedAdditionalPropertyTypeChangedCheck(t *testing.T) {
 	s1, err := open("../data/additional-properties/embedded-base.yaml")
 	require.NoError(t, err)
@@ -180,7 +180,7 @@ func setResponseBodyType(t *testing.T, s *load.SpecInfo, types *openapi3.Types) 
 	s.Spec.Paths.Value("/test").Get.Responses.Value("200").Value.Content["application/json"].Schema.Value.Type = types
 }
 
-// BC: narrowing a response type set ([string, integer] -> [string]) is not
+// narrowing a response type set ([string, integer] -> [string]) is not
 // breaking; the server returns fewer kinds of values, all of which the client
 // already handled. (#1003 / #989 Gap 2)
 func TestResponseBodyTypeNarrowingMultiTypeNotBreaking(t *testing.T) {
@@ -198,7 +198,7 @@ func TestResponseBodyTypeNarrowingMultiTypeNotBreaking(t *testing.T) {
 		"narrowing a response type set is non-breaking; must not report response-body-type-changed")
 }
 
-// BC: narrowing a previously untyped response to a concrete type (no type ->
+// narrowing a previously untyped response to a concrete type (no type ->
 // [string]) is not breaking; the server returns fewer kinds of values.
 func TestResponseBodyTypeAddedFromUntypedNotBreaking(t *testing.T) {
 	s1, err := open("../data/type-change/simple-response.yaml")
@@ -215,7 +215,7 @@ func TestResponseBodyTypeAddedFromUntypedNotBreaking(t *testing.T) {
 		"narrowing an untyped response to a concrete type is non-breaking")
 }
 
-// BC: widening a response type set ([string] -> [string, integer]) is breaking;
+// widening a response type set ([string] -> [string, integer]) is breaking;
 // the server may now return a type the client did not handle.
 func TestResponseBodyTypeWideningStillBreaking(t *testing.T) {
 	s1, err := open("../data/type-change/simple-response.yaml")
@@ -232,7 +232,7 @@ func TestResponseBodyTypeWideningStillBreaking(t *testing.T) {
 		"widening a response type set is breaking")
 }
 
-// BC: removing the type entirely from a response ([string] -> no type) is
+// removing the type entirely from a response ([string] -> no type) is
 // breaking; the server may now return any value.
 func TestResponseBodyTypeRemovedStillBreaking(t *testing.T) {
 	s1, err := open("../data/type-change/simple-response.yaml")
@@ -249,7 +249,7 @@ func TestResponseBodyTypeRemovedStillBreaking(t *testing.T) {
 		"removing the type from a response is breaking")
 }
 
-// BC: a response type narrowing that co-occurs with a breaking format change is
+// a response type narrowing that co-occurs with a breaking format change is
 // breaking; the safe type axis must not mask the format axis. [string, integer]
 // -> [integer] narrows the type (not breaking on its own), but int32 -> int64
 // widens the format (the server may now return values outside the range a client

--- a/checker/check_response_property_unevaluated_updated_test.go
+++ b/checker/check_response_property_unevaluated_updated_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: removing unevaluated constraints from response body
+// removing unevaluated constraints from response body
 func TestResponseBodyUnevaluatedRemoved(t *testing.T) {
 	s1, err := open("../data/checker/unevaluated_revision.yaml")
 	require.NoError(t, err)
@@ -22,7 +22,7 @@ func TestResponseBodyUnevaluatedRemoved(t *testing.T) {
 	requireChange(t, errs, checker.ResponseBodyUnevaluatedPropertiesRemovedId)
 }
 
-// CL: adding unevaluated constraints to response property
+// adding unevaluated constraints to response property
 func TestResponsePropertyUnevaluatedAdded(t *testing.T) {
 	s1, err := open("../data/checker/unevaluated_property_base.yaml")
 	require.NoError(t, err)
@@ -36,7 +36,7 @@ func TestResponsePropertyUnevaluatedAdded(t *testing.T) {
 	requireChange(t, errs, checker.ResponsePropertyUnevaluatedPropertiesAddedId)
 }
 
-// CL: removing unevaluated constraints from response property
+// removing unevaluated constraints from response property
 func TestResponsePropertyUnevaluatedRemoved(t *testing.T) {
 	s1, err := open("../data/checker/unevaluated_property_revision.yaml")
 	require.NoError(t, err)
@@ -50,7 +50,7 @@ func TestResponsePropertyUnevaluatedRemoved(t *testing.T) {
 	requireChange(t, errs, checker.ResponsePropertyUnevaluatedPropertiesRemovedId)
 }
 
-// CL: adding unevaluated constraints to response body
+// adding unevaluated constraints to response body
 func TestResponseBodyUnevaluatedAdded(t *testing.T) {
 	s1, err := open("../data/checker/unevaluated_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_response_required_property_updated_test.go
+++ b/checker/check_response_required_property_updated_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding a required property to response body is detected
+// adding a required property to response body is detected
 func TestResponseRequiredPropertyAdded(t *testing.T) {
 	s1, err := open("../data/checker/response_required_property_added_base.yaml")
 	require.NoError(t, err)
@@ -30,7 +30,7 @@ func TestResponseRequiredPropertyAdded(t *testing.T) {
 	}, errs)
 }
 
-// CL: removing an existent property that was required in response body is detected
+// removing an existent property that was required in response body is detected
 func TestResponseRequiredPropertyRemoved(t *testing.T) {
 	s1, err := open("../data/checker/response_required_property_added_revision.yaml")
 	require.NoError(t, err)
@@ -51,7 +51,7 @@ func TestResponseRequiredPropertyRemoved(t *testing.T) {
 	}, errs)
 }
 
-// CL: adding a required write-only property to response body is detected
+// adding a required write-only property to response body is detected
 func TestResponseRequiredWriteOnlyPropertyAdded(t *testing.T) {
 	s1, err := open("../data/checker/response_required_property_added_base.yaml")
 	require.NoError(t, err)
@@ -74,7 +74,7 @@ func TestResponseRequiredWriteOnlyPropertyAdded(t *testing.T) {
 	}, errs)
 }
 
-// CL: removing a required write-only property that was required in response body is detected
+// removing a required write-only property that was required in response body is detected
 func TestResponseRequiredWriteOnlyPropertyRemoved(t *testing.T) {
 	s1, err := open("../data/checker/response_required_property_added_revision.yaml")
 	require.NoError(t, err)
@@ -96,7 +96,7 @@ func TestResponseRequiredWriteOnlyPropertyRemoved(t *testing.T) {
 	}, errs)
 }
 
-// CL: wrapping a concrete object response body into a oneOf (#702) is a
+// wrapping a concrete object response body into a oneOf (#702) is a
 // breaking restructuring: a field that was previously guaranteed in the
 // response may now be absent depending on which alternative matches. The moved
 // properties must not be reported as removed, and the wrapping must be reported

--- a/checker/check_response_required_property_write_only_read_only_test.go
+++ b/checker/check_response_required_property_write_only_read_only_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: changing required response property to write-only
+// changing required response property to write-only
 func TestResponseRequiredPropertyBecameWriteOnly(t *testing.T) {
 	s1, err := open("../data/checker/response_required_property_write_only_read_only_base.yaml")
 	require.NoError(t, err)
@@ -32,7 +32,7 @@ func TestResponseRequiredPropertyBecameWriteOnly(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing required response property to not write-only
+// changing required response property to not write-only
 func TestResponseRequiredPropertyBecameNotWriteOnly(t *testing.T) {
 	s1, err := open("../data/checker/response_required_property_write_only_read_only_base.yaml")
 	require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestResponseRequiredPropertyBecameNotWriteOnly(t *testing.T) {
 	require.Equal(t, "the response required property `data/writeOnlyName` became not write-only for the status `200`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// CL: changing required response property to read-only
+// changing required response property to read-only
 func TestResponseRequiredPropertyBecameReadOnly(t *testing.T) {
 	s1, err := open("../data/checker/response_required_property_write_only_read_only_base.yaml")
 	require.NoError(t, err)
@@ -81,7 +81,7 @@ func TestResponseRequiredPropertyBecameReadOnly(t *testing.T) {
 	}, errs)
 }
 
-// CL: changing required response property to not read-only
+// changing required response property to not read-only
 func TestResponseRequiredPropertyBecameNonReadOnly(t *testing.T) {
 	s1, err := open("../data/checker/response_required_property_write_only_read_only_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_response_status_updated_test.go
+++ b/checker/check_response_status_updated_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding a success response status
+// adding a success response status
 func TestResponseSuccessStatusAdded(t *testing.T) {
 	s1, err := open("../data/checker/response_status_base.yaml")
 	require.NoError(t, err)
@@ -32,7 +32,7 @@ func TestResponseSuccessStatusAdded(t *testing.T) {
 	}, errs)
 }
 
-// CL: adding a non-success response status
+// adding a non-success response status
 func TestResponseNonSuccessStatusAdded(t *testing.T) {
 	s1, err := open("../data/checker/response_status_base.yaml")
 	require.NoError(t, err)
@@ -55,7 +55,7 @@ func TestResponseNonSuccessStatusAdded(t *testing.T) {
 	}, errs)
 }
 
-// CL: removing a non-success response status
+// removing a non-success response status
 func TestResponseNonSuccessStatusRemoved(t *testing.T) {
 	s1, err := open("../data/checker/response_status_base.yaml")
 	require.NoError(t, err)
@@ -78,7 +78,7 @@ func TestResponseNonSuccessStatusRemoved(t *testing.T) {
 	}, errs)
 }
 
-// BC: removing a success status is breaking
+// removing a success status is breaking
 func TestResponseSuccessStatusRemoved(t *testing.T) {
 	s1, err := open("../data/checker/response_status_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_sub_schema_traversal_test.go
+++ b/checker/check_sub_schema_traversal_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: exercise processModifiedPropertiesDiff traversal through 3.1 sub-schema paths
+// exercise processModifiedPropertiesDiff traversal through 3.1 sub-schema paths
 // (if, then, else, contains, prefixItems, propertyNames, unevaluatedItems, unevaluatedProperties, contentSchema)
 func TestSubSchemaTraversalMinLengthChanged(t *testing.T) {
 	s1, err := open("../data/checker/sub_schema_traversal_base.yaml")
@@ -25,7 +25,7 @@ func TestSubSchemaTraversalMinLengthChanged(t *testing.T) {
 	require.True(t, containsId(errs, checker.RequestPropertyMinLengthIncreasedId), "expected minLength increased via sub-schema traversal")
 }
 
-// CL: exercise processAddedPropertiesDiff through 3.1 sub-schema paths
+// exercise processAddedPropertiesDiff through 3.1 sub-schema paths
 func TestSubSchemaTraversalAddedProperty(t *testing.T) {
 	s1, err := open("../data/checker/sub_schema_added_property_base.yaml")
 	require.NoError(t, err)
@@ -40,7 +40,7 @@ func TestSubSchemaTraversalAddedProperty(t *testing.T) {
 	require.True(t, containsId(errs, checker.NewRequiredRequestPropertyId), "expected new-required-request-property via sub-schema traversal")
 }
 
-// CL: exercise processDeletedPropertiesDiff through 3.1 sub-schema paths
+// exercise processDeletedPropertiesDiff through 3.1 sub-schema paths
 func TestSubSchemaTraversalDeletedProperty(t *testing.T) {
 	// Swapped base/revision: the "newField" properties are being removed
 	s1, err := open("../data/checker/sub_schema_added_property_revision.yaml")
@@ -56,7 +56,7 @@ func TestSubSchemaTraversalDeletedProperty(t *testing.T) {
 	require.True(t, containsId(errs, checker.RequestPropertyRemovedId), "expected request-property-removed via sub-schema traversal")
 }
 
-// CL: exercise processDeletedPropertiesDiff traversal through additionalProperties.
+// exercise processDeletedPropertiesDiff traversal through additionalProperties.
 // Regression: prior to the fix, processDeletedPropertiesDiff and
 // processAddedPropertiesDiff did not recurse through AdditionalPropertiesDiff
 // (only processModifiedPropertiesDiff did), so removing a required property from
@@ -74,7 +74,7 @@ func TestAdditionalPropertiesTraversalDeletedRequiredProperty(t *testing.T) {
 	require.True(t, containsId(errs, checker.ResponseRequiredPropertyRemovedId), "expected response-required-property-removed via additionalProperties traversal")
 }
 
-// CL: exercise processAddedPropertiesDiff traversal through additionalProperties.
+// exercise processAddedPropertiesDiff traversal through additionalProperties.
 // Symmetric to the deletion test above — swapping base/revision exercises the
 // added-required-property path through AdditionalPropertiesDiff.
 func TestAdditionalPropertiesTraversalAddedRequiredProperty(t *testing.T) {
@@ -90,7 +90,7 @@ func TestAdditionalPropertiesTraversalAddedRequiredProperty(t *testing.T) {
 	require.True(t, containsId(errs, checker.ResponseRequiredPropertyAddedId), "expected response-required-property-added via additionalProperties traversal")
 }
 
-// CL: exercise processModifiedPropertiesDiff traversal for minimum changes through if/then sub-schemas
+// exercise processModifiedPropertiesDiff traversal for minimum changes through if/then sub-schemas
 func TestSubSchemaTraversalMinChanged(t *testing.T) {
 	s1, err := open("../data/checker/sub_schema_traversal_base.yaml")
 	require.NoError(t, err)
@@ -106,7 +106,7 @@ func TestSubSchemaTraversalMinChanged(t *testing.T) {
 	require.True(t, containsId(errs, checker.RequestPropertyMinIncreasedId), "expected min increased in then sub-schema")
 }
 
-// CL: exercise processModifiedPropertiesDiff traversal through the `not` sub-schema
+// exercise processModifiedPropertiesDiff traversal through the `not` sub-schema
 func TestNotSubSchemaTraversalModifiedProperty(t *testing.T) {
 	s1, err := open("../data/checker/not_base.yaml")
 	require.NoError(t, err)
@@ -122,7 +122,7 @@ func TestNotSubSchemaTraversalModifiedProperty(t *testing.T) {
 	require.True(t, containsId(errs, checker.RequestPropertyMaxLengthDecreasedId), "expected maxLength decreased via not sub-schema traversal")
 }
 
-// CL: exercise processAddedPropertiesDiff traversal through the `not` sub-schema
+// exercise processAddedPropertiesDiff traversal through the `not` sub-schema
 func TestNotSubSchemaTraversalAddedProperty(t *testing.T) {
 	s1, err := open("../data/checker/not_base.yaml")
 	require.NoError(t, err)
@@ -138,7 +138,7 @@ func TestNotSubSchemaTraversalAddedProperty(t *testing.T) {
 	require.True(t, containsId(errs, checker.NewRequiredRequestPropertyId), "expected new-required-request-property via not sub-schema traversal")
 }
 
-// CL: exercise processDeletedPropertiesDiff traversal through the `not` sub-schema
+// exercise processDeletedPropertiesDiff traversal through the `not` sub-schema
 func TestNotSubSchemaTraversalDeletedProperty(t *testing.T) {
 	s1, err := open("../data/checker/not_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_webhook_operation_test.go
+++ b/checker/check_webhook_operation_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: modified webhook operations are covered by existing operation-level checkers
+// modified webhook operations are covered by existing operation-level checkers
 func TestWebhookOperationChangesDetected(t *testing.T) {
 	s1, err := open("../data/checker/webhook_operation_base.yaml")
 	require.NoError(t, err)
@@ -41,7 +41,7 @@ func TestWebhookOperationChangesDetected(t *testing.T) {
 		"expected at least one of: request-body-became-required or new-optional-request-property")
 }
 
-// CL: no changes in webhooks should produce no webhook-related changes
+// no changes in webhooks should produce no webhook-related changes
 func TestWebhookOperationNoChanges(t *testing.T) {
 	s1, err := open("../data/checker/webhook_operation_base.yaml")
 	require.NoError(t, err)

--- a/checker/check_webhook_updated_test.go
+++ b/checker/check_webhook_updated_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// CL: adding and removing webhooks
+// adding and removing webhooks
 func TestWebhookAddedAndRemoved(t *testing.T) {
 	s1, err := open("../data/checker/webhook_base.yaml")
 	require.NoError(t, err)
@@ -32,7 +32,7 @@ func TestWebhookAddedAndRemoved(t *testing.T) {
 	}}, errs)
 }
 
-// CL: no webhook changes
+// no webhook changes
 func TestWebhookNoChanges(t *testing.T) {
 	s1, err := open("../data/checker/webhook_base.yaml")
 	require.NoError(t, err)


### PR DESCRIPTION
Checker test comments historically carried a `// BC:` (breaking change) or `// CL:` (changelog) prefix. They are pure clutter today:

- **Nothing parses them** (no tooling, filter, or codegen reads `BC`/`CL`).
- **The distinction no longer carries information** - changelog is a superset of breaking, both kinds of test just run the checker, and the prefix maps to no real difference in test structure or assertions. It is an artifact of when `breaking` and `changelog` were separate.
- **The sentence already says it** - 184 of the 224 `BC:` comments literally end in `is breaking` / `is not breaking`.
- **Inconsistently applied** (224 `BC:` vs ~397 `CL:`, including three `CL (guard|soundness):` variants).

This strips the prefix across `checker/*_test.go`, keeping each description verbatim. The three `// CL (guard|soundness):` forms keep their meaningful qualifier and lose only the `CL`.

Comment-only, 621 sites across 104 files, no behavior change, whole suite green.