### PR TITLE
feat(checker): point sunset and x-extensible-enum changes at the exact field

### DIFF
--- a/checker/check_api_sunset_changed.go
+++ b/checker/check_api_sunset_changed.go
@@ -26,7 +26,7 @@ func APISunsetChangedCheck(diffReport *diff.Diff, operationsSources *diff.Operat
 		for operation, operationDiff := range pathItem.OperationsDiff.Modified {
 			opRevision := pathItem.Revision.GetOperation(operation)
 			opBase := pathItem.Base.GetOperation(operation)
-			baseSource, revisionSource := operationSources(operationsSources, operationDiff.Base, operationDiff.Revision)
+			baseSource, revisionSource := operationFieldSources(operationsSources, operationDiff, diff.SunsetExtension)
 
 			if !opRevision.Deprecated {
 				continue

--- a/checker/check_api_sunset_changed_test.go
+++ b/checker/check_api_sunset_changed_test.go
@@ -25,6 +25,27 @@ func TestBreaking_SunsetDeletedForDeprecatedEndpoint(t *testing.T) {
 	require.Equal(t, "api sunset date deleted, but deprecated=true kept", requireChange(t, errs, checker.APISunsetDeletedId).GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
+// the sunset change points at the x-sunset field in the base spec
+func TestBreaking_SunsetDeleted_WithSources(t *testing.T) {
+
+	s1, err := open(deprecationFile("deprecated-with-sunset.yaml"), newLoaderWithOriginTracking())
+	require.NoError(t, err)
+
+	s2, err := open(deprecationFile("deprecated-no-sunset.yaml"), newLoaderWithOriginTracking())
+	require.NoError(t, err)
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibility(singleCheckConfig(checker.APISunsetChangedCheck), d, osm)
+	require.Len(t, errs, 1)
+
+	require.Equal(t, checker.APISunsetDeletedId, errs[0].GetId())
+	require.NotEmpty(t, errs[0].GetBaseSource())
+	require.Equal(t, deprecationFile("deprecated-with-sunset.yaml"), errs[0].GetBaseSource().File)
+	require.Equal(t, 13, errs[0].GetBaseSource().Line) // the x-sunset field
+	require.Empty(t, errs[0].GetRevisionSource())
+}
+
 // changing sunset to an earlier date for a deprecated endpoint with a deprecation policy is breaking
 func TestBreaking_SunsetModifiedForDeprecatedEndpoint(t *testing.T) {
 

--- a/checker/check_request_parameter_sunset_changed.go
+++ b/checker/check_request_parameter_sunset_changed.go
@@ -33,7 +33,7 @@ func RequestParameterSunsetChangedCheck(diffReport *diff.Diff, operationsSources
 
 			for paramLocation, paramItems := range operationDiff.ParametersDiff.Modified {
 				for paramName, paramItem := range paramItems {
-					baseSource, revisionSource := ParameterSources(operationsSources, operationDiff, paramItem)
+					baseSource, revisionSource := parameterFieldSources(operationsSources, operationDiff, paramItem, diff.SunsetExtension)
 
 					paramBase := paramItem.Base
 					paramRevision := paramItem.Revision

--- a/checker/check_request_parameter_x_extensible_enum_value_removed.go
+++ b/checker/check_request_parameter_x_extensible_enum_value_removed.go
@@ -31,7 +31,6 @@ func RequestParameterXExtensibleEnumValueRemovedCheck(diffReport *diff.Diff, ope
 					if paramItem.SchemaDiff == nil {
 						continue
 					}
-					baseSource, revisionSource := ParameterSources(operationsSources, operationItem, paramItem)
 					if paramItem.SchemaDiff.ExtensionsDiff == nil {
 						continue
 					}
@@ -68,6 +67,7 @@ func RequestParameterXExtensibleEnumValueRemovedCheck(diffReport *diff.Diff, ope
 					}
 
 					for _, enumVal := range deletedVals {
+						baseSource, revisionSource := SchemaDeletedItemSources(operationsSources, operationItem, paramItem.SchemaDiff, diff.XExtensibleEnumExtension, enumVal)
 						result = append(result, opInfo.NewApiChange(
 							RequestParameterXExtensibleEnumValueRemovedId,
 							[]any{enumVal, paramLocation, paramName},

--- a/checker/check_request_property_x_extensible_enum_value_removed.go
+++ b/checker/check_request_property_x_extensible_enum_value_removed.go
@@ -53,13 +53,13 @@ func RequestPropertyXExtensibleEnumValueRemovedCheck(diffReport *diff.Diff, oper
 			if p.propertyDiff.Revision.ReadOnly {
 				return
 			}
-			propBaseSource, propRevisionSource := SchemaSources(operationsSources, info.operationItem, p.propertyDiff)
 			for _, enumVal := range deletedVals {
+				baseSource, revisionSource := SchemaDeletedItemSources(operationsSources, info.operationItem, p.propertyDiff, diff.XExtensibleEnumExtension, enumVal)
 				result = append(result, p.newChange(
 					RequestPropertyXExtensibleEnumValueRemovedId,
 					[]any{enumVal, propertyFullName(p.propertyPath, p.propertyName)},
 					"",
-				).WithSources(propBaseSource, propRevisionSource))
+				).WithSources(baseSource, revisionSource))
 			}
 		})
 	})

--- a/checker/check_request_property_x_extensible_enum_value_removed_test.go
+++ b/checker/check_request_property_x_extensible_enum_value_removed_test.go
@@ -21,3 +21,22 @@ func TestRequestPropertyXExtensibleEnumValueRemovedCheck(t *testing.T) {
 	errs := checker.CheckBackwardCompatibility(singleCheckConfig(checker.RequestPropertyXExtensibleEnumValueRemovedCheck), d, osm)
 	requireSingleChange(t, errs, checker.RequestPropertyXExtensibleEnumValueRemovedId)
 }
+
+// the change points at the exact removed x-extensible-enum value in the base spec
+func TestRequestPropertyXExtensibleEnumValueRemoved_WithSources(t *testing.T) {
+	s1, err := open("../data/checker/request_property_extensible_enum_base.yaml", newLoaderWithOriginTracking())
+	require.NoError(t, err)
+
+	s2, err := open("../data/checker/request_property_extensible_enum_revision.yaml", newLoaderWithOriginTracking())
+	require.NoError(t, err)
+
+	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	errs := checker.CheckBackwardCompatibility(singleCheckConfig(checker.RequestPropertyXExtensibleEnumValueRemovedCheck), d, osm)
+	requireSingleChange(t, errs, checker.RequestPropertyXExtensibleEnumValueRemovedId)
+
+	require.NotEmpty(t, errs[0].GetBaseSource())
+	require.Equal(t, "../data/checker/request_property_extensible_enum_base.yaml", errs[0].GetBaseSource().File)
+	require.Equal(t, 20, errs[0].GetBaseSource().Line) // the removed "sold" value
+	require.Empty(t, errs[0].GetRevisionSource())
+}


### PR DESCRIPTION
Follow-up to the source-location work: two extension-driven check families were anchoring at the containing element instead of the extension, unlike the stability check (points at `x-stability-level`) and the `enum` check (points at the exact removed value). Origin already captures both at full precision, so this tightens them.

## Changes

- **`x-sunset`**: `api-sunset-*` (`check_api_sunset_changed`) and `request-parameter-sunset-*` now point at the `x-sunset` field via `operationFieldSources` / `parameterFieldSources` with `SunsetExtension`, instead of the operation / parameter.
- **`x-extensible-enum`**: `request-property-x-extensible-enum-value-removed` and `request-parameter-x-extensible-enum-value-removed` now point at the **exact removed value** via `SchemaDeletedItemSources(..., XExtensibleEnumExtension, value)` (origin tracks it as a sequence, exactly like `enum`), instead of the property / parameter.

## Verification

Empirically: a removed `x-extensible-enum` value resolves to its own line; a deleted `x-sunset` resolves to the `x-sunset` line. Added source-tracking tests (`*_WithSources`) for both; `go build`, `go vet`, full `go test ./...` pass.
