### PR TITLE
formatters: carry changelog versions only in HTML and Markup

### DIFF
--- a/formatters/doc.go
+++ b/formatters/doc.go
@@ -11,7 +11,7 @@ and breaking changes in multiple output formats suitable for different use cases
 Get a formatter and render output:
 
 	formatter, err := formatters.Lookup("json", formatters.FormatterOpts{Language: "en"})
-	output, err := formatter.RenderChangelog(changes, formatters.RenderOpts{}, baseVersion, revisionVersion)
+	output, err := formatter.RenderChangelog(changes, formatters.RenderOpts{})
 
 # Available Formats
 

--- a/formatters/format_githubactions.go
+++ b/formatters/format_githubactions.go
@@ -27,7 +27,7 @@ func newGitHubActionsFormatter(l checker.Localizer) GitHubActionsFormatter {
 	}
 }
 
-func (f GitHubActionsFormatter) RenderChangelog(changes checker.Changes, opts RenderOpts, _, _ string) ([]byte, error) {
+func (f GitHubActionsFormatter) RenderChangelog(changes checker.Changes, opts RenderOpts) ([]byte, error) {
 	var buf bytes.Buffer
 
 	// add error, warning and notice count to job output parameters

--- a/formatters/format_githubactions_test.go
+++ b/formatters/format_githubactions_test.go
@@ -34,7 +34,7 @@ func TestGitHubActionsFormatter_RenderChangelog_OneFailure(t *testing.T) {
 	}
 
 	// check output
-	output, err := gitHubFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts(), "", "")
+	output, err := gitHubFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts())
 	assert.NoError(t, err)
 	expectedOutput := "::error title=change_id,file=openapi.yaml::in API GET /api/test This is a breaking change.\n"
 	assert.Equal(t, expectedOutput, string(output))
@@ -66,7 +66,7 @@ func TestGitHubActionsFormatter_RenderChangelog_MultipleLevels(t *testing.T) {
 	}
 
 	// check output
-	output, err := gitHubFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts(), "", "")
+	output, err := gitHubFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts())
 	assert.NoError(t, err)
 	expectedOutput := "::error title=change_id,file=openapi.yaml::in API GET /api/test This is a breaking change.\n::warning title=warning_id,file=openapi.yaml::in API GET /api/test This is a warning.\n::notice title=notice_id,file=openapi.yaml::in API GET /api/test This is a notice.\n"
 	assert.Equal(t, expectedOutput, string(output))
@@ -84,7 +84,7 @@ func TestGitHubActionsFormatter_DontRenderHttpSource(t *testing.T) {
 	}
 
 	// check output
-	output, err := gitHubFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts(), "", "")
+	output, err := gitHubFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts())
 	assert.NoError(t, err)
 	expectedOutput := "::error title=change_id::in API GET /api/test This is a breaking change.\n"
 	assert.Equal(t, expectedOutput, string(output))
@@ -102,7 +102,7 @@ func TestGitHubActionsFormatter_RenderChangelog_MultilineText(t *testing.T) {
 	}
 
 	// check output
-	output, err := gitHubFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts(), "", "")
+	output, err := gitHubFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts())
 	assert.NoError(t, err)
 	expectedOutput := "::error title=change_two_lines_id,file=openapi.yaml::in API GET /api/test This is a breaking change.%0AThis is a second line.\n"
 	assert.Equal(t, expectedOutput, string(output))
@@ -127,7 +127,7 @@ func TestGitHubActionsFormatter_RenderChangelog_FileLocation(t *testing.T) {
 	}
 
 	// check output
-	output, err := gitHubFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts(), "", "")
+	output, err := gitHubFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts())
 	assert.NoError(t, err)
 	expectedOutput := "::error title=change_id,file=openapi.json,line=21,col=6::in API GET /api/test This is a breaking change.\n"
 	assert.Equal(t, expectedOutput, string(output))
@@ -172,7 +172,7 @@ func TestGitHubActionsFormatter_RenderChangelog_JobOutputParameters(t *testing.T
 	}
 
 	// check output
-	output, err := gitHubFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts(), "", "")
+	output, err := gitHubFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts())
 	assert.NoError(t, err)
 	_ = os.Unsetenv("GITHUB_OUTPUT")
 	expectedOutput := "::error title=change_id,file=openapi.yaml::in API GET /api/test This is a breaking change.\n::error title=change_id,file=openapi.yaml::in API GET /api/test This is a breaking change.\n::warning title=warning_id,file=openapi.yaml::in API GET /api/test This is a warning.\n::notice title=notice_id,file=openapi.yaml::in API GET /api/test This is a notice.\n"
