### PR TITLE
refactor(checker): unexport internal-only source/value helpers

### DIFF
--- a/checker/check_api_deprecation.go
+++ b/checker/check_api_deprecation.go
@@ -55,7 +55,7 @@ func APIDeprecationCheck(diffReport *diff.Diff, operationsSources *diff.Operatio
 		}
 		for operation, operationDiff := range pathItem.OperationsDiff.Modified {
 			op := pathItem.Revision.GetOperation(operation)
-			baseSource, revisionSource := OperationFieldSources(operationsSources, operationDiff, "deprecated")
+			baseSource, revisionSource := operationFieldSources(operationsSources, operationDiff, "deprecated")
 
 			if operationDiff.DeprecatedDiff == nil {
 				continue

--- a/checker/check_api_operation_id_updated.go
+++ b/checker/check_api_operation_id_updated.go
@@ -25,7 +25,7 @@ func APIOperationIdUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.O
 				continue
 			}
 
-			baseSource, revisionSource := OperationFieldSources(operationsSources, operationItem, "operationId")
+			baseSource, revisionSource := operationFieldSources(operationsSources, operationItem, "operationId")
 
 			op := pathItem.Base.GetOperation(operation)
 			id := APIOperationIdRemovedId

--- a/checker/check_api_tag_updated.go
+++ b/checker/check_api_tag_updated.go
@@ -27,7 +27,7 @@ func APITagUpdatedCheck(diffReport *diff.Diff, operationsSources *diff.Operation
 				continue
 			}
 
-			baseSource, revisionSource := OperationFieldSources(operationsSources, operationItem, "tags")
+			baseSource, revisionSource := operationFieldSources(operationsSources, operationItem, "tags")
 
 			for _, tag := range operationItem.TagsDiff.Deleted {
 				result = append(result, NewApiChange(

--- a/checker/check_request_parameter_required_value_updated.go
+++ b/checker/check_request_parameter_required_value_updated.go
@@ -32,7 +32,7 @@ func RequestParameterRequiredValueUpdatedCheck(diffReport *diff.Diff, operations
 					if requiredDiff == nil {
 						continue
 					}
-					baseSource, revisionSource := ParameterFieldSources(operationsSources, operationItem, paramItem, "required")
+					baseSource, revisionSource := parameterFieldSources(operationsSources, operationItem, paramItem, "required")
 
 					id := RequestParameterBecomeRequiredId
 

--- a/checker/check_request_parameters_max_items_updated.go
+++ b/checker/check_request_parameters_max_items_updated.go
@@ -46,7 +46,7 @@ func RequestParameterMaxItemsUpdatedCheck(diffReport *diff.Diff, operationsSourc
 					}
 
 					id := RequestParameterMaxItemsDecreasedId
-					if IsIncreasedValue(maxItemsDiff) {
+					if isIncreasedValue(maxItemsDiff) {
 						id = RequestParameterMaxItemsIncreasedId
 					}
 

--- a/checker/check_request_parameters_max_length_updated.go
+++ b/checker/check_request_parameters_max_length_updated.go
@@ -38,7 +38,7 @@ func RequestParameterMaxLengthUpdatedCheck(diffReport *diff.Diff, operationsSour
 					}
 
 					id := RequestParameterMaxLengthDecreasedId
-					if !IsDecreasedValue(maxLengthDiff) {
+					if !isDecreasedValue(maxLengthDiff) {
 						id = RequestParameterMaxLengthIncreasedId
 					}
 

--- a/checker/check_request_parameters_max_updated.go
+++ b/checker/check_request_parameters_max_updated.go
@@ -43,7 +43,7 @@ func RequestParameterMaxUpdatedCheck(diffReport *diff.Diff, operationsSources *d
 							continue
 						}
 						id := entry.decreasedId
-						if !IsDecreasedValue(entry.diff) {
+						if !isDecreasedValue(entry.diff) {
 							id = entry.increasedId
 						}
 						baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, paramDiff.SchemaDiff, entry.field)

--- a/checker/check_request_parameters_min_items_updated.go
+++ b/checker/check_request_parameters_min_items_updated.go
@@ -39,7 +39,7 @@ func RequestParameterMinItemsUpdatedCheck(diffReport *diff.Diff, operationsSourc
 					}
 
 					id := RequestParameterMinItemsIncreasedId
-					if !IsIncreasedValue(minItemsDiff) {
+					if !isIncreasedValue(minItemsDiff) {
 						id = RequestParameterMinItemsDecreasedId
 					}
 

--- a/checker/check_request_parameters_min_length_updated.go
+++ b/checker/check_request_parameters_min_length_updated.go
@@ -39,7 +39,7 @@ func RequestParameterMinLengthUpdatedCheck(diffReport *diff.Diff, operationsSour
 					}
 
 					id := RequestParameterMinLengthIncreasedId
-					if IsDecreasedValue(minLengthDiff) {
+					if isDecreasedValue(minLengthDiff) {
 						id = RequestParameterMinLengthDecreasedId
 					}
 

--- a/checker/check_request_parameters_min_updated.go
+++ b/checker/check_request_parameters_min_updated.go
@@ -43,7 +43,7 @@ func RequestParameterMinUpdatedCheck(diffReport *diff.Diff, operationsSources *d
 							continue
 						}
 						id := entry.increasedId
-						if !IsIncreasedValue(entry.diff) {
+						if !isIncreasedValue(entry.diff) {
 							id = entry.decreasedId
 						}
 						baseSource, revisionSource := SchemaFieldSources(operationsSources, operationItem, paramDiff.SchemaDiff, entry.field)

--- a/checker/check_request_property_contains_updated.go
+++ b/checker/check_request_property_contains_updated.go
@@ -37,11 +37,11 @@ func RequestPropertyContainsUpdatedCheck(diffReport *diff.Diff, operationsSource
 
 		if d := info.schemaDiff.MinContainsDiff; d != nil {
 			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "minContains")
-			if IsIncreasedValue(d) {
+			if isIncreasedValue(d) {
 				result = append(result, info.newChange(RequestBodyMinContainsIncreasedId, []any{d.From, d.To}, "").
 					WithSources(baseSource, revisionSource))
 			}
-			if IsDecreasedValue(d) {
+			if isDecreasedValue(d) {
 				result = append(result, info.newChange(RequestBodyMinContainsDecreasedId, []any{d.From, d.To}, "").
 					WithSources(baseSource, revisionSource))
 			}
@@ -49,11 +49,11 @@ func RequestPropertyContainsUpdatedCheck(diffReport *diff.Diff, operationsSource
 
 		if d := info.schemaDiff.MaxContainsDiff; d != nil {
 			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "maxContains")
-			if IsIncreasedValue(d) {
+			if isIncreasedValue(d) {
 				result = append(result, info.newChange(RequestBodyMaxContainsIncreasedId, []any{d.From, d.To}, "").
 					WithSources(baseSource, revisionSource))
 			}
-			if IsDecreasedValue(d) {
+			if isDecreasedValue(d) {
 				result = append(result, info.newChange(RequestBodyMaxContainsDecreasedId, []any{d.From, d.To}, "").
 					WithSources(baseSource, revisionSource))
 			}
@@ -76,11 +76,11 @@ func RequestPropertyContainsUpdatedCheck(diffReport *diff.Diff, operationsSource
 
 			if d := p.propertyDiff.MinContainsDiff; d != nil {
 				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "minContains")
-				if IsIncreasedValue(d) {
+				if isIncreasedValue(d) {
 					result = append(result, p.newChange(RequestPropertyMinContainsIncreasedId, []any{propName, d.From, d.To}, "").
 						WithSources(propBaseSource, propRevisionSource))
 				}
-				if IsDecreasedValue(d) {
+				if isDecreasedValue(d) {
 					result = append(result, p.newChange(RequestPropertyMinContainsDecreasedId, []any{propName, d.From, d.To}, "").
 						WithSources(propBaseSource, propRevisionSource))
 				}
@@ -88,11 +88,11 @@ func RequestPropertyContainsUpdatedCheck(diffReport *diff.Diff, operationsSource
 
 			if d := p.propertyDiff.MaxContainsDiff; d != nil {
 				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "maxContains")
-				if IsIncreasedValue(d) {
+				if isIncreasedValue(d) {
 					result = append(result, p.newChange(RequestPropertyMaxContainsIncreasedId, []any{propName, d.From, d.To}, "").
 						WithSources(propBaseSource, propRevisionSource))
 				}
-				if IsDecreasedValue(d) {
+				if isDecreasedValue(d) {
 					result = append(result, p.newChange(RequestPropertyMaxContainsDecreasedId, []any{propName, d.From, d.To}, "").
 						WithSources(propBaseSource, propRevisionSource))
 				}

--- a/checker/check_request_property_dependent_schemas_updated.go
+++ b/checker/check_request_property_dependent_schemas_updated.go
@@ -18,12 +18,12 @@ func RequestPropertyDependentSchemasUpdatedCheck(diffReport *diff.Diff, operatio
 		if info.schemaDiff.DependentSchemasDiff != nil {
 			depSchemasDiff := info.schemaDiff.DependentSchemasDiff
 			for _, name := range depSchemasDiff.Added {
-				revisionSource := SchemaMapItemSource(operationsSources, info.operationItem.Revision, depSchemasDiff.Revision, name)
+				revisionSource := schemaMapItemSource(operationsSources, info.operationItem.Revision, depSchemasDiff.Revision, name)
 				result = append(result, info.newChange(RequestBodyDependentSchemaAddedId, []any{name}, "").
 					WithSources(nil, revisionSource))
 			}
 			for _, name := range depSchemasDiff.Deleted {
-				baseSource := SchemaMapItemSource(operationsSources, info.operationItem.Base, depSchemasDiff.Base, name)
+				baseSource := schemaMapItemSource(operationsSources, info.operationItem.Base, depSchemasDiff.Base, name)
 				result = append(result, info.newChange(RequestBodyDependentSchemaRemovedId, []any{name}, "").
 					WithSources(baseSource, nil))
 			}
@@ -36,12 +36,12 @@ func RequestPropertyDependentSchemasUpdatedCheck(diffReport *diff.Diff, operatio
 			propName := propertyFullName(p.propertyPath, p.propertyName)
 			depSchemasDiff := p.propertyDiff.DependentSchemasDiff
 			for _, name := range depSchemasDiff.Added {
-				revisionSource := SchemaMapItemSource(operationsSources, info.operationItem.Revision, depSchemasDiff.Revision, name)
+				revisionSource := schemaMapItemSource(operationsSources, info.operationItem.Revision, depSchemasDiff.Revision, name)
 				result = append(result, p.newChange(RequestPropertyDependentSchemaAddedId, []any{name, propName}, "").
 					WithSources(nil, revisionSource))
 			}
 			for _, name := range depSchemasDiff.Deleted {
-				baseSource := SchemaMapItemSource(operationsSources, info.operationItem.Base, depSchemasDiff.Base, name)
+				baseSource := schemaMapItemSource(operationsSources, info.operationItem.Base, depSchemasDiff.Base, name)
 				result = append(result, p.newChange(RequestPropertyDependentSchemaRemovedId, []any{name, propName}, "").
 					WithSources(baseSource, nil))
 			}

--- a/checker/check_request_property_max_length_updated.go
+++ b/checker/check_request_property_max_length_updated.go
@@ -20,7 +20,7 @@ func RequestPropertyMaxLengthUpdatedCheck(diffReport *diff.Diff, operationsSourc
 		if maxLengthDiff := info.schemaDiff.MaxLengthDiff; maxLengthDiff != nil &&
 			maxLengthDiff.From != nil &&
 			maxLengthDiff.To != nil {
-			if IsDecreasedValue(maxLengthDiff) {
+			if isDecreasedValue(maxLengthDiff) {
 				result = append(result, info.newChange(
 					RequestBodyMaxLengthDecreasedId,
 					[]any{maxLengthDiff.To},
@@ -48,7 +48,7 @@ func RequestPropertyMaxLengthUpdatedCheck(diffReport *diff.Diff, operationsSourc
 			propName := propertyFullName(p.propertyPath, p.propertyName)
 			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "maxLength")
 
-			if IsDecreasedValue(maxLengthDiff) {
+			if isDecreasedValue(maxLengthDiff) {
 
 				id := RequestPropertyMaxLengthDecreasedId
 

--- a/checker/check_request_property_max_updated.go
+++ b/checker/check_request_property_max_updated.go
@@ -24,7 +24,7 @@ func RequestPropertyMaxDecreasedCheck(diffReport *diff.Diff, operationsSources *
 		if maxDiff := info.schemaDiff.MaxDiff; maxDiff != nil &&
 			maxDiff.From != nil && maxDiff.To != nil {
 			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "maximum")
-			if IsDecreasedValue(maxDiff) {
+			if isDecreasedValue(maxDiff) {
 				result = append(result, info.newChange(
 					RequestBodyMaxDecreasedId,
 					[]any{maxDiff.To},
@@ -41,7 +41,7 @@ func RequestPropertyMaxDecreasedCheck(diffReport *diff.Diff, operationsSources *
 		if exMaxDiff := info.schemaDiff.ExclusiveMaxDiff; exMaxDiff != nil &&
 			exMaxDiff.From != nil && exMaxDiff.To != nil {
 			exBaseSource, exRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "exclusiveMaximum")
-			if IsDecreasedValue(exMaxDiff) {
+			if isDecreasedValue(exMaxDiff) {
 				result = append(result, info.newChange(
 					RequestBodyExclusiveMaxDecreasedId,
 					[]any{exMaxDiff.To},
@@ -62,7 +62,7 @@ func RequestPropertyMaxDecreasedCheck(diffReport *diff.Diff, operationsSources *
 			if maxDiff := p.propertyDiff.MaxDiff; maxDiff != nil &&
 				maxDiff.From != nil && maxDiff.To != nil {
 				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "maximum")
-				if IsDecreasedValue(maxDiff) {
+				if isDecreasedValue(maxDiff) {
 					id := RequestPropertyMaxDecreasedId
 					if p.propertyDiff.Revision.ReadOnly {
 						id = RequestReadOnlyPropertyMaxDecreasedId
@@ -84,7 +84,7 @@ func RequestPropertyMaxDecreasedCheck(diffReport *diff.Diff, operationsSources *
 			if exMaxDiff := p.propertyDiff.ExclusiveMaxDiff; exMaxDiff != nil &&
 				exMaxDiff.From != nil && exMaxDiff.To != nil {
 				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "exclusiveMaximum")
-				if IsDecreasedValue(exMaxDiff) {
+				if isDecreasedValue(exMaxDiff) {
 					id := RequestPropertyExclusiveMaxDecreasedId
 					if p.propertyDiff.Revision.ReadOnly {
 						id = RequestReadOnlyPropertyExclusiveMaxDecreasedId

--- a/checker/check_request_property_min_items_increased.go
+++ b/checker/check_request_property_min_items_increased.go
@@ -14,7 +14,7 @@ func RequestPropertyMinItemsIncreasedCheck(diffReport *diff.Diff, operationsSour
 
 	walkModifiedRequestBodySchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
 		if minItemsDiff := info.schemaDiff.MinItemsDiff; minItemsDiff != nil &&
-			minItemsDiff.From != nil && minItemsDiff.To != nil && IsIncreasedValue(minItemsDiff) {
+			minItemsDiff.From != nil && minItemsDiff.To != nil && isIncreasedValue(minItemsDiff) {
 			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "minItems")
 			result = append(result, info.newChange(
 				RequestBodyMinItemsIncreasedId,
@@ -31,7 +31,7 @@ func RequestPropertyMinItemsIncreasedCheck(diffReport *diff.Diff, operationsSour
 			if p.propertyDiff.Revision.ReadOnly {
 				return
 			}
-			if !IsIncreasedValue(minItemsDiff) {
+			if !isIncreasedValue(minItemsDiff) {
 				return
 			}
 

--- a/checker/check_request_property_min_length_updated.go
+++ b/checker/check_request_property_min_length_updated.go
@@ -19,7 +19,7 @@ func RequestPropertyMinLengthUpdatedCheck(diffReport *diff.Diff, operationsSourc
 			minLengthDiff.From != nil && minLengthDiff.To != nil {
 			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "minLength")
 			id := RequestBodyMinLengthDecreasedId
-			if IsIncreasedValue(minLengthDiff) {
+			if isIncreasedValue(minLengthDiff) {
 				id = RequestBodyMinLengthIncreasedId
 			}
 			result = append(result, info.newChange(
@@ -38,7 +38,7 @@ func RequestPropertyMinLengthUpdatedCheck(diffReport *diff.Diff, operationsSourc
 			propName := propertyFullName(p.propertyPath, p.propertyName)
 			propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "minLength")
 			id := RequestPropertyMinLengthIncreasedId
-			if IsDecreasedValue(minLengthDiff) {
+			if isDecreasedValue(minLengthDiff) {
 				id = RequestPropertyMinLengthDecreasedId
 			}
 			result = append(result, p.newChange(

--- a/checker/check_request_property_min_updated.go
+++ b/checker/check_request_property_min_updated.go
@@ -24,7 +24,7 @@ func RequestPropertyMinIncreasedCheck(diffReport *diff.Diff, operationsSources *
 		if minDiff := info.schemaDiff.MinDiff; minDiff != nil &&
 			minDiff.From != nil && minDiff.To != nil {
 			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "minimum")
-			if IsIncreasedValue(minDiff) {
+			if isIncreasedValue(minDiff) {
 				result = append(result, info.newChange(
 					RequestBodyMinIncreasedId,
 					[]any{minDiff.To},
@@ -41,7 +41,7 @@ func RequestPropertyMinIncreasedCheck(diffReport *diff.Diff, operationsSources *
 		if exMinDiff := info.schemaDiff.ExclusiveMinDiff; exMinDiff != nil &&
 			exMinDiff.From != nil && exMinDiff.To != nil {
 			exBaseSource, exRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "exclusiveMinimum")
-			if IsIncreasedValue(exMinDiff) {
+			if isIncreasedValue(exMinDiff) {
 				result = append(result, info.newChange(
 					RequestBodyExclusiveMinIncreasedId,
 					[]any{exMinDiff.To},
@@ -62,7 +62,7 @@ func RequestPropertyMinIncreasedCheck(diffReport *diff.Diff, operationsSources *
 			if minDiff := p.propertyDiff.MinDiff; minDiff != nil &&
 				minDiff.From != nil && minDiff.To != nil {
 				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "minimum")
-				if IsIncreasedValue(minDiff) {
+				if isIncreasedValue(minDiff) {
 					id := RequestPropertyMinIncreasedId
 					if p.propertyDiff.Revision.ReadOnly {
 						id = RequestReadOnlyPropertyMinIncreasedId
@@ -84,7 +84,7 @@ func RequestPropertyMinIncreasedCheck(diffReport *diff.Diff, operationsSources *
 			if exMinDiff := p.propertyDiff.ExclusiveMinDiff; exMinDiff != nil &&
 				exMinDiff.From != nil && exMinDiff.To != nil {
 				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "exclusiveMinimum")
-				if IsIncreasedValue(exMinDiff) {
+				if isIncreasedValue(exMinDiff) {
 					id := RequestPropertyExclusiveMinIncreasedId
 					if p.propertyDiff.Revision.ReadOnly {
 						id = RequestReadOnlyPropertyExclusiveMinIncreasedId

--- a/checker/check_request_property_pattern_properties_updated.go
+++ b/checker/check_request_property_pattern_properties_updated.go
@@ -18,12 +18,12 @@ func RequestPropertyPatternPropertiesUpdatedCheck(diffReport *diff.Diff, operati
 		if info.schemaDiff.PatternPropertiesDiff != nil {
 			patPropsDiff := info.schemaDiff.PatternPropertiesDiff
 			for _, pattern := range patPropsDiff.Added {
-				revisionSource := SchemaMapItemSource(operationsSources, info.operationItem.Revision, patPropsDiff.Revision, pattern)
+				revisionSource := schemaMapItemSource(operationsSources, info.operationItem.Revision, patPropsDiff.Revision, pattern)
 				result = append(result, info.newChange(RequestBodyPatternPropertyAddedId, []any{pattern}, "").
 					WithSources(nil, revisionSource))
 			}
 			for _, pattern := range patPropsDiff.Deleted {
-				baseSource := SchemaMapItemSource(operationsSources, info.operationItem.Base, patPropsDiff.Base, pattern)
+				baseSource := schemaMapItemSource(operationsSources, info.operationItem.Base, patPropsDiff.Base, pattern)
 				result = append(result, info.newChange(RequestBodyPatternPropertyRemovedId, []any{pattern}, "").
 					WithSources(baseSource, nil))
 			}
@@ -36,12 +36,12 @@ func RequestPropertyPatternPropertiesUpdatedCheck(diffReport *diff.Diff, operati
 			propName := propertyFullName(p.propertyPath, p.propertyName)
 			patPropsDiff := p.propertyDiff.PatternPropertiesDiff
 			for _, pattern := range patPropsDiff.Added {
-				revisionSource := SchemaMapItemSource(operationsSources, info.operationItem.Revision, patPropsDiff.Revision, pattern)
+				revisionSource := schemaMapItemSource(operationsSources, info.operationItem.Revision, patPropsDiff.Revision, pattern)
 				result = append(result, p.newChange(RequestPropertyPatternPropertyAddedId, []any{pattern, propName}, "").
 					WithSources(nil, revisionSource))
 			}
 			for _, pattern := range patPropsDiff.Deleted {
-				baseSource := SchemaMapItemSource(operationsSources, info.operationItem.Base, patPropsDiff.Base, pattern)
+				baseSource := schemaMapItemSource(operationsSources, info.operationItem.Base, patPropsDiff.Base, pattern)
 				result = append(result, p.newChange(RequestPropertyPatternPropertyRemovedId, []any{pattern, propName}, "").
 					WithSources(baseSource, nil))
 			}

--- a/checker/check_response_property_contains_updated.go
+++ b/checker/check_response_property_contains_updated.go
@@ -37,11 +37,11 @@ func ResponsePropertyContainsUpdatedCheck(diffReport *diff.Diff, operationsSourc
 
 		if d := info.schemaDiff.MinContainsDiff; d != nil {
 			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "minContains")
-			if IsIncreasedValue(d) {
+			if isIncreasedValue(d) {
 				result = append(result, info.newChange(ResponseBodyMinContainsIncreasedId, []any{d.From, d.To, info.responseStatus}, "").
 					WithSources(baseSource, revisionSource))
 			}
-			if IsDecreasedValue(d) {
+			if isDecreasedValue(d) {
 				result = append(result, info.newChange(ResponseBodyMinContainsDecreasedId, []any{d.From, d.To, info.responseStatus}, "").
 					WithSources(baseSource, revisionSource))
 			}
@@ -49,11 +49,11 @@ func ResponsePropertyContainsUpdatedCheck(diffReport *diff.Diff, operationsSourc
 
 		if d := info.schemaDiff.MaxContainsDiff; d != nil {
 			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "maxContains")
-			if IsIncreasedValue(d) {
+			if isIncreasedValue(d) {
 				result = append(result, info.newChange(ResponseBodyMaxContainsIncreasedId, []any{d.From, d.To, info.responseStatus}, "").
 					WithSources(baseSource, revisionSource))
 			}
-			if IsDecreasedValue(d) {
+			if isDecreasedValue(d) {
 				result = append(result, info.newChange(ResponseBodyMaxContainsDecreasedId, []any{d.From, d.To, info.responseStatus}, "").
 					WithSources(baseSource, revisionSource))
 			}
@@ -76,11 +76,11 @@ func ResponsePropertyContainsUpdatedCheck(diffReport *diff.Diff, operationsSourc
 
 			if d := p.propertyDiff.MinContainsDiff; d != nil {
 				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "minContains")
-				if IsIncreasedValue(d) {
+				if isIncreasedValue(d) {
 					result = append(result, p.newChange(ResponsePropertyMinContainsIncreasedId, []any{propName, d.From, d.To, info.responseStatus}, "").
 						WithSources(propBaseSource, propRevisionSource))
 				}
-				if IsDecreasedValue(d) {
+				if isDecreasedValue(d) {
 					result = append(result, p.newChange(ResponsePropertyMinContainsDecreasedId, []any{propName, d.From, d.To, info.responseStatus}, "").
 						WithSources(propBaseSource, propRevisionSource))
 				}
@@ -88,11 +88,11 @@ func ResponsePropertyContainsUpdatedCheck(diffReport *diff.Diff, operationsSourc
 
 			if d := p.propertyDiff.MaxContainsDiff; d != nil {
 				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "maxContains")
-				if IsIncreasedValue(d) {
+				if isIncreasedValue(d) {
 					result = append(result, p.newChange(ResponsePropertyMaxContainsIncreasedId, []any{propName, d.From, d.To, info.responseStatus}, "").
 						WithSources(propBaseSource, propRevisionSource))
 				}
-				if IsDecreasedValue(d) {
+				if isDecreasedValue(d) {
 					result = append(result, p.newChange(ResponsePropertyMaxContainsDecreasedId, []any{propName, d.From, d.To, info.responseStatus}, "").
 						WithSources(propBaseSource, propRevisionSource))
 				}

--- a/checker/check_response_property_dependent_schemas_updated.go
+++ b/checker/check_response_property_dependent_schemas_updated.go
@@ -18,12 +18,12 @@ func ResponsePropertyDependentSchemasUpdatedCheck(diffReport *diff.Diff, operati
 		if info.schemaDiff.DependentSchemasDiff != nil {
 			depSchemasDiff := info.schemaDiff.DependentSchemasDiff
 			for _, name := range depSchemasDiff.Added {
-				revisionSource := SchemaMapItemSource(operationsSources, info.operationItem.Revision, depSchemasDiff.Revision, name)
+				revisionSource := schemaMapItemSource(operationsSources, info.operationItem.Revision, depSchemasDiff.Revision, name)
 				result = append(result, info.newChange(ResponseBodyDependentSchemaAddedId, []any{name, info.responseStatus}, "").
 					WithSources(nil, revisionSource))
 			}
 			for _, name := range depSchemasDiff.Deleted {
-				baseSource := SchemaMapItemSource(operationsSources, info.operationItem.Base, depSchemasDiff.Base, name)
+				baseSource := schemaMapItemSource(operationsSources, info.operationItem.Base, depSchemasDiff.Base, name)
 				result = append(result, info.newChange(ResponseBodyDependentSchemaRemovedId, []any{name, info.responseStatus}, "").
 					WithSources(baseSource, nil))
 			}
@@ -36,12 +36,12 @@ func ResponsePropertyDependentSchemasUpdatedCheck(diffReport *diff.Diff, operati
 			propName := propertyFullName(p.propertyPath, p.propertyName)
 			depSchemasDiff := p.propertyDiff.DependentSchemasDiff
 			for _, name := range depSchemasDiff.Added {
-				revisionSource := SchemaMapItemSource(operationsSources, info.operationItem.Revision, depSchemasDiff.Revision, name)
+				revisionSource := schemaMapItemSource(operationsSources, info.operationItem.Revision, depSchemasDiff.Revision, name)
 				result = append(result, p.newChange(ResponsePropertyDependentSchemaAddedId, []any{name, propName, info.responseStatus}, "").
 					WithSources(nil, revisionSource))
 			}
 			for _, name := range depSchemasDiff.Deleted {
-				baseSource := SchemaMapItemSource(operationsSources, info.operationItem.Base, depSchemasDiff.Base, name)
+				baseSource := schemaMapItemSource(operationsSources, info.operationItem.Base, depSchemasDiff.Base, name)
 				result = append(result, p.newChange(ResponsePropertyDependentSchemaRemovedId, []any{name, propName, info.responseStatus}, "").
 					WithSources(baseSource, nil))
 			}

--- a/checker/check_response_property_max_increased.go
+++ b/checker/check_response_property_max_increased.go
@@ -16,7 +16,7 @@ func ResponsePropertyMaxIncreasedCheck(diffReport *diff.Diff, operationsSources 
 
 	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
 		if maxDiff := info.schemaDiff.MaxDiff; maxDiff != nil &&
-			maxDiff.From != nil && maxDiff.To != nil && IsIncreasedValue(maxDiff) {
+			maxDiff.From != nil && maxDiff.To != nil && isIncreasedValue(maxDiff) {
 			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "maximum")
 			result = append(result, info.newChange(
 				ResponseBodyMaxIncreasedId,
@@ -25,7 +25,7 @@ func ResponsePropertyMaxIncreasedCheck(diffReport *diff.Diff, operationsSources 
 			).WithSources(baseSource, revisionSource))
 		}
 		if exMaxDiff := info.schemaDiff.ExclusiveMaxDiff; exMaxDiff != nil &&
-			exMaxDiff.From != nil && exMaxDiff.To != nil && IsIncreasedValue(exMaxDiff) {
+			exMaxDiff.From != nil && exMaxDiff.To != nil && isIncreasedValue(exMaxDiff) {
 			exBaseSource, exRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "exclusiveMaximum")
 			result = append(result, info.newChange(
 				ResponseBodyExclusiveMaxIncreasedId,
@@ -41,7 +41,7 @@ func ResponsePropertyMaxIncreasedCheck(diffReport *diff.Diff, operationsSources 
 			propName := propertyFullName(p.propertyPath, p.propertyName)
 
 			if maxDiff := p.propertyDiff.MaxDiff; maxDiff != nil &&
-				maxDiff.To != nil && maxDiff.From != nil && IsIncreasedValue(maxDiff) {
+				maxDiff.To != nil && maxDiff.From != nil && isIncreasedValue(maxDiff) {
 				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "maximum")
 				result = append(result, p.newChange(
 					ResponsePropertyMaxIncreasedId,
@@ -51,7 +51,7 @@ func ResponsePropertyMaxIncreasedCheck(diffReport *diff.Diff, operationsSources 
 			}
 
 			if exMaxDiff := p.propertyDiff.ExclusiveMaxDiff; exMaxDiff != nil &&
-				exMaxDiff.To != nil && exMaxDiff.From != nil && IsIncreasedValue(exMaxDiff) {
+				exMaxDiff.To != nil && exMaxDiff.From != nil && isIncreasedValue(exMaxDiff) {
 				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "exclusiveMaximum")
 				result = append(result, p.newChange(
 					ResponsePropertyExclusiveMaxIncreasedId,

--- a/checker/check_response_property_max_length_increased.go
+++ b/checker/check_response_property_max_length_increased.go
@@ -16,7 +16,7 @@ func ResponsePropertyMaxLengthIncreasedCheck(diffReport *diff.Diff, operationsSo
 		if maxLengthDiff := info.schemaDiff.MaxLengthDiff; maxLengthDiff != nil &&
 			maxLengthDiff.From != nil &&
 			maxLengthDiff.To != nil &&
-			IsIncreasedValue(maxLengthDiff) {
+			isIncreasedValue(maxLengthDiff) {
 			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "maxLength")
 			result = append(result, info.newChange(
 				ResponseBodyMaxLengthIncreasedId,
@@ -34,7 +34,7 @@ func ResponsePropertyMaxLengthIncreasedCheck(diffReport *diff.Diff, operationsSo
 				maxLengthDiff.From == nil {
 				return
 			}
-			if !IsIncreasedValue(maxLengthDiff) {
+			if !isIncreasedValue(maxLengthDiff) {
 				return
 			}
 

--- a/checker/check_response_property_min_decreased.go
+++ b/checker/check_response_property_min_decreased.go
@@ -16,7 +16,7 @@ func ResponsePropertyMinDecreasedCheck(diffReport *diff.Diff, operationsSources 
 
 	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
 		if minDiff := info.schemaDiff.MinDiff; minDiff != nil &&
-			minDiff.From != nil && minDiff.To != nil && IsDecreasedValue(minDiff) {
+			minDiff.From != nil && minDiff.To != nil && isDecreasedValue(minDiff) {
 			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "minimum")
 			result = append(result, info.newChange(
 				ResponseBodyMinDecreasedId,
@@ -25,7 +25,7 @@ func ResponsePropertyMinDecreasedCheck(diffReport *diff.Diff, operationsSources 
 			).WithSources(baseSource, revisionSource))
 		}
 		if exMinDiff := info.schemaDiff.ExclusiveMinDiff; exMinDiff != nil &&
-			exMinDiff.From != nil && exMinDiff.To != nil && IsDecreasedValue(exMinDiff) {
+			exMinDiff.From != nil && exMinDiff.To != nil && isDecreasedValue(exMinDiff) {
 			exBaseSource, exRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "exclusiveMinimum")
 			result = append(result, info.newChange(
 				ResponseBodyExclusiveMinDecreasedId,
@@ -41,7 +41,7 @@ func ResponsePropertyMinDecreasedCheck(diffReport *diff.Diff, operationsSources 
 			propName := propertyFullName(p.propertyPath, p.propertyName)
 
 			if minDiff := p.propertyDiff.MinDiff; minDiff != nil &&
-				minDiff.To != nil && minDiff.From != nil && IsDecreasedValue(minDiff) {
+				minDiff.To != nil && minDiff.From != nil && isDecreasedValue(minDiff) {
 				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "minimum")
 				result = append(result, p.newChange(
 					ResponsePropertyMinDecreasedId,
@@ -51,7 +51,7 @@ func ResponsePropertyMinDecreasedCheck(diffReport *diff.Diff, operationsSources 
 			}
 
 			if exMinDiff := p.propertyDiff.ExclusiveMinDiff; exMinDiff != nil &&
-				exMinDiff.To != nil && exMinDiff.From != nil && IsDecreasedValue(exMinDiff) {
+				exMinDiff.To != nil && exMinDiff.From != nil && isDecreasedValue(exMinDiff) {
 				propBaseSource, propRevisionSource := SchemaFieldSources(operationsSources, info.operationItem, p.propertyDiff, "exclusiveMinimum")
 				result = append(result, p.newChange(
 					ResponsePropertyExclusiveMinDecreasedId,

--- a/checker/check_response_property_min_items_decreased.go
+++ b/checker/check_response_property_min_items_decreased.go
@@ -14,7 +14,7 @@ func ResponsePropertyMinItemsDecreasedCheck(diffReport *diff.Diff, operationsSou
 
 	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
 		if minItemsDiff := info.schemaDiff.MinItemsDiff; minItemsDiff != nil &&
-			minItemsDiff.From != nil && minItemsDiff.To != nil && IsDecreasedValue(minItemsDiff) {
+			minItemsDiff.From != nil && minItemsDiff.To != nil && isDecreasedValue(minItemsDiff) {
 			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "minItems")
 			result = append(result, info.newChange(
 				ResponseBodyMinItemsDecreasedId,
@@ -28,7 +28,7 @@ func ResponsePropertyMinItemsDecreasedCheck(diffReport *diff.Diff, operationsSou
 			if minItemsDiff == nil || minItemsDiff.To == nil || minItemsDiff.From == nil {
 				return
 			}
-			if !IsDecreasedValue(minItemsDiff) {
+			if !isDecreasedValue(minItemsDiff) {
 				return
 			}
 			if p.propertyDiff.Revision.WriteOnly {

--- a/checker/check_response_property_min_length_decreased.go
+++ b/checker/check_response_property_min_length_decreased.go
@@ -14,7 +14,7 @@ func ResponsePropertyMinLengthDecreasedCheck(diffReport *diff.Diff, operationsSo
 
 	walkModifiedResponseSchemas(diffReport, operationsSources, config, func(info mediaTypeInfo) {
 		if minLengthDiff := info.schemaDiff.MinLengthDiff; minLengthDiff != nil &&
-			minLengthDiff.From != nil && minLengthDiff.To != nil && IsDecreasedValue(minLengthDiff) {
+			minLengthDiff.From != nil && minLengthDiff.To != nil && isDecreasedValue(minLengthDiff) {
 			baseSource, revisionSource := SchemaFieldSources(operationsSources, info.operationItem, info.schemaDiff, "minLength")
 			result = append(result, info.newChange(
 				ResponseBodyMinLengthDecreasedId,
@@ -28,7 +28,7 @@ func ResponsePropertyMinLengthDecreasedCheck(diffReport *diff.Diff, operationsSo
 			if minLengthDiff == nil || minLengthDiff.To == nil || minLengthDiff.From == nil {
 				return
 			}
-			if !IsDecreasedValue(minLengthDiff) {
+			if !isDecreasedValue(minLengthDiff) {
 				return
 			}
 			if p.propertyDiff.Revision.WriteOnly {

--- a/checker/check_response_property_pattern_properties_updated.go
+++ b/checker/check_response_property_pattern_properties_updated.go
@@ -18,12 +18,12 @@ func ResponsePropertyPatternPropertiesUpdatedCheck(diffReport *diff.Diff, operat
 		if info.schemaDiff.PatternPropertiesDiff != nil {
 			patPropsDiff := info.schemaDiff.PatternPropertiesDiff
 			for _, pattern := range patPropsDiff.Added {
-				revisionSource := SchemaMapItemSource(operationsSources, info.operationItem.Revision, patPropsDiff.Revision, pattern)
+				revisionSource := schemaMapItemSource(operationsSources, info.operationItem.Revision, patPropsDiff.Revision, pattern)
 				result = append(result, info.newChange(ResponseBodyPatternPropertyAddedId, []any{pattern, info.responseStatus}, "").
 					WithSources(nil, revisionSource))
 			}
 			for _, pattern := range patPropsDiff.Deleted {
-				baseSource := SchemaMapItemSource(operationsSources, info.operationItem.Base, patPropsDiff.Base, pattern)
+				baseSource := schemaMapItemSource(operationsSources, info.operationItem.Base, patPropsDiff.Base, pattern)
 				result = append(result, info.newChange(ResponseBodyPatternPropertyRemovedId, []any{pattern, info.responseStatus}, "").
 					WithSources(baseSource, nil))
 			}
@@ -36,12 +36,12 @@ func ResponsePropertyPatternPropertiesUpdatedCheck(diffReport *diff.Diff, operat
 			propName := propertyFullName(p.propertyPath, p.propertyName)
 			patPropsDiff := p.propertyDiff.PatternPropertiesDiff
 			for _, pattern := range patPropsDiff.Added {
-				revisionSource := SchemaMapItemSource(operationsSources, info.operationItem.Revision, patPropsDiff.Revision, pattern)
+				revisionSource := schemaMapItemSource(operationsSources, info.operationItem.Revision, patPropsDiff.Revision, pattern)
 				result = append(result, p.newChange(ResponsePropertyPatternPropertyAddedId, []any{pattern, propName, info.responseStatus}, "").
 					WithSources(nil, revisionSource))
 			}
 			for _, pattern := range patPropsDiff.Deleted {
-				baseSource := SchemaMapItemSource(operationsSources, info.operationItem.Base, patPropsDiff.Base, pattern)
+				baseSource := schemaMapItemSource(operationsSources, info.operationItem.Base, patPropsDiff.Base, pattern)
 				result = append(result, p.newChange(ResponsePropertyPatternPropertyRemovedId, []any{pattern, propName, info.responseStatus}, "").
 					WithSources(baseSource, nil))
 			}

--- a/checker/checks_utils.go
+++ b/checker/checks_utils.go
@@ -402,11 +402,11 @@ func IsIncreased(from any, to any) bool {
 	return false
 }
 
-func IsIncreasedValue(diff *diff.ValueDiff) bool {
+func isIncreasedValue(diff *diff.ValueDiff) bool {
 	return IsIncreased(diff.From, diff.To)
 }
 
-func IsDecreasedValue(diff *diff.ValueDiff) bool {
+func isDecreasedValue(diff *diff.ValueDiff) bool {
 	return IsDecreased(diff.From, diff.To)
 }
 

--- a/checker/source.go
+++ b/checker/source.go
@@ -113,9 +113,9 @@ func NewSourceFromSequenceItem(operationsSources *diff.OperationsSourcesMap, ope
 	return nil
 }
 
-// OperationFieldSources returns source locations from a specific field within operation Origins.
+// operationFieldSources returns source locations from a specific field within operation Origins.
 // Falls back to operation-level sources when the field is not found in origin data.
-func OperationFieldSources(operationsSources *diff.OperationsSourcesMap, operationItem *diff.MethodDiff, field string) (*Source, *Source) {
+func operationFieldSources(operationsSources *diff.OperationsSourcesMap, operationItem *diff.MethodDiff, field string) (*Source, *Source) {
 	hasOrigin := (operationItem.Base != nil && operationItem.Base.Origin != nil) ||
 		(operationItem.Revision != nil && operationItem.Revision.Origin != nil)
 	if !hasOrigin {
@@ -132,9 +132,9 @@ func OperationFieldSources(operationsSources *diff.OperationsSourcesMap, operati
 	return baseSource, revisionSource
 }
 
-// ParameterFieldSources returns source locations from a specific field within parameter Origins.
+// parameterFieldSources returns source locations from a specific field within parameter Origins.
 // Falls back to parameter-level sources when the field is not found in origin data.
-func ParameterFieldSources(operationsSources *diff.OperationsSourcesMap, operationItem *diff.MethodDiff, paramDiff *diff.ParameterDiff, field string) (*Source, *Source) {
+func parameterFieldSources(operationsSources *diff.OperationsSourcesMap, operationItem *diff.MethodDiff, paramDiff *diff.ParameterDiff, field string) (*Source, *Source) {
 	if paramDiff == nil {
 		return operationSources(operationsSources, operationItem.Base, operationItem.Revision)
 	}
@@ -267,10 +267,10 @@ func SchemaAddedItemSources(operationsSources *diff.OperationsSourcesMap, operat
 	return nil, revisionSource
 }
 
-// SchemaMapItemSource returns the source location for a named schema within a Schemas map
+// schemaMapItemSource returns the source location for a named schema within a Schemas map
 // (e.g., a specific key in dependentSchemas, patternProperties, or properties).
 // It uses the schema's own Origin rather than the parent field's origin.
-func SchemaMapItemSource(operationsSources *diff.OperationsSourcesMap, operation *openapi3.Operation, schemas openapi3.Schemas, name string) *Source {
+func schemaMapItemSource(operationsSources *diff.OperationsSourcesMap, operation *openapi3.Operation, schemas openapi3.Schemas, name string) *Source {
 	if schemas == nil {
 		return nil
 	}


### PR DESCRIPTION
Follow-up to an exported-symbol audit of the `checker` package.

## Why

oasdiff treats its Go package API as a versioned breaking-change surface, so every needlessly-exported symbol is API surface to maintain. These five `checker` funcs are used **only inside the package**: no cross-package use, not referenced from the external `checker_test` package, and not part of the public entry-point API (`CheckBackwardCompatibility`, `NewConfig`, `GetAllRules`, etc.). They're internal source/value-comparison helpers that were exported without need.

## Change (visibility only, no behavior change)

```
OperationFieldSources -> operationFieldSources
ParameterFieldSources -> parameterFieldSources
SchemaMapItemSource   -> schemaMapItemSource
IsDecreasedValue      -> isDecreasedValue
IsIncreasedValue      -> isIncreasedValue
```

Each still has internal callers (the rename just lowercases the identifier and its in-package call sites). `go build`, `go vet`, and the full `go test ./...` pass unchanged.

## Scope note

This is deliberately small. The bulk of `checker`'s large exported surface — the ~125 individual `*Check` funcs and most source helpers — stays exported on purpose: the external `checker_test` package tests them by name (black-box per-check tests). Collapsing that would mean relocating those tests into the package, a separate philosophy decision. `diff`/`formatters` exported types are the machine-output (JSON) contract and are left alone.
