### PR TITLE
feat(checker): report source location for stability and sunset-parse changes

### DIFF
--- a/checker/check_api_stability_level.go
+++ b/checker/check_api_stability_level.go
@@ -41,16 +41,19 @@ func checkInvalidStabilityLevels(config *Config, diffReport *diff.Diff, operatio
 		}
 		for operation, operationItem := range pathDiff.OperationsDiff.Modified {
 			if _, err := getStabilityLevel(pathDiff.Base.GetOperation(operation).Extensions); err != nil {
-				result = append(result, getAPIInvalidStabilityLevel(config, operationItem.Base, operationsSources, operation, path, err))
+				baseSource := stabilityFieldSource(operationsSources, operationItem.Base, operationItem.Base.Origin)
+				result = append(result, getAPIInvalidStabilityLevel(config, operationItem.Base, operationsSources, operation, path, err).WithSources(baseSource, nil))
 			}
 			if _, err := getStabilityLevel(pathDiff.Revision.GetOperation(operation).Extensions); err != nil {
-				result = append(result, getAPIInvalidStabilityLevel(config, operationItem.Revision, operationsSources, operation, path, err))
+				revisionSource := stabilityFieldSource(operationsSources, operationItem.Revision, operationItem.Revision.Origin)
+				result = append(result, getAPIInvalidStabilityLevel(config, operationItem.Revision, operationsSources, operation, path, err).WithSources(nil, revisionSource))
 			}
 		}
 		for _, operation := range pathDiff.OperationsDiff.Deleted {
 			operationItem := pathDiff.Base.GetOperation(operation)
 			if _, err := getStabilityLevel(operationItem.Extensions); err != nil {
-				result = append(result, getAPIInvalidStabilityLevel(config, operationItem, operationsSources, operation, path, err))
+				baseSource := stabilityFieldSource(operationsSources, operationItem, operationItem.Origin)
+				result = append(result, getAPIInvalidStabilityLevel(config, operationItem, operationsSources, operation, path, err).WithSources(baseSource, nil))
 			}
 		}
 	}
@@ -60,7 +63,8 @@ func checkInvalidStabilityLevels(config *Config, diffReport *diff.Diff, operatio
 		pathVal := diffReport.PathsDiff.Base.Value(path)
 		for operation, operationItem := range pathVal.Operations() {
 			if _, err := getStabilityLevel(pathVal.GetOperation(operation).Extensions); err != nil {
-				result = append(result, getAPIInvalidStabilityLevel(config, operationItem, operationsSources, operation, path, err))
+				baseSource := stabilityFieldSource(operationsSources, operationItem, operationItem.Origin)
+				result = append(result, getAPIInvalidStabilityLevel(config, operationItem, operationsSources, operation, path, err).WithSources(baseSource, nil))
 			}
 		}
 	}
@@ -111,6 +115,9 @@ func checkStabilityLevelChanged(config *Config, diffReport *diff.Diff, operation
 				changeId = APIStabilityDecreasedId
 			}
 
+			baseSource := stabilityFieldSource(operationsSources, pathDiff.Base.GetOperation(operation), pathDiff.Base.GetOperation(operation).Origin)
+			revisionSource := stabilityFieldSource(operationsSources, operationItem.Revision, operationItem.Revision.Origin)
+
 			result = append(result, NewApiChange(
 				changeId,
 				config,
@@ -120,7 +127,7 @@ func checkStabilityLevelChanged(config *Config, diffReport *diff.Diff, operation
 				operationItem.Revision,
 				operation,
 				path,
-			))
+			).WithSources(baseSource, revisionSource))
 		}
 	}
 
@@ -198,7 +205,7 @@ func normalizedStability(label string) string {
 	return label
 }
 