@@ -203,7 +203,7 @@ func TestGitHubActionsFormatter_RenderChangelog_EscapesProperties(t *testing.T) 
 		},
 	}
 
-	output, err := gitHubFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts(), "", "")
+	output, err := gitHubFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts())
 	require.NoError(t, err)
 	expectedOutput := "::error title=change_id,file=main%3Aspec%2Cv2.yaml,line=1,col=1::in API GET /api/test This is a breaking change.\n"
 	assert.Equal(t, expectedOutput, string(output))

--- a/formatters/format_html.go
+++ b/formatters/format_html.go
@@ -23,12 +23,16 @@ type GroupEntry struct {
 
 type HTMLFormatter struct {
 	notImplementedFormatter
-	Localizer checker.Localizer
+	Localizer       checker.Localizer
+	BaseVersion     string
+	RevisionVersion string
 }
 
-func newHTMLFormatter(l checker.Localizer) HTMLFormatter {
+func newHTMLFormatter(l checker.Localizer, baseVersion, revisionVersion string) HTMLFormatter {
 	return HTMLFormatter{
-		Localizer: l,
+		Localizer:       l,
+		BaseVersion:     baseVersion,
+		RevisionVersion: revisionVersion,
 	}
 }
 
@@ -44,7 +48,7 @@ func (f HTMLFormatter) RenderDiff(diff *diff.Diff, opts RenderOpts) ([]byte, err
 //go:embed templates/changelog.html
 var changelogHtml string
 
-func (f HTMLFormatter) RenderChangelog(changes checker.Changes, opts RenderOpts, baseVersion, revisionVersion string) ([]byte, error) {
+func (f HTMLFormatter) RenderChangelog(changes checker.Changes, opts RenderOpts) ([]byte, error) {
 	var tmpl *template.Template
 	var err error
 
@@ -57,7 +61,7 @@ func (f HTMLFormatter) RenderChangelog(changes checker.Changes, opts RenderOpts,
 		tmpl = template.Must(template.New("changelog").Funcs(HtmlTemplateFuncs()).Parse(changelogHtml))
 	}
 
-	return ExecuteHtmlTemplate(tmpl, GroupChanges(changes, f.Localizer), baseVersion, revisionVersion, opts.DiffEmpty, opts.IsBreaking)
+	return ExecuteHtmlTemplate(tmpl, GroupChanges(changes, f.Localizer), f.BaseVersion, f.RevisionVersion, opts.DiffEmpty, opts.IsBreaking)
 }
 
 func (f HTMLFormatter) loadCustomTemplate(templatePath string) (*template.Template, error) {

--- a/formatters/format_html_test.go
+++ b/formatters/format_html_test.go
@@ -60,7 +60,8 @@ func TestHtmlFormatter_RenderChangelog_NoBaseVersion(t *testing.T) {
 		},
 	}
 
-	out, err := htmlFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts(), "", "2.0.0")
+	f := formatters.HTMLFormatter{Localizer: htmlFormatter.Localizer, RevisionVersion: "2.0.0"}
+	out, err := f.RenderChangelog(testChanges, formatters.NewRenderOpts())
 	require.NoError(t, err)
 	require.Contains(t, string(out), "<div class=\"title\">API Changelog </div>")
 }
@@ -75,7 +76,8 @@ func TestHtmlFormatter_RenderChangelog_WithBaseAndRevisionVersion(t *testing.T) 
 		},
 	}
 
-	out, err := htmlFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts(), "1.0.0", "2.0.0")
+	f := formatters.HTMLFormatter{Localizer: htmlFormatter.Localizer, BaseVersion: "1.0.0", RevisionVersion: "2.0.0"}
+	out, err := f.RenderChangelog(testChanges, formatters.NewRenderOpts())
 	require.NoError(t, err)
 	require.Contains(t, string(out), "<div class=\"title\">API Changelog 1.0.0 vs. 2.0.0</div>")
 }
@@ -93,7 +95,7 @@ func TestHtmlFormatter_RenderChangelog_SecurityAndComponentChanges(t *testing.T)
 		},
 	}
 
-	out, err := htmlFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts(), "", "")
+	out, err := htmlFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts())
 	require.NoError(t, err)
 
 	result := string(out)
