### PR TITLE
feat(checker): report source location for security changes

### DIFF
--- a/checker/check_api_security_updated.go
+++ b/checker/check_api_security_updated.go
@@ -21,12 +21,18 @@ func checkGlobalSecurity(diffReport *diff.Diff) Changes {
 		return result
 	}
 
+	// The document-root "security" field location in each spec; nil when origin
+	// tracking is off. Added/scope-added are reported against the revision, the
+	// rest against the base, matching the add/remove source convention.
+	baseSource := sourceFromField(diffReport.SecurityDiff.BaseOrigin, "security")
+	revisionSource := sourceFromField(diffReport.SecurityDiff.RevisionOrigin, "security")
+
 	for _, addedSecurity := range diffReport.SecurityDiff.Added {
 		result = append(result, SecurityChange{
 			Id:    APIGlobalSecurityAddedCheckId,
 			Level: INFO,
 			Args:  []any{addedSecurity.String()},
-		})
+		}.WithSources(nil, revisionSource))
 	}
 
 	for _, removedSecurity := range diffReport.SecurityDiff.Deleted {
@@ -34,7 +40,7 @@ func checkGlobalSecurity(diffReport *diff.Diff) Changes {
 			Id:    APIGlobalSecurityRemovedCheckId,
 			Level: INFO,
 			Args:  []any{removedSecurity.String()},
-		})
+		}.WithSources(baseSource, nil))
 	}
 
 	for _, updatedSecurity := range diffReport.SecurityDiff.Modified {
@@ -44,14 +50,14 @@ func checkGlobalSecurity(diffReport *diff.Diff) Changes {
 					Id:    APIGlobalSecurityScopeAddedId,
 					Level: INFO,
 					Args:  []any{addedScope, securitySchemeName},
-				})
+				}.WithSources(nil, revisionSource))
 			}
 			for _, deletedScope := range updatedSecuritySchemeScopes.Deleted {
 				result = append(result, SecurityChange{
 					Id:    APIGlobalSecurityScopeRemovedId,
 					Level: INFO,
 					Args:  []any{deletedScope, securitySchemeName},
-				})
+				}.WithSources(baseSource, nil))
 			}
 		}
 	}
@@ -78,6 +84,9 @@ func APISecurityUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.Oper
 				continue
 			}
 
+			baseSource := securitySource(operationsSources, operationItem.Base)
+			revisionSource := securitySource(operationsSources, operationItem.Revision)
+
 			for _, addedSecurity := range operationItem.SecurityDiff.Added {
 				if len(addedSecurity.Schemes) == 0 {
 					continue
@@ -92,7 +101,7 @@ func APISecurityUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.Oper
 					operationItem.Revision,
 					operation,
 					path,
-				))
+				).WithSources(nil, revisionSource))
 			}
 
 			for _, deletedSecurity := range operationItem.SecurityDiff.Deleted {
@@ -109,7 +118,7 @@ func APISecurityUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.Oper
 					operationItem.Revision,
 					operation,
 					path,
-				))
+				).WithSources(baseSource, nil))
 			}
 
 			for _, updatedSecurity := range operationItem.SecurityDiff.Modified {
@@ -127,7 +136,7 @@ func APISecurityUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.Oper
 							operationItem.Revision,
 							operation,
 							path,
-						))
+						).WithSources(nil, revisionSource))
 					}
 					for _, deletedScope := range updatedSecuritySchemeScopes.Deleted {
 						result = append(result, NewApiChange(
@@ -139,7 +148,7 @@ func APISecurityUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.Oper
 							operationItem.Revision,
 							operation,
 							path,
-						))
+						).WithSources(baseSource, nil))
 					}
 				}
 			}

