### PR TITLE
refactor(checker): construct ApiChange via opInfo.NewApiChange

### DIFF
--- a/checker/check_added_required_request_body.go
+++ b/checker/check_added_required_request_body.go
@@ -22,6 +22,7 @@ func AddedRequestBodyCheck(diffReport *diff.Diff, operationsSources *diff.Operat
 			if operationItem.RequestBodyDiff == nil {
 				continue
 			}
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 			if operationItem.RequestBodyDiff.Added {
 				id := AddedOptionalRequestBodyId
 
@@ -30,15 +31,10 @@ func AddedRequestBodyCheck(diffReport *diff.Diff, operationsSources *diff.Operat
 				}
 
 				revisionSource := requestBodySource(operationsSources, operationItem.Revision)
-				result = append(result, NewApiChange(
+				result = append(result, opInfo.NewApiChange(
 					id,
-					config,
 					nil,
 					"",
-					operationsSources,
-					operationItem.Revision,
-					operation,
-					path,
 				).WithSources(nil, revisionSource))
 			}
 		}

--- a/checker/check_api_removed.go
+++ b/checker/check_api_removed.go
@@ -80,70 +80,45 @@ func checkAPIRemoval(opInfo opInfo, isPath bool) Change {
 	revisionSource := NewEmptySource()
 
 	if !opInfo.operation.Deprecated {
-		return NewApiChange(
+		return opInfo.NewApiChange(
 			getWithoutDeprecationId(isPath),
-			opInfo.config,
 			nil,
 			"",
-			opInfo.operationsSources,
-			opInfo.operation,
-			opInfo.method,
-			opInfo.path,
 		).WithSources(baseSource, revisionSource)
 	}
 	sunset, ok := getSunset(opInfo.operation.Extensions)
 	if !ok {
-		return NewApiChange(
+		return opInfo.NewApiChange(
 			getWithDeprecationId(isPath),
-			opInfo.config,
 			nil,
 			"",
-			opInfo.operationsSources,
-			opInfo.operation,
-			opInfo.method,
-			opInfo.path,
 		).WithSources(baseSource, revisionSource)
 	}
 
 	date, err := getSunsetDate(sunset)
 	if err != nil {
-		return NewApiChange(
+		return opInfo.NewApiChange(
 			APIPathSunsetParseId,
-			opInfo.config,
 			[]any{err},
 			"",
-			opInfo.operationsSources,
-			opInfo.operation,
-			opInfo.method,
-			opInfo.path,
 		).WithSources(baseSource, nil)
 	}
 
 	if civil.DateOf(time.Now()).Before(date) {
-		return NewApiChange(
+		return opInfo.NewApiChange(
 			getBeforeSunsetId(isPath),
-			opInfo.config,
 			[]any{date},
 			"",
-			opInfo.operationsSources,
-			opInfo.operation,
-			opInfo.method,
-			opInfo.path,
 		).WithSources(baseSource, revisionSource)
 	}
 	return nil
 }
 
 func getAPIPathSunsetParse(opInfo opInfo, err error) ApiChange {
-	return NewApiChange(
+	return opInfo.NewApiChange(
 		APIPathSunsetParseId,
-		opInfo.config,
 		[]any{err},
 		"",
-		opInfo.operationsSources,
-		opInfo.operation,
-		opInfo.method,
-		opInfo.path,
 	)
 }
 

--- a/checker/check_api_security_updated.go
+++ b/checker/check_api_security_updated.go
@@ -87,20 +87,17 @@ func APISecurityUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.Oper
 			baseSource := securitySource(operationsSources, operationItem.Base)
 			revisionSource := securitySource(operationsSources, operationItem.Revision)
 
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
+
 			for _, addedSecurity := range operationItem.SecurityDiff.Added {
 				if len(addedSecurity.Schemes) == 0 {
 					continue
 				}
 
-				result = append(result, NewApiChange(
+				result = append(result, opInfo.NewApiChange(
 					APISecurityAddedCheckId,
-					config,
 					[]any{addedSecurity.String()},
 					"",
-					operationsSources,
-					operationItem.Revision,
-					operation,
-					path,
 				).WithSources(nil, revisionSource))
 			}
 
@@ -109,15 +106,10 @@ func APISecurityUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.Oper
 					continue
 				}
 
-				result = append(result, NewApiChange(
+				result = append(result, opInfo.NewApiChange(
 					APISecurityRemovedCheckId,
-					config,
 					[]any{deletedSecurity.String()},
 					"",
-					operationsSources,
-					operationItem.Revision,
-					operation,
-					path,
 				).WithSources(baseSource, nil))
 			}
 
@@ -127,27 +119,17 @@ func APISecurityUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.Oper
 				}
 				for securitySchemeName, updatedSecuritySchemeScopes := range updatedSecurity.Scopes {
 					for _, addedScope := range updatedSecuritySchemeScopes.Added {
-						result = append(result, NewApiChange(
+						result = append(result, opInfo.NewApiChange(
 							APISecurityScopeAddedId,
-							config,
 							[]any{addedScope, securitySchemeName},
 							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
 						).WithSources(nil, revisionSource))
 					}
 					for _, deletedScope := range updatedSecuritySchemeScopes.Deleted {
-						result = append(result, NewApiChange(
+						result = append(result, opInfo.NewApiChange(
 							APISecurityScopeRemovedId,
-							config,
 							[]any{deletedScope, securitySchemeName},
 							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
 						).WithSources(baseSource, nil))
 					}
 				}

--- a/checker/check_api_stability_level.go
+++ b/checker/check_api_stability_level.go
@@ -118,15 +118,11 @@ func checkStabilityLevelChanged(config *Config, diffReport *diff.Diff, operation
 			baseSource := stabilityFieldSource(operationsSources, pathDiff.Base.GetOperation(operation), pathDiff.Base.GetOperation(operation).Origin)
 			revisionSource := stabilityFieldSource(operationsSources, operationItem.Revision, operationItem.Revision.Origin)
 
-			result = append(result, NewApiChange(
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
+			result = append(result, opInfo.NewApiChange(
 				changeId,
-				config,
 				[]any{baseLabel, revisionLabel},
 				"",
-				operationsSources,
-				operationItem.Revision,
-				operation,
-				path,
 			).WithSources(baseSource, revisionSource))
 		}
 	}

--- a/checker/check_api_sunset_changed.go
+++ b/checker/check_api_sunset_changed.go
@@ -130,14 +130,9 @@ func getDeprecationDays(config *Config, stability string) uint {
 }
 
 func getAPIDeprecatedSunsetMissing(opInfo opInfo) ApiChange {
-	return NewApiChange(
+	return opInfo.NewApiChange(
 		APIDeprecatedSunsetMissingId,
-		opInfo.config,
 		nil,
 		"",
-		opInfo.operationsSources,
-		opInfo.operation,
-		opInfo.method,
-		opInfo.path,
 	)
 }

--- a/checker/check_media_type_schema_existence.go
+++ b/checker/check_media_type_schema_existence.go
@@ -35,18 +35,18 @@ func MediaTypeSchemaExistenceCheck(diffReport *diff.Diff, operationsSources *dif
 		}
 		for operation, operationItem := range pathItem.OperationsDiff.Modified {
 
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
+
 			if operationItem.RequestBodyDiff != nil && operationItem.RequestBodyDiff.ContentDiff != nil {
 				for mediaType, mediaTypeDiff := range operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified {
 					added, removed := schemaSideAddedRemoved(mediaTypeDiff.SchemaDiff)
 					if added {
-						result = append(result, NewApiChange(
-							RequestBodyMediaTypeSchemaAddedId, config, []any{mediaType}, "",
-							operationsSources, operationItem.Revision, operation, path,
+						result = append(result, opInfo.NewApiChange(
+							RequestBodyMediaTypeSchemaAddedId, []any{mediaType}, "",
 						).WithSources(nil, requestBodyMediaTypeSource(operationsSources, operationItem.Revision, mediaType)))
 					} else if removed {
-						result = append(result, NewApiChange(
-							RequestBodyMediaTypeSchemaRemovedId, config, []any{mediaType}, "",
-							operationsSources, operationItem.Revision, operation, path,
+						result = append(result, opInfo.NewApiChange(
+							RequestBodyMediaTypeSchemaRemovedId, []any{mediaType}, "",
 						).WithSources(requestBodyMediaTypeSource(operationsSources, operationItem.Base, mediaType), nil))
 					}
 				}
@@ -62,14 +62,12 @@ func MediaTypeSchemaExistenceCheck(diffReport *diff.Diff, operationsSources *dif
 				for mediaType, mediaTypeDiff := range responseDiff.ContentDiff.MediaTypeModified {
 					added, removed := schemaSideAddedRemoved(mediaTypeDiff.SchemaDiff)
 					if added {
-						result = append(result, NewApiChange(
-							ResponseBodyMediaTypeSchemaAddedId, config, []any{mediaType, responseStatus}, "",
-							operationsSources, operationItem.Revision, operation, path,
+						result = append(result, opInfo.NewApiChange(
+							ResponseBodyMediaTypeSchemaAddedId, []any{mediaType, responseStatus}, "",
 						).WithSources(nil, mediaTypeSource(operationsSources, operationItem.Revision, responseDiff.Revision, mediaType)))
 					} else if removed {
-						result = append(result, NewApiChange(
-							ResponseBodyMediaTypeSchemaRemovedId, config, []any{mediaType, responseStatus}, "",
-							operationsSources, operationItem.Revision, operation, path,
+						result = append(result, opInfo.NewApiChange(
+							ResponseBodyMediaTypeSchemaRemovedId, []any{mediaType, responseStatus}, "",
 						).WithSources(mediaTypeSource(operationsSources, operationItem.Base, responseDiff.Base, mediaType), nil))
 					}
 				}

--- a/checker/check_new_request_non_path_parameter.go
+++ b/checker/check_new_request_non_path_parameter.go
@@ -22,6 +22,7 @@ func NewRequestNonPathParameterCheck(diffReport *diff.Diff, operationsSources *d
 			if operationItem.ParametersDiff == nil {
 				continue
 			}
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 			for paramLocation, paramItems := range operationItem.ParametersDiff.Added {
 				if paramLocation == "path" {
 					// it is processed in the separate check NewRequestPathParameterCheck
@@ -36,15 +37,10 @@ func NewRequestNonPathParameterCheck(diffReport *diff.Diff, operationsSources *d
 								id = NewOptionalRequestParameterId
 							}
 							revisionSource := parameterSource(operationsSources, operationItem.Revision, param.Value)
-							result = append(result, NewApiChange(
+							result = append(result, opInfo.NewApiChange(
 								id,
-								config,
 								[]any{paramLocation, paramName},
 								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
 							).WithSources(nil, revisionSource))
 							break
 						}

--- a/checker/check_new_requried_request_header_property.go
+++ b/checker/check_new_requried_request_header_property.go
@@ -25,6 +25,8 @@ func NewRequiredRequestHeaderPropertyCheck(diffReport *diff.Diff, operationsSour
 				continue
 			}
 
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
+
 			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
 
 				if paramLocation != "header" {
@@ -43,15 +45,10 @@ func NewRequiredRequestHeaderPropertyCheck(diffReport *diff.Diff, operationsSour
 								return
 							}
 
-							result = append(result, NewApiChange(
+							result = append(result, opInfo.NewApiChange(
 								NewRequiredRequestHeaderPropertyId,
-								config,
 								[]any{paramName, propertyFullName(propertyPath, newPropertyName)},
 								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
 							).WithSources(baseSource, revisionSource))
 						})
 				}

--- a/checker/check_request_body_became_enum.go
+++ b/checker/check_request_body_became_enum.go
@@ -25,6 +25,8 @@ func RequestBodyBecameEnumCheck(diffReport *diff.Diff, operationsSources *diff.O
 				continue
 			}
 
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
+
 			modifiedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
 
 			for mediaType, mediaTypeDiff := range modifiedMediaTypes {
@@ -37,15 +39,10 @@ func RequestBodyBecameEnumCheck(diffReport *diff.Diff, operationsSources *diff.O
 					continue
 				}
 				baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, schemaDiff, "enum")
-				result = append(result, NewApiChange(
+				result = append(result, opInfo.NewApiChange(
 					RequestBodyBecameEnumId,
-					config,
 					nil,
 					"",
-					operationsSources,
-					operationItem.Revision,
-					operation,
-					path,
 				).WithSources(baseSource, revisionSource).WithDetails(mediaTypeDetails))
 			}
 		}

--- a/checker/check_request_body_enum_deleted.go
+++ b/checker/check_request_body_enum_deleted.go
@@ -30,6 +30,8 @@ func RequestBodyEnumValueRemovedCheck(diffReport *diff.Diff, operationsSources *
 				continue
 			}
 
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
+
 			mediaTypeChanges := operationItem.RequestBodyDiff.ContentDiff.MediaTypeModified
 
 			for _, mediaTypeItem := range mediaTypeChanges {
@@ -44,15 +46,10 @@ func RequestBodyEnumValueRemovedCheck(diffReport *diff.Diff, operationsSources *
 				}
 				for _, enumVal := range enumDiff.Deleted {
 					baseSource, revisionSource := SchemaDeletedItemSources(operationsSources, operationItem, schemaDiff, "enum", fmt.Sprintf("%v", enumVal))
-					result = append(result, NewApiChange(
+					result = append(result, opInfo.NewApiChange(
 						RequestBodyEnumValueRemovedId,
-						config,
 						[]any{enumVal},
 						"",
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
 					).WithSources(baseSource, revisionSource))
 				}
 			}

--- a/checker/check_request_body_mediatype_updated.go
+++ b/checker/check_request_body_mediatype_updated.go
@@ -25,33 +25,25 @@ func RequestBodyMediaTypeChangedCheck(diffReport *diff.Diff, operationsSources *
 				continue
 			}
 
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
+
 			addedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeAdded
 			for _, mediaType := range addedMediaTypes {
 				revisionSource := requestBodyMediaTypeSource(operationsSources, operationItem.Revision, mediaType)
-				result = append(result, NewApiChange(
+				result = append(result, opInfo.NewApiChange(
 					RequestBodyMediaTypeAddedId,
-					config,
 					[]any{mediaType},
 					"",
-					operationsSources,
-					operationItem.Revision,
-					operation,
-					path,
 				).WithSources(nil, revisionSource))
 			}
 
 			removedMediaTypes := operationItem.RequestBodyDiff.ContentDiff.MediaTypeDeleted
 			for _, mediaType := range removedMediaTypes {
 				baseSource := requestBodyMediaTypeSource(operationsSources, operationItem.Base, mediaType)
-				result = append(result, NewApiChange(
+				result = append(result, opInfo.NewApiChange(
 					RequestBodyMediaTypeRemovedId,
-					config,
 					[]any{mediaType},
 					"",
-					operationsSources,
-					operationItem.Revision,
-					operation,
-					path,
 				).WithSources(baseSource, nil))
 			}
 		}

--- a/checker/check_request_body_removed.go
+++ b/checker/check_request_body_removed.go
@@ -24,17 +24,14 @@ func RequestBodyRemovedCheck(diffReport *diff.Diff, operationsSources *diff.Oper
 				continue
 			}
 
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
+
 			if operationItem.RequestBodyDiff.Deleted {
 				baseSource := requestBodySource(operationsSources, operationItem.Base)
-				result = append(result, NewApiChange(
+				result = append(result, opInfo.NewApiChange(
 					RequestBodyRemovedId,
-					config,
 					nil,
 					"",
-					operationsSources,
-					operationItem.Revision,
-					operation,
-					path,
 				).WithSources(baseSource, nil))
 			}
 		}

--- a/checker/check_request_body_required_value_updated.go
+++ b/checker/check_request_body_required_value_updated.go
@@ -27,21 +27,18 @@ func RequestBodyRequiredUpdatedCheck(diffReport *diff.Diff, operationsSources *d
 				continue
 			}
 
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
+
 			id := RequestBodyBecameOptionalId
 			if operationItem.RequestBodyDiff.RequiredDiff.To == true {
 				id = RequestBodyBecameRequiredId
 			}
 
 			baseSource, revisionSource := requestBodyFieldSources(operationsSources, operationItem, "required")
-			result = append(result, NewApiChange(
+			result = append(result, opInfo.NewApiChange(
 				id,
-				config,
 				nil,
 				"",
-				operationsSources,
-				operationItem.Revision,
-				operation,
-				path,
 			).WithSources(baseSource, revisionSource))
 		}
 	}

--- a/checker/check_request_header_property_became_enum.go
+++ b/checker/check_request_header_property_became_enum.go
@@ -23,6 +23,8 @@ func RequestHeaderPropertyBecameEnumCheck(diffReport *diff.Diff, operationsSourc
 				continue
 			}
 
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
+
 			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
 
 				if paramLocation != "header" {
@@ -36,15 +38,10 @@ func RequestHeaderPropertyBecameEnumCheck(diffReport *diff.Diff, operationsSourc
 
 					baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, paramDiff.SchemaDiff, "enum")
 					if paramDiff.SchemaDiff.EnumDiff != nil && paramDiff.SchemaDiff.EnumDiff.EnumAdded {
-						result = append(result, NewApiChange(
+						result = append(result, opInfo.NewApiChange(
 							RequestHeaderPropertyBecameEnumId,
-							config,
 							[]any{paramName},
 							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
 						).WithSources(baseSource, revisionSource))
 					}
 
@@ -57,15 +54,10 @@ func RequestHeaderPropertyBecameEnumCheck(diffReport *diff.Diff, operationsSourc
 							}
 
 							propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, operationItem, propertyDiff, "enum")
-							result = append(result, NewApiChange(
+							result = append(result, opInfo.NewApiChange(
 								RequestHeaderPropertyBecameEnumId,
-								config,
 								[]any{paramName, propertyFullName(propertyPath, propertyName)},
 								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
 							).WithSources(propBaseSource, propRevisionSource))
 						})
 				}

--- a/checker/check_request_header_property_became_required.go
+++ b/checker/check_request_header_property_became_required.go
@@ -23,6 +23,8 @@ func RequestHeaderPropertyBecameRequiredCheck(diffReport *diff.Diff, operationsS
 				continue
 			}
 
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
+
 			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
 
 				if paramLocation != "header" {
@@ -49,15 +51,10 @@ func RequestHeaderPropertyBecameRequiredCheck(diffReport *diff.Diff, operationsS
 							}
 
 							baseSource, revisionSource := SchemaAddedItemSources(operationsSources, operationItem, paramDiff.SchemaDiff, "required", changedRequiredPropertyName)
-							result = append(result, NewApiChange(
+							result = append(result, opInfo.NewApiChange(
 								RequestHeaderPropertyBecameRequiredId,
-								config,
 								[]any{paramName, changedRequiredPropertyName},
 								"",
-								operationsSources,
-								operationItem.Revision,
-								operation,
-								path,
 							).WithSources(baseSource, revisionSource))
 						}
 					}
@@ -77,15 +74,10 @@ func RequestHeaderPropertyBecameRequiredCheck(diffReport *diff.Diff, operationsS
 									continue
 								}
 								propBaseSource, propRevisionSource := SchemaAddedItemSources(operationsSources, operationItem, propertyDiff, "required", changedRequiredPropertyName)
-								result = append(result, NewApiChange(
+								result = append(result, opInfo.NewApiChange(
 									RequestHeaderPropertyBecameRequiredId,
-									config,
 									[]any{paramName, propertyFullName(propertyPath, propertyFullName(propertyName, changedRequiredPropertyName))},
 									"",
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
 								).WithSources(propBaseSource, propRevisionSource))
 							}
 						})

--- a/checker/check_request_parameter_became_enum.go
+++ b/checker/check_request_parameter_became_enum.go
@@ -24,6 +24,7 @@ func RequestParameterBecameEnumCheck(diffReport *diff.Diff, operationsSources *d
 			if operationItem.ParametersDiff.Modified == nil {
 				continue
 			}
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 			for paramLocation, paramItems := range operationItem.ParametersDiff.Modified {
 				for paramName, paramItem := range paramItems {
 					if paramItem.SchemaDiff == nil {
@@ -35,15 +36,10 @@ func RequestParameterBecameEnumCheck(diffReport *diff.Diff, operationsSources *d
 						continue
 					}
 
-					result = append(result, NewApiChange(
+					result = append(result, opInfo.NewApiChange(
 						RequestParameterBecameEnumId,
-						config,
 						[]any{paramLocation, paramName},
 						"",
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
 					).WithSources(baseSource, revisionSource))
 				}
 			}

--- a/checker/check_request_parameter_deprecation.go
+++ b/checker/check_request_parameter_deprecation.go
@@ -45,15 +45,10 @@ func RequestParameterDeprecationCheck(diffReport *diff.Diff, operationsSources *
 
 					if paramItem.DeprecatedDiff.To == nil || paramItem.DeprecatedDiff.To == false {
 						// not breaking changes
-						result = append(result, NewApiChange(
+						result = append(result, opInfo.NewApiChange(
 							RequestParameterReactivatedId,
-							config,
 							[]any{paramLocation, paramName},
 							"",
-							operationsSources,
-							op,
-							operation,
-							path,
 						).WithSources(baseSource, revisionSource).WithDetails(formatDeprecationDetails(op.Extensions)))
 						continue
 					}
@@ -73,15 +68,10 @@ func RequestParameterDeprecationCheck(diffReport *diff.Diff, operationsSources *
 							result = append(result, getParameterDeprecatedSunsetMissing(opInfo, param).WithSources(baseSource, revisionSource))
 						} else {
 							// no policy, report deprecation without sunset as INFO
-							result = append(result, NewApiChange(
+							result = append(result, opInfo.NewApiChange(
 								RequestParameterDeprecatedId,
-								config,
 								[]any{paramLocation, paramName},
 								"",
-								operationsSources,
-								op,
-								operation,
-								path,
 							).WithSources(baseSource, revisionSource).WithDetails(formatDeprecationDetails(op.Extensions)))
 						}
 						continue
@@ -89,15 +79,10 @@ func RequestParameterDeprecationCheck(diffReport *diff.Diff, operationsSources *
 
 					date, err := getSunsetDate(sunset)
 					if err != nil {
-						result = append(result, NewApiChange(
+						result = append(result, opInfo.NewApiChange(
 							RequestParameterSunsetParseId,
-							config,
 							[]any{param.In, param.Name, err},
 							"",
-							operationsSources,
-							op,
-							operation,
-							path,
 						).WithSources(baseSource, revisionSource))
 						continue
 					}
@@ -105,29 +90,19 @@ func RequestParameterDeprecationCheck(diffReport *diff.Diff, operationsSources *
 					days := date.DaysSince(civil.DateOf(time.Now()))
 
 					if days < int(deprecationDays) {
-						result = append(result, NewApiChange(
+						result = append(result, opInfo.NewApiChange(
 							RequestParameterSunsetDateTooSmallId,
-							config,
 							[]any{param.In, param.Name, date, deprecationDays},
 							"",
-							operationsSources,
-							op,
-							operation,
-							path,
 						).WithSources(baseSource, revisionSource))
 						continue
 					}
 
 					// not breaking changes
-					result = append(result, NewApiChange(
+					result = append(result, opInfo.NewApiChange(
 						RequestParameterDeprecatedId,
-						config,
 						[]any{paramLocation, paramName},
 						"",
-						operationsSources,
-						op,
-						operation,
-						path,
 					).WithSources(baseSource, revisionSource).WithDetails(formatDeprecationDetailsWithSunset(date, op.Extensions)))
 				}
 			}
@@ -138,14 +113,9 @@ func RequestParameterDeprecationCheck(diffReport *diff.Diff, operationsSources *
 }
 
 func getParameterDeprecatedSunsetMissing(opInfo opInfo, param *openapi3.Parameter) ApiChange {
-	return NewApiChange(
+	return opInfo.NewApiChange(
 		RequestParameterDeprecatedSunsetMissingId,
-		opInfo.config,
 		[]any{param.In, param.Name},
 		"",
-		opInfo.operationsSources,
-		opInfo.operation,
-		opInfo.method,
-		opInfo.path,
 	)
 }

--- a/checker/check_request_parameter_enum_value_updated.go
+++ b/checker/check_request_parameter_enum_value_updated.go
@@ -80,29 +80,19 @@ func checkParameterEnumDiff(
 
 	for _, enumVal := range enumDiff.Deleted {
 		baseSource, revisionSource := SchemaDeletedItemSources(opInfo.operationsSources, opInfo.methodDiff, schemaDiff, "enum", fmt.Sprintf("%v", enumVal))
-		result = append(result, NewApiChange(
+		result = append(result, opInfo.NewApiChange(
 			removedId,
-			opInfo.config,
 			makeArgs(enumVal),
 			"",
-			opInfo.operationsSources,
-			opInfo.operation,
-			opInfo.method,
-			opInfo.path,
 		).WithSources(baseSource, revisionSource))
 	}
 
 	for _, enumVal := range enumDiff.Added {
 		baseSource, revisionSource := SchemaAddedItemSources(opInfo.operationsSources, opInfo.methodDiff, schemaDiff, "enum", fmt.Sprintf("%v", enumVal))
-		result = append(result, NewApiChange(
+		result = append(result, opInfo.NewApiChange(
 			addedId,
-			opInfo.config,
 			makeArgs(enumVal),
 			"",
-			opInfo.operationsSources,
-			opInfo.operation,
-			opInfo.method,
-			opInfo.path,
 		).WithSources(baseSource, revisionSource))
 	}
 

--- a/checker/check_request_parameter_pattern_added_or_changed.go
+++ b/checker/check_request_parameter_pattern_added_or_changed.go
@@ -29,6 +29,7 @@ func RequestParameterPatternAddedOrChangedCheck(diffReport *diff.Diff, operation
 			if operationItem.ParametersDiff.Modified == nil {
 				continue
 			}
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 			for paramLocation, paramItems := range operationItem.ParametersDiff.Modified {
 				for paramName, paramItem := range paramItems {
 					if paramItem.SchemaDiff == nil {
@@ -41,26 +42,16 @@ func RequestParameterPatternAddedOrChangedCheck(diffReport *diff.Diff, operation
 					}
 
 					if patternDiff.From == "" {
-						result = append(result, NewApiChange(
+						result = append(result, opInfo.NewApiChange(
 							RequestParameterPatternAddedId,
-							config,
 							[]any{patternDiff.To, paramLocation, paramName},
 							PatternAddedCommentId,
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
 						).WithSources(nil, revisionSource))
 					} else if patternDiff.To == "" {
-						result = append(result, NewApiChange(
+						result = append(result, opInfo.NewApiChange(
 							RequestParameterPatternRemovedId,
-							config,
 							[]any{patternDiff.From, paramLocation, paramName},
 							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
 						).WithSources(baseSource, nil))
 					} else {
 						id := RequestParameterPatternChangedId
@@ -71,15 +62,10 @@ func RequestParameterPatternAddedOrChangedCheck(diffReport *diff.Diff, operation
 							comment = ""
 						}
 
-						result = append(result, NewApiChange(
+						result = append(result, opInfo.NewApiChange(
 							id,
-							config,
 							[]any{paramLocation, paramName, patternDiff.From, patternDiff.To},
 							comment,
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
 						).WithSources(baseSource, revisionSource))
 					}
 				}

--- a/checker/check_request_parameter_removed.go
+++ b/checker/check_request_parameter_removed.go
@@ -54,29 +54,19 @@ func RequestParameterRemovedCheck(diffReport *diff.Diff, operationsSources *diff
 func checkParameterRemoval(opInfo opInfo, param *openapi3.Parameter) (ApiChange, bool) {
 
 	if !param.Deprecated {
-		return NewApiChange(
+		return opInfo.NewApiChange(
 			RequestParameterRemovedId,
-			opInfo.config,
 			[]any{param.In, param.Name},
 			commentId(RequestParameterRemovedId),
-			opInfo.operationsSources,
-			opInfo.operation,
-			opInfo.method,
-			opInfo.path,
 		), true
 	}
 
 	sunset, ok := getSunset(param.Extensions)
 	if !ok {
-		return NewApiChange(
+		return opInfo.NewApiChange(
 			RequestParameterRemovedWithDeprecationId,
-			opInfo.config,
 			[]any{param.In, param.Name},
 			"",
-			opInfo.operationsSources,
-			opInfo.operation,
-			opInfo.method,
-			opInfo.path,
 		), true
 	}
 
@@ -86,29 +76,19 @@ func checkParameterRemoval(opInfo opInfo, param *openapi3.Parameter) (ApiChange,
 	}
 
 	if civil.DateOf(time.Now()).Before(date) {
-		return NewApiChange(
+		return opInfo.NewApiChange(
 			ParameterRemovedBeforeSunsetId,
-			opInfo.config,
 			[]any{param.In, param.Name, date},
 			"",
-			opInfo.operationsSources,
-			opInfo.operation,
-			opInfo.method,
-			opInfo.path,
 		), true
 	}
 	return ApiChange{}, false
 }
 
 func getRequestParameterSunsetParse(opInfo opInfo, param *openapi3.Parameter, err error) ApiChange {
-	return NewApiChange(
+	return opInfo.NewApiChange(
 		RequestParameterSunsetParseId,
-		opInfo.config,
 		[]any{param.In, param.Name, err},
 		"",
-		opInfo.operationsSources,
-		opInfo.operation,
-		opInfo.method,
-		opInfo.path,
 	)
 }

--- a/checker/check_request_parameter_required_value_updated.go
+++ b/checker/check_request_parameter_required_value_updated.go
@@ -25,6 +25,7 @@ func RequestParameterRequiredValueUpdatedCheck(diffReport *diff.Diff, operations
 			if operationItem.ParametersDiff.Modified == nil {
 				continue
 			}
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 			for paramLocation, paramItems := range operationItem.ParametersDiff.Modified {
 				for paramName, paramItem := range paramItems {
 					requiredDiff := paramItem.RequiredDiff
@@ -39,15 +40,10 @@ func RequestParameterRequiredValueUpdatedCheck(diffReport *diff.Diff, operations
 						id = RequestParameterBecomeOptionalId
 					}
 
-					result = append(result, NewApiChange(
+					result = append(result, opInfo.NewApiChange(
 						id,
-						config,
 						[]any{paramLocation, paramName},
 						"",
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
 					).WithSources(baseSource, revisionSource))
 				}
 			}

--- a/checker/check_request_parameter_x_extensible_enum_value_removed.go
+++ b/checker/check_request_parameter_x_extensible_enum_value_removed.go
@@ -25,6 +25,7 @@ func RequestParameterXExtensibleEnumValueRemovedCheck(diffReport *diff.Diff, ope
 			if operationItem.ParametersDiff.Modified == nil {
 				continue
 			}
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 			for paramLocation, paramItems := range operationItem.ParametersDiff.Modified {
 				for paramName, paramItem := range paramItems {
 					if paramItem.SchemaDiff == nil {
@@ -67,15 +68,10 @@ func RequestParameterXExtensibleEnumValueRemovedCheck(diffReport *diff.Diff, ope
 					}
 
 					for _, enumVal := range deletedVals {
-						result = append(result, NewApiChange(
+						result = append(result, opInfo.NewApiChange(
 							RequestParameterXExtensibleEnumValueRemovedId,
-							config,
 							[]any{enumVal, paramLocation, paramName},
 							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
 						).WithSources(baseSource, revisionSource))
 					}
 				}

--- a/checker/check_request_parameters_default_value_changed.go
+++ b/checker/check_request_parameters_default_value_changed.go
@@ -23,6 +23,7 @@ func RequestParameterDefaultValueChangedCheck(diffReport *diff.Diff, operationsS
 			if operationItem.ParametersDiff == nil {
 				continue
 			}
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
 				for paramName, paramDiff := range paramDiffs {
 
@@ -47,15 +48,10 @@ func RequestParameterDefaultValueChangedCheck(diffReport *diff.Diff, operationsS
 
 					baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, paramDiff.SchemaDiff, "default")
 					appendResultItem := func(messageId string, a ...any) {
-						result = append(result, NewApiChange(
+						result = append(result, opInfo.NewApiChange(
 							messageId,
-							config,
 							a,
 							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
 						).WithSources(baseSource, revisionSource))
 					}
 

--- a/checker/check_request_parameters_max_items_updated.go
+++ b/checker/check_request_parameters_max_items_updated.go
@@ -22,6 +22,7 @@ func RequestParameterMaxItemsUpdatedCheck(diffReport *diff.Diff, operationsSourc
 			if operationItem.ParametersDiff == nil {
 				continue
 			}
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
 				for paramName, paramDiff := range paramDiffs {
 					if paramDiff.SchemaDiff == nil {
@@ -49,15 +50,10 @@ func RequestParameterMaxItemsUpdatedCheck(diffReport *diff.Diff, operationsSourc
 						id = RequestParameterMaxItemsIncreasedId
 					}
 
-					result = append(result, NewApiChange(
+					result = append(result, opInfo.NewApiChange(
 						id,
-						config,
 						[]any{paramLocation, paramName, maxItemsDiff.From, maxItemsDiff.To},
 						"",
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
 					).WithSources(baseSource, revisionSource))
 				}
 			}

--- a/checker/check_request_parameters_max_length_set.go
+++ b/checker/check_request_parameters_max_length_set.go
@@ -21,6 +21,7 @@ func RequestParameterMaxLengthSetCheck(diffReport *diff.Diff, operationsSources 
 			if operationItem.ParametersDiff == nil {
 				continue
 			}
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
 				for paramName, paramDiff := range paramDiffs {
 					if paramDiff.SchemaDiff == nil {
@@ -36,15 +37,10 @@ func RequestParameterMaxLengthSetCheck(diffReport *diff.Diff, operationsSources 
 					}
 
 					_, revisionSource := SchemaFieldSources(operationsSources, operationItem, paramDiff.SchemaDiff, "maxLength")
-					result = append(result, NewApiChange(
+					result = append(result, opInfo.NewApiChange(
 						RequestParameterMaxLengthSetId,
-						config,
 						[]any{paramLocation, paramName, maxLengthDiff.To},
 						commentId(RequestParameterMaxLengthSetId),
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
 					).WithSources(nil, revisionSource))
 				}
 			}

--- a/checker/check_request_parameters_max_length_updated.go
+++ b/checker/check_request_parameters_max_length_updated.go
@@ -22,6 +22,7 @@ func RequestParameterMaxLengthUpdatedCheck(diffReport *diff.Diff, operationsSour
 			if operationItem.ParametersDiff == nil {
 				continue
 			}
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
 				for paramName, paramDiff := range paramDiffs {
 					if paramDiff.SchemaDiff == nil {
@@ -42,15 +43,10 @@ func RequestParameterMaxLengthUpdatedCheck(diffReport *diff.Diff, operationsSour
 					}
 
 					baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, paramDiff.SchemaDiff, "maxLength")
-					result = append(result, NewApiChange(
+					result = append(result, opInfo.NewApiChange(
 						id,
-						config,
 						[]any{paramLocation, paramName, maxLengthDiff.From, maxLengthDiff.To},
 						"",
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
 					).WithSources(baseSource, revisionSource))
 				}
 			}

--- a/checker/check_request_parameters_max_set.go
+++ b/checker/check_request_parameters_max_set.go
@@ -22,6 +22,7 @@ func RequestParameterMaxSetCheck(diffReport *diff.Diff, operationsSources *diff.
 			if operationItem.ParametersDiff == nil {
 				continue
 			}
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
 				for paramName, paramDiff := range paramDiffs {
 					if paramDiff.SchemaDiff == nil {
@@ -39,15 +40,10 @@ func RequestParameterMaxSetCheck(diffReport *diff.Diff, operationsSources *diff.
 							continue
 						}
 						_, revisionSource := SchemaFieldSources(operationsSources, operationItem, paramDiff.SchemaDiff, entry.field)
-						result = append(result, NewApiChange(
+						result = append(result, opInfo.NewApiChange(
 							entry.id,
-							config,
 							[]any{paramLocation, paramName, entry.diff.To},
 							commentId(entry.id),
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
 						).WithSources(nil, revisionSource))
 					}
 				}

--- a/checker/check_request_parameters_max_updated.go
+++ b/checker/check_request_parameters_max_updated.go
@@ -24,6 +24,7 @@ func RequestParameterMaxUpdatedCheck(diffReport *diff.Diff, operationsSources *d
 			if operationItem.ParametersDiff == nil {
 				continue
 			}
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
 				for paramName, paramDiff := range paramDiffs {
 					if paramDiff.SchemaDiff == nil {
@@ -46,15 +47,10 @@ func RequestParameterMaxUpdatedCheck(diffReport *diff.Diff, operationsSources *d
 							id = entry.increasedId
 						}
 						baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, paramDiff.SchemaDiff, entry.field)
-						result = append(result, NewApiChange(
+						result = append(result, opInfo.NewApiChange(
 							id,
-							config,
 							[]any{paramLocation, paramName, entry.diff.From, entry.diff.To},
 							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
 						).WithSources(baseSource, revisionSource))
 					}
 				}

--- a/checker/check_request_parameters_min_items_set.go
+++ b/checker/check_request_parameters_min_items_set.go
@@ -21,6 +21,7 @@ func RequestParameterMinItemsSetCheck(diffReport *diff.Diff, operationsSources *
 			if operationItem.ParametersDiff == nil {
 				continue
 			}
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
 				for paramName, paramDiff := range paramDiffs {
 					if paramDiff.SchemaDiff == nil {
@@ -36,15 +37,10 @@ func RequestParameterMinItemsSetCheck(diffReport *diff.Diff, operationsSources *
 						continue
 					}
 
-					result = append(result, NewApiChange(
+					result = append(result, opInfo.NewApiChange(
 						RequestParameterMinItemsSetId,
-						config,
 						[]any{paramLocation, paramName, minItemsDiff.To},
 						commentId(RequestParameterMinItemsSetId),
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
 					).WithSources(nil, revisionSource))
 				}
 			}

--- a/checker/check_request_parameters_min_items_updated.go
+++ b/checker/check_request_parameters_min_items_updated.go
@@ -22,6 +22,7 @@ func RequestParameterMinItemsUpdatedCheck(diffReport *diff.Diff, operationsSourc
 			if operationItem.ParametersDiff == nil {
 				continue
 			}
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
 				for paramName, paramDiff := range paramDiffs {
 					if paramDiff.SchemaDiff == nil {
@@ -42,15 +43,10 @@ func RequestParameterMinItemsUpdatedCheck(diffReport *diff.Diff, operationsSourc
 						id = RequestParameterMinItemsDecreasedId
 					}
 
-					result = append(result, NewApiChange(
+					result = append(result, opInfo.NewApiChange(
 						id,
-						config,
 						[]any{paramLocation, paramName, minItemsDiff.From, minItemsDiff.To},
 						"",
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
 					).WithSources(baseSource, revisionSource))
 				}
 			}

--- a/checker/check_request_parameters_min_length_updated.go
+++ b/checker/check_request_parameters_min_length_updated.go
@@ -22,6 +22,7 @@ func RequestParameterMinLengthUpdatedCheck(diffReport *diff.Diff, operationsSour
 			if operationItem.ParametersDiff == nil {
 				continue
 			}
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
 				for paramName, paramDiff := range paramDiffs {
 					if paramDiff.SchemaDiff == nil {
@@ -42,15 +43,10 @@ func RequestParameterMinLengthUpdatedCheck(diffReport *diff.Diff, operationsSour
 						id = RequestParameterMinLengthDecreasedId
 					}
 
-					result = append(result, NewApiChange(
+					result = append(result, opInfo.NewApiChange(
 						id,
-						config,
 						[]any{paramLocation, paramName, minLengthDiff.From, minLengthDiff.To},
 						"",
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
 					).WithSources(baseSource, revisionSource))
 				}
 			}

--- a/checker/check_request_parameters_min_set.go
+++ b/checker/check_request_parameters_min_set.go
@@ -22,6 +22,7 @@ func RequestParameterMinSetCheck(diffReport *diff.Diff, operationsSources *diff.
 			if operationItem.ParametersDiff == nil {
 				continue
 			}
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
 				for paramName, paramDiff := range paramDiffs {
 					if paramDiff.SchemaDiff == nil {
@@ -39,15 +40,10 @@ func RequestParameterMinSetCheck(diffReport *diff.Diff, operationsSources *diff.
 							continue
 						}
 						_, revisionSource := SchemaFieldSources(operationsSources, operationItem, paramDiff.SchemaDiff, entry.field)
-						result = append(result, NewApiChange(
+						result = append(result, opInfo.NewApiChange(
 							entry.id,
-							config,
 							[]any{paramLocation, paramName, entry.diff.To},
 							commentId(entry.id),
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
 						).WithSources(nil, revisionSource))
 					}
 				}

--- a/checker/check_request_parameters_min_updated.go
+++ b/checker/check_request_parameters_min_updated.go
@@ -24,6 +24,7 @@ func RequestParameterMinUpdatedCheck(diffReport *diff.Diff, operationsSources *d
 			if operationItem.ParametersDiff == nil {
 				continue
 			}
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
 				for paramName, paramDiff := range paramDiffs {
 					if paramDiff.SchemaDiff == nil {
@@ -46,15 +47,10 @@ func RequestParameterMinUpdatedCheck(diffReport *diff.Diff, operationsSources *d
 							id = entry.decreasedId
 						}
 						baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, paramDiff.SchemaDiff, entry.field)
-						result = append(result, NewApiChange(
+						result = append(result, opInfo.NewApiChange(
 							id,
-							config,
 							[]any{paramLocation, paramName, entry.diff.From, entry.diff.To},
 							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
 						).WithSources(baseSource, revisionSource))
 					}
 				}

--- a/checker/check_request_parameters_type_changed.go
+++ b/checker/check_request_parameters_type_changed.go
@@ -117,6 +117,7 @@ func RequestParameterTypeChangedCheck(diffReport *diff.Diff, operationsSources *
 				continue
 			}
 
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 			for paramLocation, paramDiffs := range operationItem.ParametersDiff.Modified {
 				for paramName, paramDiff := range paramDiffs {
 					if paramDiff.SchemaDiff == nil {
@@ -159,15 +160,10 @@ func RequestParameterTypeChangedCheck(diffReport *diff.Diff, operationsSources *
 							}
 						}
 
-						result = append(result, NewApiChange(
+						result = append(result, opInfo.NewApiChange(
 							id,
-							config,
 							[]any{paramLocation, paramName, getTypeFormatDimension(schemaDiff), getBaseTypeFormat(schemaDiff), getRevisionTypeFormat(schemaDiff)},
 							comment,
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
 						).WithSources(baseSource, revisionSource))
 					}
 
@@ -194,15 +190,10 @@ func RequestParameterTypeChangedCheck(diffReport *diff.Diff, operationsSources *
 
 								id, comment := checkRequestParameterPropertyTypeChanged(typeDiff, formatDiff, schemaDiff)
 
-								result = append(result, NewApiChange(
+								result = append(result, opInfo.NewApiChange(
 									id,
-									config,
 									[]any{paramLocation, paramName, getTypeFormatDimension(schemaDiff), propertyFullName(propertyPath, propertyName), getBaseTypeFormat(schemaDiff), getRevisionTypeFormat(schemaDiff)},
 									comment,
-									operationsSources,
-									operationItem.Revision,
-									operation,
-									path,
 								).WithSources(propBaseSource, propRevisionSource))
 							}
 						})

--- a/checker/check_request_path_parameter_added.go
+++ b/checker/check_request_path_parameter_added.go
@@ -21,6 +21,7 @@ func NewRequestPathParameterCheck(diffReport *diff.Diff, operationsSources *diff
 			if operationItem.ParametersDiff == nil {
 				continue
 			}
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 			for paramLocation, paramItems := range operationItem.ParametersDiff.Added {
 				if paramLocation != "path" {
 					continue
@@ -34,15 +35,10 @@ func NewRequestPathParameterCheck(diffReport *diff.Diff, operationsSources *diff
 							break
 						}
 					}
-					result = append(result, NewApiChange(
+					result = append(result, opInfo.NewApiChange(
 						NewRequestPathParameterId,
-						config,
 						[]any{paramName},
 						"",
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
 					).WithSources(nil, revisionSource))
 				}
 			}

--- a/checker/check_response_header_added.go
+++ b/checker/check_response_header_added.go
@@ -27,6 +27,7 @@ func ResponseHeaderAddedCheck(diffReport *diff.Diff, operationsSources *diff.Ope
 			if operationItem.ResponsesDiff.Modified == nil {
 				continue
 			}
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
 				if responseDiff.HeadersDiff == nil {
 					continue
@@ -38,15 +39,10 @@ func ResponseHeaderAddedCheck(diffReport *diff.Diff, operationsSources *diff.Ope
 					}
 					header := responseDiff.Revision.Headers[headerName].Value
 					revisionSource := NewSourceFromOrigin(operationsSources, operationItem.Revision, header.Origin)
-					result = append(result, NewApiChange(
+					result = append(result, opInfo.NewApiChange(
 						ResponseHeaderAddedId,
-						config,
 						[]any{headerName, responseStatus},
 						"",
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
 					).WithSources(nil, revisionSource))
 				}
 			}

--- a/checker/check_response_header_became_optional.go
+++ b/checker/check_response_header_became_optional.go
@@ -24,6 +24,7 @@ func ResponseHeaderBecameOptionalCheck(diffReport *diff.Diff, operationsSources 
 			if operationItem.ResponsesDiff.Modified == nil {
 				continue
 			}
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
 				if responseDiff.HeadersDiff == nil {
 					continue
@@ -39,15 +40,10 @@ func ResponseHeaderBecameOptionalCheck(diffReport *diff.Diff, operationsSources 
 					}
 
 					baseSource, revisionSource := headerSources(operationsSources, operationItem, responseDiff, headerName)
-					result = append(result, NewApiChange(
+					result = append(result, opInfo.NewApiChange(
 						ResponseHeaderBecameOptionalId,
-						config,
 						[]any{headerName, responseStatus},
 						"",
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
 					).WithSources(baseSource, revisionSource))
 				}
 			}

--- a/checker/check_response_header_removed.go
+++ b/checker/check_response_header_removed.go
@@ -25,6 +25,7 @@ func ResponseHeaderRemovedCheck(diffReport *diff.Diff, operationsSources *diff.O
 			if operationItem.ResponsesDiff.Modified == nil {
 				continue
 			}
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 			for responseStatus, responseDiff := range operationItem.ResponsesDiff.Modified {
 				if responseDiff.HeadersDiff == nil {
 					continue
@@ -38,26 +39,16 @@ func ResponseHeaderRemovedCheck(diffReport *diff.Diff, operationsSources *diff.O
 					baseSource := NewSourceFromOrigin(operationsSources, operationItem.Base, header.Origin)
 					required := header.Required
 					if required {
-						result = append(result, NewApiChange(
+						result = append(result, opInfo.NewApiChange(
 							RequiredResponseHeaderRemovedId,
-							config,
 							[]any{headerName, responseStatus},
 							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
 						).WithSources(baseSource, nil))
 					} else {
-						result = append(result, NewApiChange(
+						result = append(result, opInfo.NewApiChange(
 							OptionalResponseHeaderRemovedId,
-							config,
 							[]any{headerName, responseStatus},
 							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
 						).WithSources(baseSource, nil))
 					}
 				}

--- a/checker/check_response_mediatype_enum_value_removed.go
+++ b/checker/check_response_mediatype_enum_value_removed.go
@@ -26,6 +26,7 @@ func ResponseMediaTypeEnumValueRemovedCheck(diffReport *diff.Diff, operationsSou
 			if operationItem.ResponsesDiff.Modified == nil {
 				continue
 			}
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 			for _, responseItems := range operationItem.ResponsesDiff.Modified {
 				if responseItems.ContentDiff == nil {
 					continue
@@ -46,15 +47,10 @@ func ResponseMediaTypeEnumValueRemovedCheck(diffReport *diff.Diff, operationsSou
 
 					for _, enumVal := range enumDiff.Deleted {
 						baseSource, revisionSource := SchemaDeletedItemSources(operationsSources, operationItem, mediaTypeItem.SchemaDiff, "enum", fmt.Sprintf("%v", enumVal))
-						result = append(result, NewApiChange(
+						result = append(result, opInfo.NewApiChange(
 							ResponseMediaTypeEnumValueRemovedId,
-							config,
 							[]any{mediaType, enumVal},
 							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
 						).WithSources(baseSource, revisionSource))
 					}
 				}

--- a/checker/check_response_mediatype_name_updated.go
+++ b/checker/check_response_mediatype_name_updated.go
@@ -26,6 +26,7 @@ func ResponseMediaTypeNameUpdatedCheck(diffReport *diff.Diff, operationsSources 
 			if operationItem.ResponsesDiff.Modified == nil {
 				continue
 			}
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 			for responseStatus, responsesDiff := range operationItem.ResponsesDiff.Modified {
 				if responsesDiff.ContentDiff == nil {
 					continue
@@ -41,15 +42,10 @@ func ResponseMediaTypeNameUpdatedCheck(diffReport *diff.Diff, operationsSources 
 
 					// If parameters changed, this is a changed media type
 					if !mediaType.NameDiff.ParametersDiff.Empty() {
-						result = append(result, NewApiChange(
+						result = append(result, opInfo.NewApiChange(
 							ResponseMediaTypeNameChangedId,
-							config,
 							[]any{mediaType.NameDiff.NameDiff.From, mediaType.NameDiff.NameDiff.To, responseStatus},
 							"",
-							operationsSources,
-							operationItem.Revision,
-							operation,
-							path,
 						).WithSources(baseSource, revisionSource))
 						continue
 					}
@@ -60,15 +56,10 @@ func ResponseMediaTypeNameUpdatedCheck(diffReport *diff.Diff, operationsSources 
 						id = ResponseMediaTypeNameSpecializedId
 					}
 
-					result = append(result, NewApiChange(
+					result = append(result, opInfo.NewApiChange(
 						id,
-						config,
 						[]any{mediaType.NameDiff.NameDiff.From, mediaType.NameDiff.NameDiff.To, responseStatus},
 						"",
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
 					).WithSources(baseSource, revisionSource))
 				}
 			}

--- a/checker/check_response_mediatype_updated.go
+++ b/checker/check_response_mediatype_updated.go
@@ -25,34 +25,25 @@ func ResponseMediaTypeUpdatedCheck(diffReport *diff.Diff, operationsSources *dif
 			if operationItem.ResponsesDiff.Modified == nil {
 				continue
 			}
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 			for responseStatus, responsesDiff := range operationItem.ResponsesDiff.Modified {
 				if responsesDiff.ContentDiff == nil {
 					continue
 				}
 				for _, mediaType := range responsesDiff.ContentDiff.MediaTypeDeleted {
 					baseSource := mediaTypeSource(operationsSources, operationItem.Base, responsesDiff.Base, mediaType)
-					result = append(result, NewApiChange(
+					result = append(result, opInfo.NewApiChange(
 						ResponseMediaTypeRemovedId,
-						config,
 						[]any{mediaType, responseStatus},
 						"",
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
 					).WithSources(baseSource, nil))
 				}
 				for _, mediaType := range responsesDiff.ContentDiff.MediaTypeAdded {
 					revisionSource := mediaTypeSource(operationsSources, operationItem.Revision, responsesDiff.Revision, mediaType)
-					result = append(result, NewApiChange(
+					result = append(result, opInfo.NewApiChange(
 						ResponseMediaTypeAddedId,
-						config,
 						[]any{mediaType, responseStatus},
 						"",
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
 					).WithSources(nil, revisionSource))
 				}
 			}

--- a/checker/check_response_status_updated.go
+++ b/checker/check_response_status_updated.go
@@ -69,6 +69,7 @@ func responseStatusUpdated(diffReport *diff.Diff, operationsSources *diff.Operat
 			if operationItem.ResponsesDiff.Modified == nil {
 				continue
 			}
+			opInfo := newOpInfoFromDiff(config, operationItem, operationsSources, operation, path)
 			for _, responseStatus := range operationItem.ResponsesDiff.Deleted {
 				status, err := strconv.Atoi(responseStatus)
 				if err != nil {
@@ -78,15 +79,10 @@ func responseStatusUpdated(diffReport *diff.Diff, operationsSources *diff.Operat
 				if filter(status) {
 					baseSource := responseSource(operationsSources, operationItem.Base, responseStatus)
 					var revisionSource *Source
-					result = append(result, NewApiChange(
+					result = append(result, opInfo.NewApiChange(
 						id,
-						config,
 						[]any{responseStatus},
 						"",
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
 					).WithSources(baseSource, revisionSource))
 				}
 			}
@@ -101,15 +97,10 @@ func responseStatusUpdated(diffReport *diff.Diff, operationsSources *diff.Operat
 				if filter(status) {
 					var baseSource *Source
 					revisionSource := responseSource(operationsSources, operationItem.Revision, responseStatus)
-					result = append(result, NewApiChange(
+					result = append(result, opInfo.NewApiChange(
 						addedId,
-						config,
 						[]any{responseStatus},
 						"",
-						operationsSources,
-						operationItem.Revision,
-						operation,
-						path,
 					).WithSources(baseSource, revisionSource))
 				}
 			}

--- a/checker/list_of_types_core.go
+++ b/checker/list_of_types_core.go
@@ -44,15 +44,10 @@ func checkPropertyListOfTypesChange(opInfo opInfo, propertyPath string, property
 	}
 
 	baseSource, revisionSource := SchemaFieldSources(opInfo.operationsSources, opInfo.methodDiff, propertyDiff, "type")
-	result = append(result, NewApiChange(
+	result = append(result, opInfo.NewApiChange(
 		messageId,
-		opInfo.config,
 		args,
 		"",
-		opInfo.operationsSources,
-		opInfo.operation,
-		opInfo.method,
-		opInfo.path,
 	).WithSources(baseSource, revisionSource))
 
 	return result
@@ -95,15 +90,10 @@ func checkBodyListOfTypesChange(opInfo opInfo, schemaDiff *diff.SchemaDiff, medi
 	}
 
 	baseSource, revisionSource := SchemaFieldSources(opInfo.operationsSources, opInfo.methodDiff, schemaDiff, "type")
-	result = append(result, NewApiChange(
+	result = append(result, opInfo.NewApiChange(
 		messageId,
-		opInfo.config,
 		args,
 		"",
-		opInfo.operationsSources,
-		opInfo.operation,
-		opInfo.method,
-		opInfo.path,
 	).WithSources(baseSource, revisionSource))
 
 	return result
@@ -133,15 +123,10 @@ func checkParameterListOfTypesChange(opInfo opInfo, paramDiff *diff.ParameterDif
 	}
 
 	baseSource, revisionSource := SchemaFieldSources(opInfo.operationsSources, opInfo.methodDiff, paramDiff.SchemaDiff, "type")
-	result = append(result, NewApiChange(
+	result = append(result, opInfo.NewApiChange(
 		messageId,
-		opInfo.config,
 		args,
 		"",
-		opInfo.operationsSources,
-		opInfo.operation,
-		opInfo.method,
-		opInfo.path,
 	).WithSources(baseSource, revisionSource))
 
 	return result
@@ -172,15 +157,10 @@ func checkParameterPropertyListOfTypesChange(opInfo opInfo, propertyPath string,
 	}
 
 	baseSource, revisionSource := SchemaFieldSources(opInfo.operationsSources, opInfo.methodDiff, propertyDiff, "type")
-	result = append(result, NewApiChange(
+	result = append(result, opInfo.NewApiChange(
 		messageId,
-		opInfo.config,
 		args,
 		"",
-		opInfo.operationsSources,
-		opInfo.operation,
-		opInfo.method,
-		opInfo.path,
 	).WithSources(baseSource, revisionSource))
 
 	return result

--- a/checker/op_info.go
+++ b/checker/op_info.go
@@ -25,6 +25,14 @@ type opInfo struct {
 	methodDiff *diff.MethodDiff
 }
 
+// NewApiChange builds an ApiChange from the operation context carried by o,
+// so a caller supplies only what varies per change (id, args, comment) instead
+// of repeating config/operationsSources/operation/method/path at every call.
+// The caller still chains WithSources / WithDetails as needed.
+func (o opInfo) NewApiChange(id string, args []any, comment string) ApiChange {
+	return NewApiChange(id, o.config, args, comment, o.operationsSources, o.operation, o.method, o.path)
+}
+
 func newOpInfo(config *Config, operation *openapi3.Operation, operationsSources *diff.OperationsSourcesMap, method, path string) opInfo {
 	return opInfo{
 		config:            config,


### PR DESCRIPTION
Resolves the standing `// TODO: use opInfo to simplify the function signature` on `NewApiChange`.

## Problem

`NewApiChange` takes 8 positional args; the last five — `config`, `operationsSources`, `operation`, `method`, `path` — are per-operation context repeated verbatim at every one of ~90 call sites.

## Change

`opInfo` already bundles exactly those five fields (and `#865` moved the diff-helpers onto it). This adds a method:

```go
func (o opInfo) NewApiChange(id string, args []any, comment string) ApiChange
```

and routes the call sites through it so each call states only what varies (`id`, `args`, `comment`), still chaining `WithSources`/`WithDetails` as before:

- Call sites already holding an `opInfo` call `opInfo.NewApiChange(...)`.
- Call sites inside an `OperationsDiff.Modified` loop build the `opInfo` once per operation via `newOpInfoFromDiff` and reuse it (variable named `opInfo`, matching the existing convention).

The free `NewApiChange` stays as the implementation the method delegates to. Call sites whose operation argument isn't the loop's `Revision` (Base-side, `GetOperation` locals, `Operations()` iteration) keep calling it directly — converting those would change which operation backs the change.

## Safety

Purely behavior-preserving. The checker tests assert exact `ApiChange` structs (including `Source` and `Attributes`), and the full suite passes unchanged. Net ~300 fewer lines across 44 files.