@@ -152,7 +154,8 @@ func TestHtmlFormatter_RenderChangelog_WithCustomTemplate(t *testing.T) {
 	opts := formatters.NewRenderOpts()
 	opts.TemplatePath = templatePath
 
-	out, err := htmlFormatter.RenderChangelog(testChanges, opts, "1.0.0", "2.0.0")
+	f := formatters.HTMLFormatter{Localizer: htmlFormatter.Localizer, BaseVersion: "1.0.0", RevisionVersion: "2.0.0"}
+	out, err := f.RenderChangelog(testChanges, opts)
 	require.NoError(t, err)
 
 	result := string(out)
@@ -174,7 +177,8 @@ func TestHtmlFormatter_RenderChangelog_CustomTemplateNotFound(t *testing.T) {
 	opts := formatters.NewRenderOpts()
 	opts.TemplatePath = "/nonexistent/template.html"
 
-	_, err := htmlFormatter.RenderChangelog(testChanges, opts, "1.0.0", "2.0.0")
+	f := formatters.HTMLFormatter{Localizer: htmlFormatter.Localizer, BaseVersion: "1.0.0", RevisionVersion: "2.0.0"}
+	_, err := f.RenderChangelog(testChanges, opts)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to load custom template")
 }
@@ -200,7 +204,8 @@ func TestHtmlFormatter_RenderChangelog_InvalidCustomTemplate(t *testing.T) {
 	opts := formatters.NewRenderOpts()
 	opts.TemplatePath = templatePath
 
-	_, err = htmlFormatter.RenderChangelog(testChanges, opts, "1.0.0", "2.0.0")
+	f := formatters.HTMLFormatter{Localizer: htmlFormatter.Localizer, BaseVersion: "1.0.0", RevisionVersion: "2.0.0"}
+	_, err = f.RenderChangelog(testChanges, opts)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to load custom template")
 }

--- a/formatters/format_json.go
+++ b/formatters/format_json.go
@@ -29,7 +29,7 @@ func (f JSONFormatter) RenderSummary(diff *diff.Diff, opts RenderOpts) ([]byte, 
 	return printJSON(diff.GetSummary())
 }
 
-func (f JSONFormatter) RenderChangelog(changes checker.Changes, opts RenderOpts, _, _ string) ([]byte, error) {
+func (f JSONFormatter) RenderChangelog(changes checker.Changes, opts RenderOpts) ([]byte, error) {
 	return printJSON(adaptStructure(NewChanges(changes, f.Localizer), opts))
 }
 

--- a/formatters/format_json_test.go
+++ b/formatters/format_json_test.go
@@ -27,7 +27,7 @@ func TestJsonFormatter_RenderChangelog(t *testing.T) {
 		},
 	}
 
-	out, err := jsonFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts(), "", "")
+	out, err := jsonFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts())
 	require.NoError(t, err)
 	require.Equal(t, "[{\"id\":\"change_id\",\"text\":\"This is a breaking change.\",\"level\":3,\"section\":\"components\",\"fingerprint\":\"f8cd9af6b117\"}]", string(out))
 }
@@ -86,11 +86,11 @@ func TestJsonFormatter_RenderChangelog_WrappedCarriesDiffEmpty(t *testing.T) {
 	// When WrapInObject is set, the JSON wrapper carries diff_empty alongside
 	// the changes list so HTTP consumers can distinguish "specs are identical"
 	// from "specs differ but no rule fired."
-	emptyOut, err := jsonFormatter.RenderChangelog(checker.Changes{}, formatters.RenderOpts{WrapInObject: true, DiffEmpty: true}, "", "")
+	emptyOut, err := jsonFormatter.RenderChangelog(checker.Changes{}, formatters.RenderOpts{WrapInObject: true, DiffEmpty: true})
 	require.NoError(t, err)
 	require.JSONEq(t, `{"changes":[], "diff_empty":true}`, string(emptyOut))
 
-	differOut, err := jsonFormatter.RenderChangelog(checker.Changes{}, formatters.RenderOpts{WrapInObject: true, DiffEmpty: false}, "", "")
+	differOut, err := jsonFormatter.RenderChangelog(checker.Changes{}, formatters.RenderOpts{WrapInObject: true, DiffEmpty: false})
 	require.NoError(t, err)
 	require.JSONEq(t, `{"changes":[], "diff_empty":false}`, string(differOut))
 }