--- a/checker/check_api_security_updated_test.go
+++ b/checker/check_api_security_updated_test.go
@@ -166,3 +166,41 @@ func TestAPISecurityScopeAdded(t *testing.T) {
 	}, errs)
 	require.Equal(t, "the security scope `read:pets` was added to the endpoint's security scheme `petstore_auth`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
+
+// removing a global security, with source tracking: the change points at the
+// document-root "security" field of the base spec.
+func TestAPIGlobalSecurityDeleted_WithSources(t *testing.T) {
+	s1, err := open("../data/checker/api_security_global_added_revision.yaml", newLoaderWithOriginTracking())
+	require.NoError(t, err)
+	s2, err := open("../data/checker/api_security_global_added_base.yaml", newLoaderWithOriginTracking())
+	require.NoError(t, err)
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.APISecurityUpdatedCheck), d, osm, checker.INFO)
+	requireSingleChange(t, errs, checker.APIGlobalSecurityRemovedCheckId)
+
+	require.NotEmpty(t, errs[0].GetBaseSource())
+	require.Equal(t, "../data/checker/api_security_global_added_revision.yaml", errs[0].GetBaseSource().File)
+	require.Equal(t, 5, errs[0].GetBaseSource().Line)
+	require.Empty(t, errs[0].GetRevisionSource())
+}
+
+// removing an endpoint security, with source tracking: the change points at the
+// operation's "security" field of the base spec.
+func TestAPISecurityDeleted_WithSources(t *testing.T) {
+	s1, err := open("../data/checker/api_security_added_revision.yaml", newLoaderWithOriginTracking())
+	require.NoError(t, err)
+	s2, err := open("../data/checker/api_security_added_base.yaml", newLoaderWithOriginTracking())
+	require.NoError(t, err)
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.APISecurityUpdatedCheck), d, osm, checker.INFO)
+	requireSingleChange(t, errs, checker.APISecurityRemovedCheckId)
+
+	require.NotEmpty(t, errs[0].GetBaseSource())
+	require.Equal(t, "../data/checker/api_security_added_revision.yaml", errs[0].GetBaseSource().File)
+	require.Equal(t, 23, errs[0].GetBaseSource().Line)
+	require.Empty(t, errs[0].GetRevisionSource())
+}

--- a/checker/check_components_security_updated.go
+++ b/checker/check_components_security_updated.go
@@ -17,7 +17,12 @@ const (
 
 const ComponentSecuritySchemes = "securitySchemes"
 
-func checkOAuthUpdates(updatedSecurity *diff.SecuritySchemeDiff, updatedSecurityName string) Changes {
+// checkOAuthUpdates reports oauth flow changes for a modified security scheme.
+// baseSource/revisionSource locate the scheme in each spec: added scopes are
+// reported against the revision, removed scopes against the base, and in-place
+// changes (urls, scope value) against both, matching the source convention used
+// elsewhere.
+func checkOAuthUpdates(updatedSecurity *diff.SecuritySchemeDiff, updatedSecurityName string, baseSource, revisionSource *Source) Changes {
 	result := make(Changes, 0)
 
 	if updatedSecurity.OAuthFlowsDiff == nil {
@@ -34,7 +39,7 @@ func checkOAuthUpdates(updatedSecurity *diff.SecuritySchemeDiff, updatedSecurity
 			Level:     INFO,
 			Args:      []any{updatedSecurityName, urlDiff.From, urlDiff.To},
 			Component: ComponentSecuritySchemes,
-		})
+		}.WithSources(baseSource, revisionSource))
 	}
 
 	if tokenDiff := updatedSecurity.OAuthFlowsDiff.ImplicitDiff.TokenURLDiff; tokenDiff != nil {
@@ -43,7 +48,7 @@ func checkOAuthUpdates(updatedSecurity *diff.SecuritySchemeDiff, updatedSecurity
 			Level:     INFO,
 			Args:      []any{updatedSecurityName, tokenDiff.From, tokenDiff.To},
 			Component: ComponentSecuritySchemes,
-		})
+		}.WithSources(baseSource, revisionSource))
 	}
 
 	if scopesDiff := updatedSecurity.OAuthFlowsDiff.ImplicitDiff.ScopesDiff; scopesDiff != nil {
@@ -53,7 +58,7 @@ func checkOAuthUpdates(updatedSecurity *diff.SecuritySchemeDiff, updatedSecurity
 				Level:     INFO,
 				Args:      []any{updatedSecurityName, addedScope},
 				Component: ComponentSecuritySchemes,
-			})
+			}.WithSources(nil, revisionSource))
 		}
 
 		for _, removedScope := range scopesDiff.Deleted {
@@ -62,7 +67,7 @@ func checkOAuthUpdates(updatedSecurity *diff.SecuritySchemeDiff, updatedSecurity
 				Level:     INFO,
 				Args:      []any{updatedSecurityName, removedScope},
 				Component: ComponentSecuritySchemes,
-			})
+			}.WithSources(baseSource, nil))
 		}
 
 		for name, modifiedScope := range scopesDiff.Modified {
@@ -71,7 +76,7 @@ func checkOAuthUpdates(updatedSecurity *diff.SecuritySchemeDiff, updatedSecurity
 				Level:     INFO,
 				Args:      []any{updatedSecurityName, name, modifiedScope.From, modifiedScope.To},
 				Component: ComponentSecuritySchemes,
-			})
+			}.WithSources(baseSource, revisionSource))
 		}
 
 	}