-func getAPIInvalidStabilityLevel(config *Config, operation *openapi3.Operation, operationsSources *diff.OperationsSourcesMap, method string, path string, err error) Change {
+func getAPIInvalidStabilityLevel(config *Config, operation *openapi3.Operation, operationsSources *diff.OperationsSourcesMap, method string, path string, err error) ApiChange {
 	return NewApiChange(
 		APIInvalidStabilityLevelId,
 		config,

--- a/checker/check_api_stability_level_test.go
+++ b/checker/check_api_stability_level_test.go
@@ -34,6 +34,32 @@ func TestBreaking_StabilityLevelDecreased(t *testing.T) {
 	require.Equal(t, "endpoint stability level decreased from `beta` to `alpha`", e0.GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
+// the stability change points at the x-stability-level field in each spec
+func TestBreaking_StabilityLevelDecreased_WithSources(t *testing.T) {
+
+	s1, err := open(deprecationFile("base-beta-stability.yaml"), newLoaderWithOriginTracking())
+	require.NoError(t, err)
+
+	s2, err := open(deprecationFile("base-alpha-stability.yaml"), newLoaderWithOriginTracking())
+	require.NoError(t, err)
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+
+	config := allChecksConfig()
+	config.StabilityLevel = checker.StabilityLevelAlpha
+	errs := checker.CheckBackwardCompatibility(config, d, osm)
+	require.Len(t, errs, 1)
+
+	require.Equal(t, checker.APIStabilityDecreasedId, errs[0].GetId())
+	require.NotEmpty(t, errs[0].GetBaseSource())
+	require.Equal(t, "../data/deprecation/base-beta-stability.yaml", errs[0].GetBaseSource().File)
+	require.Equal(t, 12, errs[0].GetBaseSource().Line)
+	require.NotEmpty(t, errs[0].GetRevisionSource())
+	require.Equal(t, "../data/deprecation/base-alpha-stability.yaml", errs[0].GetRevisionSource().File)
+	require.Equal(t, 12, errs[0].GetRevisionSource().Line)
+}
+
 // increasing stability level is not breaking
 func TestBreaking_StabilityLevelIncreased(t *testing.T) {
 

--- a/checker/check_property_stability_level.go
+++ b/checker/check_property_stability_level.go
@@ -102,14 +102,16 @@ func checkPropertyStabilityChange(
 	if propertyDiff.Base != nil {
 		baseStability, err = getStabilityLevel(propertyDiff.Base.Extensions)
 		if err != nil {
-			*result = append(*result, getAPIInvalidStabilityLevel(config, op, operationsSources, operation, path, err))
+			baseSource := stabilityFieldSource(operationsSources, op, propertyDiff.Base.Origin)
+			*result = append(*result, getAPIInvalidStabilityLevel(config, op, operationsSources, operation, path, err).WithSources(baseSource, nil))
 			return
 		}
 	}
 	if propertyDiff.Revision != nil {
 		revisionStability, err = getStabilityLevel(propertyDiff.Revision.Extensions)
 		if err != nil {
-			*result = append(*result, getAPIInvalidStabilityLevel(config, op, operationsSources, operation, path, err))
+			revisionSource := stabilityFieldSource(operationsSources, op, propertyDiff.Revision.Origin)
+			*result = append(*result, getAPIInvalidStabilityLevel(config, op, operationsSources, operation, path, err).WithSources(nil, revisionSource))
 			return
 		}
 	}
@@ -137,6 +139,18 @@ func checkPropertyStabilityChange(
 
 	propName := propertyFullName(propertyPath, propertyName)
 
+	// Base/Revision can be nil here (a sub-schema present on only one side);
+	// stabilityFieldSource tolerates a nil origin.
+	var baseOrigin, revisionOrigin *openapi3.Origin
+	if propertyDiff.Base != nil {
+		baseOrigin = propertyDiff.Base.Origin
+	}
+	if propertyDiff.Revision != nil {
+		revisionOrigin = propertyDiff.Revision.Origin
+	}
+	baseSource := stabilityFieldSource(operationsSources, op, baseOrigin)
+	revisionSource := stabilityFieldSource(operationsSources, op, revisionOrigin)
+
 	*result = append(*result, NewApiChange(
 		changeId,
 		config,
@@ -146,5 +160,5 @@ func checkPropertyStabilityChange(
 		op,
 		operation,
 		path,
-	))
+	).WithSources(baseSource, revisionSource))
 }

--- a/checker/check_request_parameter_sunset_changed.go
+++ b/checker/check_request_parameter_sunset_changed.go
@@ -67,14 +67,14 @@ func RequestParameterSunsetChangedCheck(diffReport *diff.Diff, operationsSources
 					date, err := getSunsetDate(paramRevision.Extensions[diff.SunsetExtension])
 					if err != nil {
 						opInfo := newOpInfo(config, opRevision, operationsSources, operation, path)
-						result = append(result, getRequestParameterSunsetParse(opInfo, paramRevision, err))
+						result = append(result, getRequestParameterSunsetParse(opInfo, paramRevision, err).WithSources(nil, revisionSource))
 						continue
 					}
 
 					baseDate, err := getSunsetDate(paramBase.Extensions[diff.SunsetExtension])
 					if err != nil {
 						opInfo := newOpInfo(config, opBase, operationsSources, operation, path)
-						result = append(result, getRequestParameterSunsetParse(opInfo, paramBase, err))
+						result = append(result, getRequestParameterSunsetParse(opInfo, paramBase, err).WithSources(baseSource, nil))
 						continue
 					}
 

--- a/checker/source.go
+++ b/checker/source.go
@@ -508,6 +508,21 @@ func sourceFromField(origin *openapi3.Origin, field string) *Source {
 	return nil
 }
 
+// stabilityFieldSource returns the location of the x-stability-level field on
+// the element whose origin is given (an operation or a property schema),
+// falling back to the element's own location. op supplies the file for the
+// fallback when the field location carries none. Returns nil without origin
+// data.
+func stabilityFieldSource(operationsSources *diff.OperationsSourcesMap, op *openapi3.Operation, origin *openapi3.Origin) *Source {
+	if origin == nil {
+		return nil
+	}
+	if s := NewSourceFromField(operationsSources, op, origin, diff.XStabilityLevelExtension); s != nil {
+		return s
+	}
+	return NewSourceFromOrigin(operationsSources, op, origin)
+}
+
 func NewEmptySource() *Source {
 	return nil
 }


### PR DESCRIPTION
Follow-up to the security source-location work, closing the remaining checkers that emitted changes with no location.

## Problem

These checkers built their change without calling `WithSources`, so `changelog`/`breaking` output showed no `baseSource`/`revisionSource`:

- `api-stability-increased` / `api-stability-decreased`
- `api-invalid-stability-level` (operation and property variants, via `getAPIInvalidStabilityLevel`)
- `request-`/`response-property-stability-increased` / `-decreased`
- `request-parameter-sunset-parse` when emitted from the sunset-changed check (the same id from the parameter-removed check was already located, so this was also an inconsistency)

## Fix

All of them now anchor to the exact `x-stability-level` field (origin tracking records it as a field origin), falling back to the element's own location when absent, via a new `stabilityFieldSource` helper. Added/changed sides are attributed to base vs revision per the existing convention. `getAPIInvalidStabilityLevel` now returns `ApiChange` so each call site attaches the correct side. The sunset-parse fix reuses the parameter sources already computed in that loop.

## Tests

- `TestBreaking_StabilityLevelDecreased_WithSources` asserts both sides resolve to the `x-stability-level` line under origin tracking.
- Existing tests run without origin tracking (sources stay nil) and pass unchanged.
- `go build`, `go vet ./...`, `go test ./...` all pass.

With this, every checker emits a location. The only remaining imprecision is the security *scope* changes pointing at their container, which is gated on a kin-openapi origin enhancement (separate PR).
