### PR TITLE
fix: construct both sides from one read when base and revision are stdin

### DIFF
--- a/internal/diff.go
+++ b/internal/diff.go
@@ -106,14 +106,18 @@ func normalDiff(loader *openapi3.Loader, flags *Flags) (*diffResult, *ReturnErro
 		return nil, getErrFailedToLoadSpec("base", flags.getBase(), err)
 	}
 
-	s2, err := load.NewSpecInfo(loader, flags.getRevision(), flattenAllOf, flattenParams, lowerHeaderNames)
-	if err != nil {
-		return nil, getErrFailedToLoadSpec("revision", flags.getRevision(), err)
-	}
-
+	var s2 *load.SpecInfo
 	if flags.getBase().IsStdin() && flags.getRevision().IsStdin() {
-		// io.ReadAll can only read stdin once, so in this edge case, we copy base into revision
-		s2.Spec = s1.Spec
+		// Two "-" operands name the same document (as in diff, where both stand
+		// for the same file): stdin cannot be read twice, so the one read
+		// serves both sides.
+		specInfo := *s1
+		s2 = &specInfo
+	} else {
+		s2, err = load.NewSpecInfo(loader, flags.getRevision(), flattenAllOf, flattenParams, lowerHeaderNames)
+		if err != nil {
+			return nil, getErrFailedToLoadSpec("revision", flags.getRevision(), err)
+		}
 	}
 
 	autoUpgradeSpecs(flags.getAutoUpgrade(), s1, s2)

--- a/internal/run_test.go
+++ b/internal/run_test.go
@@ -547,3 +547,23 @@ func Test_Changelog_WithInvalidCustomTemplate(t *testing.T) {
 	require.Equal(t, 105, internal.Run(cmdToArgs("oasdiff changelog ../data/run_test/changelog_base.yaml ../data/run_test/changelog_revision.yaml --format markdown --template /nonexistent/template.md"), io.Discard, &stderr))
 	require.Contains(t, stderr.String(), "failed to load custom template")
 }
+
+// Two "-" operands name the same document (as in diff, where both stand for
+// the same file): the single stdin read serves both sides, and the revision
+// side carries the document's version, not an empty second read's ("n/a").
+func Test_BothSidesStdin(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "openapi.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("openapi: 3.0.0\ninfo: {title: t, version: \"1.2.3\"}\npaths: {}\n"), 0644))
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+	orig := os.Stdin
+	os.Stdin = f
+	t.Cleanup(func() { os.Stdin = orig })
+
+	var stdout bytes.Buffer
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff changelog - - --format html"), &stdout, io.Discard))
+	require.Equal(t, 2, strings.Count(stdout.String(), "1.2.3"), "both sides carry the document's version")
+	require.NotContains(t, stdout.String(), "n/a")
+}


### PR DESCRIPTION
When base and revision are both `-`, the revision was loaded from the already-exhausted stdin and then patched by overwriting its `Spec` pointer with the base's. That left the rest of the revision `SpecInfo` built from the empty read (its version reported `n/a`) and depended on the parser quietly accepting empty input.

This skips the second read instead: two `-` operands name the same document, matching `diff`, where two `-` operands stand for the same file and compare as identical. The single read serves both sides, so the revision side is a fully-constructed `SpecInfo` with a consistent version, and nothing depends on empty-input parsing.

Observable behavior is unchanged: `oasdiff changelog - -` still reports no changes and exits 0. The new test pins the version consistency, which the previous code fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)