@@ -117,7 +122,15 @@ func APIComponentsSecurityUpdatedCheck(diffReport *diff.Diff, operationsSources 
 	}
 
 	for updatedSecurityName, updatedSecurity := range diffReport.ComponentsDiff.SecuritySchemesDiff.Modified {
-		result = append(result, checkOAuthUpdates(updatedSecurity, updatedSecurityName)...)
+		var baseSource, revisionSource *Source
+		if ref := diffReport.ComponentsDiff.SecuritySchemesDiff.Base[updatedSecurityName]; ref != nil && ref.Value != nil {
+			baseSource = sourceFromOrigin(ref.Value.Origin)
+		}
+		if ref := diffReport.ComponentsDiff.SecuritySchemesDiff.Revision[updatedSecurityName]; ref != nil && ref.Value != nil {
+			revisionSource = sourceFromOrigin(ref.Value.Origin)
+		}
+
+		result = append(result, checkOAuthUpdates(updatedSecurity, updatedSecurityName, baseSource, revisionSource)...)
 
 		if updatedSecurity.TypeDiff != nil {
 			result = append(result, ComponentChange{
@@ -125,7 +138,7 @@ func APIComponentsSecurityUpdatedCheck(diffReport *diff.Diff, operationsSources 
 				Level:     INFO,
 				Args:      []any{updatedSecurityName, updatedSecurity.TypeDiff.From, updatedSecurity.TypeDiff.To},
 				Component: ComponentSecuritySchemes,
-			})
+			}.WithSources(baseSource, revisionSource))
 		}
 	}
 

