### PR TITLE
docs: state what changelog, breaking, and diff each cover

### DIFF
--- a/docs/BREAKING-CHANGES.md
+++ b/docs/BREAKING-CHANGES.md
@@ -1,7 +1,7 @@
 # Breaking Changes and Changelog
 As your API evolves, it undergoes changes. Some of these changes may be "breaking" while others are not.  
-The `oasdiff breaking` command displays the breaking changes between OpenAPI specifications.  
-The `oasdiff changelog` command displays all significant changes between OpenAPI specifications, including breaking and non-breaking changes.  
+The `oasdiff breaking` command displays the changes that break existing API clients.  
+The `oasdiff changelog` command displays the changes that can affect API consumers, both breaking and non-breaking. Documentation-only edits, such as descriptions and examples, are not included; use `oasdiff diff` to see every difference in the API definition.  
 These commands are typically used in the CI to report or prevent breaking changes.
 
 > **Note:** `breaking` and `changelog` run on the diff engine described in [DIFF.md](DIFF.md). The flags and concepts there — extension tracking, path matching, `allOf` flattening, the path-prefix family, header case, `--allow-external-refs`, `--fail-on-diff` — apply here too, in addition to the breaking-specific options below.

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ docker run --rm -t tufin/oasdiff changelog \
   https://raw.githubusercontent.com/oasdiff/oasdiff/main/data/openapi-test5.yaml
 ```
 
-That prints a human-readable changelog of every significant change between the two specs. Swap `changelog` for `breaking` to see only breaking changes, or `diff` for the full machine-readable diff.
+That prints a human-readable changelog of the changes that can affect API consumers, breaking and non-breaking. Swap `changelog` for `breaking` to see only the changes that break existing API clients, or `diff` for the full machine-readable diff of the API definition, including documentation-only edits.
 
 ## Installation
 
@@ -63,10 +63,10 @@ Grouped by what you're trying to do. New to oasdiff? Start with **Commands**.
 ### Commands
 The top-level subcommands.
 
-- [`diff`](DIFF.md) — full diff between two OpenAPI specs (output: html, json, markdown, markup, text, or yaml — default yaml)
+- [`diff`](DIFF.md) — full diff of the API definition, including documentation-only edits (output: html, json, markdown, markup, text, or yaml — default yaml)
 - [`summary`](DIFF.md) — high-level count of changes between two specs (built on the diff engine; same shared options)
-- [`breaking`](BREAKING-CHANGES.md) — only breaking changes
-- [`changelog`](BREAKING-CHANGES.md) — every significant change, breaking or not, in human-readable form
+- [`breaking`](BREAKING-CHANGES.md) — only the changes that break existing API clients
+- [`changelog`](BREAKING-CHANGES.md) — changes that can affect API consumers, breaking or not, in human-readable form
 - [`flatten`](ALLOF.md) — replace `allOf` schemas with a merged equivalent
 - [`upgrade`](OPENAPI-31.md#converting-a-spec-with-oasdiff-upgrade) — canonicalize an OpenAPI 3.0 spec to the latest 3.x
 - [`validate`](VALIDATE.md) — check a single spec for per-RFC violations (invalid types, missing required fields, bad regex, unresolved `$ref`s)


### PR DESCRIPTION
The changelog was described as "every significant change" in the README and "all significant changes" in BREAKING-CHANGES.md. Both hide what it excludes: documentation-only edits, such as descriptions and examples, are not reported by any check, so a reader cannot tell when they need `diff` instead.

This names the boundary instead of using adjectives, consistently across the three commands:

- `breaking`: the changes that break existing API clients
- `changelog`: the changes that can affect API consumers, breaking and non-breaking (documentation-only edits are not included)
- `diff`: the full diff of the API definition, including documentation-only edits

"API consumers" (changelog) is deliberately broader than "API clients" (breaking): the checks also cover changes like operationId and deprecation that affect generated SDKs and tooling rather than runtime clients.

Matching wording changes for the action README and the oasdiff.com diff page are in their own PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)