@@ -98,7 +98,7 @@ func TestJsonFormatter_RenderChangelog_WrappedCarriesDiffEmpty(t *testing.T) {
 func TestJsonFormatter_RenderChangelog_BareArrayIgnoresOpts(t *testing.T) {
 	// Without WrapInObject the output is a bare JSON array. DiffEmpty has
 	// nowhere to live and is ignored, preserving the existing CLI shape.
-	out, err := jsonFormatter.RenderChangelog(checker.Changes{}, formatters.RenderOpts{DiffEmpty: false}, "", "")
+	out, err := jsonFormatter.RenderChangelog(checker.Changes{}, formatters.RenderOpts{DiffEmpty: false})
 	require.NoError(t, err)
 	require.Equal(t, "[]", string(out))
 }
@@ -118,7 +118,7 @@ func TestJsonFormatter_RenderChangelog_WithSources(t *testing.T) {
 		},
 	}
 
-	out, err := jsonFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts(), "", "")
+	out, err := jsonFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts())
 	require.NoError(t, err)
 
 	// Parse and check that baseSource is included but revisionSource is not (due to omitempty)

--- a/formatters/format_junit.go
+++ b/formatters/format_junit.go
@@ -46,7 +46,7 @@ func newJUnitFormatter(l checker.Localizer) JUnitFormatter {
 	}
 }
 