--- a/checker/check_components_security_updated_test.go
+++ b/checker/check_components_security_updated_test.go
@@ -136,6 +136,27 @@ func TestComponentSecurityOauthScopeAdded(t *testing.T) {
 	require.Equal(t, "the component security scheme `petstore_auth` oauth scope `admin:pets` was added", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
+// adding an oauth scope, with source tracking: the change points at the
+// revision scheme's location.
+func TestComponentSecurityOauthScopeAdded_WithSources(t *testing.T) {
+	s1, err := open("../data/checker/component_security_updated_base.yaml", newLoaderWithOriginTracking())
+	require.NoError(t, err)
+	s2, err := open("../data/checker/component_security_updated_base.yaml", newLoaderWithOriginTracking())
+	require.NoError(t, err)
+
+	s2.Spec.Components.SecuritySchemes["petstore_auth"].Value.Flows.Implicit.Scopes["admin:pets"] = "grants access to admin operations"
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(singleCheckConfig(checker.APIComponentsSecurityUpdatedCheck), d, osm, checker.INFO)
+	requireSingleChange(t, errs, checker.APIComponentSecurityOauthScopeAddedId)
+
+	require.NotEmpty(t, errs[0].GetRevisionSource())
+	require.Equal(t, "../data/checker/component_security_updated_base.yaml", errs[0].GetRevisionSource().File)
+	require.Equal(t, 29, errs[0].GetRevisionSource().Line)
+	require.Empty(t, errs[0].GetBaseSource())
+}
+
 // removing a new oauth security scope
 func TestComponentSecurityOauthScopeRemoved(t *testing.T) {
 	s1, err := open("../data/checker/component_security_updated_base.yaml")

--- a/checker/source.go
+++ b/checker/source.go
@@ -478,6 +478,36 @@ func sourceFromOrigin(origin *openapi3.Origin) *Source {
 	}
 }
 
+// securitySource returns the location of an operation's "security" field,
+// falling back to the operation's own location. Returns nil when the operation
+// has no origin data.
+func securitySource(operationsSources *diff.OperationsSourcesMap, op *openapi3.Operation) *Source {
+	if op == nil || op.Origin == nil {
+		return nil
+	}
+	if s := NewSourceFromField(operationsSources, op, op.Origin, "security"); s != nil {
+		return s
+	}
+	return NewSourceFromOrigin(operationsSources, op, op.Origin)
+}
+
+// sourceFromField creates a Source from a named field of an origin (e.g. the
+// document-root "security" field). Used for top-level changes where no
+// operation context is available. Returns nil when the field has no origin data.
+func sourceFromField(origin *openapi3.Origin, field string) *Source {
+	if origin == nil {
+		return nil
+	}
+	if location, ok := origin.Fields[field]; ok {
+		return &Source{
+			File:   displayFilePath(location.File),
+			Line:   location.Line,
+			Column: location.Column,
+		}
+	}
+	return nil
+}
+
 func NewEmptySource() *Source {
 	return nil
 }

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -290,6 +290,13 @@ func getDiffInternal(config *Config, state *state, s1, s2 *openapi3.T) (*Diff, e
 	}
 
 	result.SecurityDiff = getSecurityRequirementsDiff(&s1.Security, &s2.Security)
+	if result.SecurityDiff != nil {
+		// Carry the document-root origins so the checker can report the source
+		// location of global security changes (the per-operation security diff in
+		// method_diff.go leaves these nil and is sourced from its operation).
+		result.SecurityDiff.BaseOrigin = s1.Origin
+		result.SecurityDiff.RevisionOrigin = s2.Origin
+	}
 	result.ServersDiff = getServersDiff(config, &s1.Servers, &s2.Servers)
 	result.TagsDiff = getTagsDiff(config, s1.Tags, s2.Tags)
 	result.ExternalDocsDiff, err = getExternalDocsDiff(config, s1.ExternalDocs, s2.ExternalDocs)

--- a/diff/security_requirements_diff.go
+++ b/diff/security_requirements_diff.go
@@ -33,6 +33,13 @@ type SecurityRequirementsDiff struct {
 	Added    SecurityAlternatives         `json:"added,omitempty" yaml:"added,omitempty"`
 	Deleted  SecurityAlternatives         `json:"deleted,omitempty" yaml:"deleted,omitempty"`
 	Modified ModifiedSecurityRequirements `json:"modified,omitempty" yaml:"modified,omitempty"`
+
+	// Origins of the documents whose root "security" field changed, used to
+	// report the source location of global security changes. Set only on the
+	// root-level diff (see diff.go), not the per-operation one, and kept out of
+	// the diff output.
+	BaseOrigin     *openapi3.Origin `json:"-" yaml:"-"`
+	RevisionOrigin *openapi3.Origin `json:"-" yaml:"-"`
 }
 
 // SecurityAlternative is one alternative (one security requirement object) in a


### PR DESCRIPTION
## Problem

Security changes had no source location in `changelog`/`breaking` output. Running

```
oasdiff changelog data/openapi-test1.yaml data/openapi-test3.yaml -f yaml
```

showed no `baseSource`/`revisionSource` for `api-global-security-removed`, `api-security-removed`, and `api-security-scope-added`. Three causes:

- **Global security** (`api-global-security-*`) emits a `SecurityChange` with no source at all.
- **Operation-level security** (`api-security-*`) and **component oauth** (`api-security-component-oauth-*`) built their change without calling `WithSources`.

## Fix

Populate the location, following the existing convention (removed -> base, added -> revision, in-place change -> both):

- **Operation-level security** (added/removed, scope added/removed): anchor to the operation's `security` field via a new `securitySource` helper.
- **Global security** (added/removed, scope added/removed): carry the document-root origins on `SecurityRequirementsDiff` (`json:"-"`, set only for the root diff, not the per-operation one) and resolve the root `security` field via a new `sourceFromField` helper.
- **Component oauth** (url / token-url / type / scope changes): anchor to the scheme's location, already on the diff's base/revision scheme refs.

After the fix, both repros (`openapi-test1/3` and `security-requirements/or_alternatives*`) emit a location for every security change.

## Known limitation (follow-up)

The two scope-addition cases point at their container, not the exact scope line:
- `api-security-scope-added` -> the operation's `security` field, not the `- list:pets` line.
- `api-security-component-oauth-scope-added` -> the scheme, not the `list:pets:` line.

Scope entries are plain strings inside a `map[string]string` (oauth `Scopes`) or a `map[string][]string` (`SecurityRequirement`, which has no `Origin` field), so kin-openapi discards their per-entry locations. Pointing at the exact scope line needs a kin-openapi origin enhancement, tracked separately.

## Tests

- `TestAPIGlobalSecurityDeleted_WithSources`, `TestAPISecurityDeleted_WithSources`, `TestComponentSecurityOauthScopeAdded_WithSources` assert the resolved file/line under origin tracking.
- Existing security tests run without origin tracking (sources stay nil), so they pass unchanged.
- `go build`, `go vet ./...`, `go test ./...` all pass.
