### PR TITLE
Add Xquik OpenAPI diff fixture

### DIFF
--- a/data/xquik/base.yaml
+++ b/data/xquik/base.yaml
@@ -1,0 +1,76 @@
+openapi: 3.1.0
+info:
+  title: Xquik API
+  version: "1.0"
+servers:
+  - url: https://xquik.com
+security:
+  - apiKey: []
+paths:
+  /api/v1/x/tweets/search:
+    get:
+      operationId: searchTweets
+      summary: Search X posts
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+      responses:
+        "200":
+          description: Search results
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Tweet"
+components:
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      in: header
+      name: x-api-key
+  schemas:
+    Tweet:
+      type: object
+      required:
+        - id
+        - text
+        - authorHandle
+        - createdAt
+        - publicMetrics
+      properties:
+        id:
+          type: string
+        text:
+          type: string
+        authorHandle:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        publicMetrics:
+          type: object
+          required:
+            - likeCount
+            - replyCount
+          properties:
+            likeCount:
+              type: integer
+              minimum: 0
+            replyCount:
+              type: integer
+              minimum: 0

--- a/data/xquik/revision.yaml
+++ b/data/xquik/revision.yaml
@@ -1,0 +1,80 @@
+openapi: 3.1.0
+info:
+  title: Xquik API
+  version: "1.0"
+servers:
+  - url: https://xquik.com
+security:
+  - apiKey: []
+paths:
+  /api/v1/x/tweets/search:
+    get:
+      operationId: searchTweets
+      summary: Search X posts
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+      responses:
+        "200":
+          description: Search results
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Tweet"
+components:
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      in: header
+      name: x-api-key
+  schemas:
+    Tweet:
+      type: object
+      required:
+        - id
+        - text
+        - authorHandle
+        - createdAt
+        - publicMetrics
+      properties:
+        id:
+          type: string
+        text:
+          type: string
+        authorHandle:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        lang:
+          type: string
+          minLength: 2
+          maxLength: 8
+        publicMetrics:
+          type: object
+          required:
+            - likeCount
+            - replyCount
+          properties:
+            likeCount:
+              type: integer
+              minimum: 0
+            replyCount:
+              type: integer
+              minimum: 0

--- a/diff/xquik_test.go
+++ b/diff/xquik_test.go
@@ -1,0 +1,24 @@
+package diff_test
+
+import (
+	"testing"
+
+	"github.com/oasdiff/oasdiff/diff"
+	"github.com/stretchr/testify/require"
+)
+
+func TestXquikOpenAPI31TweetSchemaPropertyAdded(t *testing.T) {
+	s1 := loadSpec(t, "../data/xquik/base.yaml")
+	s2 := loadSpec(t, "../data/xquik/revision.yaml")
+
+	d, err := diff.Get(diff.NewConfig(), s1, s2)
+	require.NoError(t, err)
+	require.NotNil(t, d)
+	require.NotNil(t, d.ComponentsDiff)
+	require.NotNil(t, d.ComponentsDiff.SchemasDiff)
+
+	tweetDiff := d.ComponentsDiff.SchemasDiff.Modified["Tweet"]
+	require.NotNil(t, tweetDiff)
+	require.NotNil(t, tweetDiff.PropertiesDiff)
+	require.Contains(t, tweetDiff.PropertiesDiff.Added, "lang")
+}


### PR DESCRIPTION
## Summary
- Add compact Xquik OpenAPI 3.1 fixtures for base and revision diff coverage.
- Assert oasdiff reports an added optional Tweet.lang response property.

## Validation
- Focused Go diff test passed locally.