-func (f JUnitFormatter) RenderChangelog(changes checker.Changes, opts RenderOpts, _, _ string) ([]byte, error) {
+func (f JUnitFormatter) RenderChangelog(changes checker.Changes, opts RenderOpts) ([]byte, error) {
 	var testSuite = JUnitTestSuite{
 		Package:   "com.oasdiff",
 		Time:      "0",

--- a/formatters/format_junit_test.go
+++ b/formatters/format_junit_test.go
@@ -23,7 +23,7 @@ func TestJUnitFormatter_RenderChangelog_Success(t *testing.T) {
 	testChanges := checker.Changes{}
 
 	// check output
-	output, err := jUnitFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts(), "", "")
+	output, err := jUnitFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts())
 	assert.NoError(t, err)
 	expectedOutput := `<?xml version="1.0" encoding="UTF-8"?>
 <testsuites>

--- a/formatters/format_markup.go
+++ b/formatters/format_markup.go
@@ -15,12 +15,16 @@ import (
 
 type MarkupFormatter struct {
 	notImplementedFormatter
-	Localizer checker.Localizer
+	Localizer       checker.Localizer
+	BaseVersion     string
+	RevisionVersion string
 }
 
-func newMarkupFormatter(l checker.Localizer) MarkupFormatter {
+func newMarkupFormatter(l checker.Localizer, baseVersion, revisionVersion string) MarkupFormatter {
 	return MarkupFormatter{
-		Localizer: l,
+		Localizer:       l,
+		BaseVersion:     baseVersion,
+		RevisionVersion: revisionVersion,
 	}
 }
 
@@ -31,7 +35,7 @@ func (f MarkupFormatter) RenderDiff(diff *diff.Diff, opts RenderOpts) ([]byte, e
 //go:embed templates/changelog.md
 var changelogMarkdown string
 
-func (f MarkupFormatter) RenderChangelog(changes checker.Changes, opts RenderOpts, baseVersion, revisionVersion string) ([]byte, error) {
+func (f MarkupFormatter) RenderChangelog(changes checker.Changes, opts RenderOpts) ([]byte, error) {
 	var tmpl *template.Template
 	var err error
 
@@ -44,7 +48,7 @@ func (f MarkupFormatter) RenderChangelog(changes checker.Changes, opts RenderOpt
 		tmpl = template.Must(template.New("changelog").Funcs(MarkupTemplateFuncs()).Parse(changelogMarkdown))
 	}
 
-	return ExecuteTextTemplate(tmpl, GroupChanges(changes, f.Localizer), baseVersion, revisionVersion, opts.DiffEmpty, opts.IsBreaking)
+	return ExecuteTextTemplate(tmpl, GroupChanges(changes, f.Localizer), f.BaseVersion, f.RevisionVersion, opts.DiffEmpty, opts.IsBreaking)
 }
 
 func (f MarkupFormatter) loadCustomTemplate(templatePath string) (*template.Template, error) {

--- a/formatters/format_markup_test.go
+++ b/formatters/format_markup_test.go
@@ -38,7 +38,7 @@ func TestMarkupFormatter_RenderChangelog_NoVersions(t *testing.T) {
 		},
 	}
 
-	out, err := markupFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts(), "", "")
+	out, err := markupFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts())
 	require.NoError(t, err)
 	require.Contains(t, string(out), "# API Changelog")
 	require.NotContains(t, string(out), "vs.")
@@ -54,7 +54,8 @@ func TestMarkupFormatter_RenderChangelog_NoBaseVersion(t *testing.T) {
 		},
 	}
 
-	out, err := markupFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts(), "", "2.0.0")
+	f := formatters.MarkupFormatter{Localizer: markupFormatter.Localizer, RevisionVersion: "2.0.0"}
+	out, err := f.RenderChangelog(testChanges, formatters.NewRenderOpts())
 	require.NoError(t, err)
 	require.Contains(t, string(out), "# API Changelog")
 	require.NotContains(t, string(out), "vs.")
@@ -70,7 +71,8 @@ func TestMarkupFormatter_RenderChangelog_WithVersions(t *testing.T) {
 		},
 	}
 
-	out, err := markupFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts(), "1.0.0", "2.0.0")
+	f := formatters.MarkupFormatter{Localizer: markupFormatter.Localizer, BaseVersion: "1.0.0", RevisionVersion: "2.0.0"}
+	out, err := f.RenderChangelog(testChanges, formatters.NewRenderOpts())
 	require.NoError(t, err)
 	require.Contains(t, string(out), "# API Changelog 1.0.0 vs. 2.0.0")
 }
@@ -88,7 +90,7 @@ func TestMarkupFormatter_RenderChangelog_SecurityAndComponentChanges(t *testing.
 		},
 	}
 
-	out, err := markupFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts(), "", "")
+	out, err := markupFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts())
 	require.NoError(t, err)
 
 	result := string(out)
@@ -140,7 +142,8 @@ func TestMarkupFormatter_RenderChangelog_WithCustomTemplate(t *testing.T) {
 	opts := formatters.NewRenderOpts()
 	opts.TemplatePath = templatePath
 
-	out, err := markupFormatter.RenderChangelog(testChanges, opts, "1.0.0", "2.0.0")
+	f := formatters.MarkupFormatter{Localizer: markupFormatter.Localizer, BaseVersion: "1.0.0", RevisionVersion: "2.0.0"}
+	out, err := f.RenderChangelog(testChanges, opts)
 	require.NoError(t, err)
 
 	result := string(out)
@@ -162,7 +165,8 @@ func TestMarkupFormatter_RenderChangelog_CustomTemplateNotFound(t *testing.T) {
 	opts := formatters.NewRenderOpts()
 	opts.TemplatePath = "/nonexistent/template.md"
 
-	_, err := markupFormatter.RenderChangelog(testChanges, opts, "1.0.0", "2.0.0")
+	f := formatters.MarkupFormatter{Localizer: markupFormatter.Localizer, BaseVersion: "1.0.0", RevisionVersion: "2.0.0"}
+	_, err := f.RenderChangelog(testChanges, opts)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to load custom template")
 }
@@ -188,7 +192,8 @@ func TestMarkupFormatter_RenderChangelog_InvalidCustomTemplate(t *testing.T) {
 	opts := formatters.NewRenderOpts()
 	opts.TemplatePath = templatePath
 
-	_, err = markupFormatter.RenderChangelog(testChanges, opts, "1.0.0", "2.0.0")
+	f := formatters.MarkupFormatter{Localizer: markupFormatter.Localizer, BaseVersion: "1.0.0", RevisionVersion: "2.0.0"}
+	_, err = f.RenderChangelog(testChanges, opts)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to load custom template")
 }

--- a/formatters/format_singleline.go
+++ b/formatters/format_singleline.go
@@ -18,7 +18,7 @@ func newSingleLineFormatter(l checker.Localizer) SingleLineFormatter {
 	}
 }
 
-func (f SingleLineFormatter) RenderChangelog(changes checker.Changes, opts RenderOpts, _, _ string) ([]byte, error) {
+func (f SingleLineFormatter) RenderChangelog(changes checker.Changes, opts RenderOpts) ([]byte, error) {
 	result := bytes.NewBuffer(nil)
 
 	if len(changes) == 0 {

--- a/formatters/format_singleline_test.go
+++ b/formatters/format_singleline_test.go
@@ -28,20 +28,20 @@ func TestSingleLineFormatter_RenderChangelog(t *testing.T) {
 		},
 	}
 
-	out, err := singleLineFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts(), "", "")
+	out, err := singleLineFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts())
 	require.NoError(t, err)
 	require.Equal(t, "1 changes: 1 error, 0 warning, 0 info\nerror, in components/test This is a breaking change. [change_id]. \n\n", string(out))
 }
 
 func TestSingleLineFormatter_RenderChangelog_EmptyChangesDifferentSpecs(t *testing.T) {
-	out, err := singleLineFormatter.RenderChangelog(checker.Changes{}, formatters.RenderOpts{}, "", "")
+	out, err := singleLineFormatter.RenderChangelog(checker.Changes{}, formatters.RenderOpts{})
 	require.NoError(t, err)
 	// Singleline keeps everything on one line: period separator, no newline.
 	require.Equal(t, "No changes to report, but the specs are different. Run 'oasdiff diff' to see structural differences.", string(out))
 }
 
 func TestSingleLineFormatter_RenderChangelog_EmptyChangesDifferentSpecs_BreakingMode(t *testing.T) {
-	out, err := singleLineFormatter.RenderChangelog(checker.Changes{}, formatters.RenderOpts{IsBreaking: true}, "", "")
+	out, err := singleLineFormatter.RenderChangelog(checker.Changes{}, formatters.RenderOpts{IsBreaking: true})
 	require.NoError(t, err)
 	require.Equal(t, "No breaking changes to report, but the specs are different. Run 'oasdiff diff' to see structural differences.", string(out))
 }

--- a/formatters/format_text.go
+++ b/formatters/format_text.go
@@ -26,7 +26,7 @@ func (f TEXTFormatter) RenderDiff(diff *diff.Diff, opts RenderOpts) ([]byte, err
 	return []byte(report.GetTextReportAsString(diff)), nil
 }
 
-func (f TEXTFormatter) RenderChangelog(changes checker.Changes, opts RenderOpts, _, _ string) ([]byte, error) {
+func (f TEXTFormatter) RenderChangelog(changes checker.Changes, opts RenderOpts) ([]byte, error) {
 	result := bytes.NewBuffer(nil)
 
 	if len(changes) == 0 {

--- a/formatters/format_text_test.go
+++ b/formatters/format_text_test.go
@@ -28,7 +28,7 @@ func TestTextFormatter_RenderChangelog(t *testing.T) {
 		},
 	}
 
-	out, err := textFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts(), "", "")
+	out, err := textFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts())
 	require.NoError(t, err)
 	require.Equal(t, "1 changes: 1 error, 0 warning, 0 info\nerror\t[change_id]\n\tin components/test\n\t\tThis is a breaking change.\n\n", string(out))
 }
@@ -48,13 +48,13 @@ func TestTextFormatter_RenderChecks(t *testing.T) {
 }
 
 func TestTextFormatter_RenderChangelog_EmptyChangesDifferentSpecs(t *testing.T) {
-	out, err := textFormatter.RenderChangelog(checker.Changes{}, formatters.RenderOpts{}, "", "")
+	out, err := textFormatter.RenderChangelog(checker.Changes{}, formatters.RenderOpts{})
 	require.NoError(t, err)
 	require.Equal(t, "No changes to report, but the specs are different.\nRun 'oasdiff diff' to see structural differences.", string(out))
 }
 
 func TestTextFormatter_RenderChangelog_EmptyChangesDifferentSpecs_BreakingMode(t *testing.T) {
-	out, err := textFormatter.RenderChangelog(checker.Changes{}, formatters.RenderOpts{IsBreaking: true}, "", "")
+	out, err := textFormatter.RenderChangelog(checker.Changes{}, formatters.RenderOpts{IsBreaking: true})
 	require.NoError(t, err)
 	require.Equal(t, "No breaking changes to report, but the specs are different.\nRun 'oasdiff diff' to see structural differences.", string(out))
 }
@@ -62,7 +62,7 @@ func TestTextFormatter_RenderChangelog_EmptyChangesDifferentSpecs_BreakingMode(t
 func TestTextFormatter_RenderChangelog_EmptyChangesIdenticalSpecs(t *testing.T) {
 	// DiffEmpty=true takes precedence; suggestion is suppressed because
 	// there's nothing for `oasdiff diff` to show.
-	out, err := textFormatter.RenderChangelog(checker.Changes{}, formatters.RenderOpts{DiffEmpty: true, IsBreaking: true}, "", "")
+	out, err := textFormatter.RenderChangelog(checker.Changes{}, formatters.RenderOpts{DiffEmpty: true, IsBreaking: true})
 	require.NoError(t, err)
 	require.Equal(t, "No changes detected", string(out))
 }

--- a/formatters/format_yaml.go
+++ b/formatters/format_yaml.go
@@ -29,7 +29,7 @@ func (f YAMLFormatter) RenderSummary(diff *diff.Diff, opts RenderOpts) ([]byte, 
 	return printYAML(diff.GetSummary())
 }
 
-func (f YAMLFormatter) RenderChangelog(changes checker.Changes, opts RenderOpts, _, _ string) ([]byte, error) {
+func (f YAMLFormatter) RenderChangelog(changes checker.Changes, opts RenderOpts) ([]byte, error) {
 	return printYAML(adaptStructure(NewChanges(changes, f.Localizer), opts))
 }
 

--- a/formatters/format_yaml_test.go
+++ b/formatters/format_yaml_test.go
@@ -28,7 +28,7 @@ func TestYamlFormatter_RenderChangelog(t *testing.T) {
 		},
 	}
 
-	out, err := yamlFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts(), "", "")
+	out, err := yamlFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts())
 	require.NoError(t, err)
 	require.Equal(t, "- id: change_id\n  text: This is a breaking change.\n  level: 3\n  section: components\n  fingerprint: f8cd9af6b117\n", string(out))
 }
@@ -41,7 +41,7 @@ func TestYamlFormatter_RenderChangelogWithWrapInObject(t *testing.T) {
 		},
 	}
 
-	out, err := yamlFormatter.RenderChangelog(testChanges, formatters.RenderOpts{WrapInObject: true}, "", "")
+	out, err := yamlFormatter.RenderChangelog(testChanges, formatters.RenderOpts{WrapInObject: true})
 	require.NoError(t, err)
 	require.True(t, strings.HasPrefix(string(out), "changes:"))
 }
@@ -109,7 +109,7 @@ func TestYamlFormatter_RenderChangelog_WithSources(t *testing.T) {
 		},
 	}
 
-	out, err := yamlFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts(), "", "")
+	out, err := yamlFormatter.RenderChangelog(testChanges, formatters.NewRenderOpts())
 	require.NoError(t, err)
 
 	expected := `- id: change_id

--- a/formatters/interface.go
+++ b/formatters/interface.go
@@ -14,7 +14,7 @@ import (
 type Formatter interface {
 	RenderDiff(diff *diff.Diff, opts RenderOpts) ([]byte, error)
 	RenderSummary(diff *diff.Diff, opts RenderOpts) ([]byte, error)
-	RenderChangelog(changes checker.Changes, opts RenderOpts, baseVersion, revisionVersion string) ([]byte, error)
+	RenderChangelog(changes checker.Changes, opts RenderOpts) ([]byte, error)
 	RenderChecks(checks Checks, opts RenderOpts) ([]byte, error)
 	RenderFlatten(spec *openapi3.T, opts RenderOpts) ([]byte, error)
 	RenderValidate(findings Findings, opts RenderOpts) ([]byte, error)
@@ -47,11 +47,11 @@ func Lookup(format string, opts FormatterOpts) (Formatter, error) {
 	case FormatText:
 		return newTEXTFormatter(l), nil
 	case FormatMarkup, FormatMarkdown:
-		return newMarkupFormatter(l), nil
+		return newMarkupFormatter(l, opts.BaseVersion, opts.RevisionVersion), nil
 	case FormatSingleLine:
 		return newSingleLineFormatter(l), nil
 	case FormatHTML:
-		return newHTMLFormatter(l), nil
+		return newHTMLFormatter(l, opts.BaseVersion, opts.RevisionVersion), nil
 	case FormatGithubActions:
 		return newGitHubActionsFormatter(l), nil
 	case FormatJUnit:

--- a/formatters/not_implemented.go
+++ b/formatters/not_implemented.go
@@ -6,7 +6,6 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/diff"
-	"github.com/oasdiff/oasdiff/load"
 )
 
 type notImplementedFormatter struct{}
@@ -19,7 +18,7 @@ func (f notImplementedFormatter) RenderSummary(*diff.Diff, RenderOpts) ([]byte, 
 	return notImplemented()
 }
 
-func (f notImplementedFormatter) RenderChangelog(checker.Changes, RenderOpts, *load.SpecInfoPair) ([]byte, error) {
+func (f notImplementedFormatter) RenderChangelog(checker.Changes, RenderOpts) ([]byte, error) {
 	return notImplemented()
 }
 

--- a/formatters/types.go
+++ b/formatters/types.go
@@ -37,7 +37,9 @@ func GetSupportedFormats() []string {
 
 // FormatterOpts can be used to pass properties to the formatter (e.g. colors)
 type FormatterOpts struct {
-	Language string
+	Language        string
+	BaseVersion     string
+	RevisionVersion string
 }
 
 // RenderOpts can be used to pass properties to the renderer method

--- a/internal/changelog.go
+++ b/internal/changelog.go
@@ -131,7 +131,9 @@ func outputChangelog(flags *Flags, stdout io.Writer, errs checker.Changes, specI
 
 	// formatter lookup
 	formatter, err := formatters.Lookup(flags.getFormat(), formatters.FormatterOpts{
-		Language: flags.getLang(),
+		Language:        flags.getLang(),
+		BaseVersion:     specInfoPair.GetBaseVersion(),
+		RevisionVersion: specInfoPair.GetRevisionVersion(),
 	})
 	if err != nil {
 		return getErrUnsupportedFormat(flags.getFormat(), changelogCmd)
@@ -148,7 +150,7 @@ func outputChangelog(flags *Flags, stdout io.Writer, errs checker.Changes, specI
 		return getErrInvalidColorMode(err)
 	}
 
-	bytes, err := formatter.RenderChangelog(errs, formatters.RenderOpts{ColorMode: colorMode, TemplatePath: flags.getTemplate(), DiffEmpty: diffEmpty, IsBreaking: isBreaking}, specInfoPair.GetBaseVersion(), specInfoPair.GetRevisionVersion())
+	bytes, err := formatter.RenderChangelog(errs, formatters.RenderOpts{ColorMode: colorMode, TemplatePath: flags.getTemplate(), DiffEmpty: diffEmpty, IsBreaking: isBreaking})
 	if err != nil {
 		return getErrFailedPrint(changelogCmd+" "+flags.getFormat(), err)
 	}

--- a/internal/open_review.go
+++ b/internal/open_review.go
@@ -167,15 +167,17 @@ func uploadAndOpen(flags *Flags, stderr io.Writer, isBreaking bool, errs checker
 // whether the review came through the plaintext path or the encrypted one.
 // Color is forced off: the output is data, not a terminal render.
 func renderChangelogJSON(flags *Flags, errs checker.Changes, specInfoPair *load.SpecInfoPair, isBreaking, diffEmpty bool) ([]byte, error) {
-	formatter, err := formatters.Lookup(string(formatters.FormatJSON), formatters.FormatterOpts{Language: flags.getLang()})
+	formatter, err := formatters.Lookup(string(formatters.FormatJSON), formatters.FormatterOpts{
+		Language:        flags.getLang(),
+		BaseVersion:     specInfoPair.GetBaseVersion(),
+		RevisionVersion: specInfoPair.GetRevisionVersion(),
+	})
 	if err != nil {
 		return nil, err
 	}
 	return formatter.RenderChangelog(
 		errs,
 		formatters.RenderOpts{WrapInObject: true, ColorMode: checker.ColorNever, IsBreaking: isBreaking, DiffEmpty: diffEmpty},
-		specInfoPair.GetBaseVersion(),
-		specInfoPair.GetRevisionVersion(),
 	)
 }
 

--- a/report/doc.go
+++ b/report/doc.go
@@ -12,7 +12,7 @@ formats, use the checker package with formatters instead:
 
 	changes := checker.CheckBackwardCompatibility(config, diffReport, operationsSources)
 	formatter, _ := formatters.Lookup("text", formatters.FormatterOpts{})
-	output, _ := formatter.RenderChangelog(changes, formatters.RenderOpts{}, baseVersion, revisionVersion)
+	output, _ := formatter.RenderChangelog(changes, formatters.RenderOpts{})
 
 # Usage
 


### PR DESCRIPTION
## What

`Formatter.RenderChangelog` took `baseVersion, revisionVersion string` positionally, but only `HTMLFormatter` and `MarkupFormatter` render them. The other six formatters (json, yaml, text, junit, githubactions, singleline) signed them as `_, _` and dropped them, so every formatter carried dead params to satisfy the interface.

## Change

Inject the versions where they are actually used, and remove them everywhere else:

* `RenderChangelog(changes, opts)` on the interface, matching its five sibling `Render*` methods.
* `HTMLFormatter` and `MarkupFormatter` hold `BaseVersion` / `RevisionVersion` fields, set at construction. `Lookup` reads them from `FormatterOpts` and passes them to those two constructors only.
* The six version-ignoring formatters drop the `_, _` params entirely.
* `notImplementedFormatter.RenderChangelog` had drifted to a third signature (`*load.SpecInfoPair`); reconciled to `(changes, opts)`, and its now-unused `load` import removed.
* Callers (`changelog`, `open_review`) move the versions into the `FormatterOpts` they already build for `Lookup`.

No behavior change. `go build`, `go vet`, and `go test ./formatters/... ./internal/...` all pass.