### PR TITLE
checker: move ComputeFingerprint out of formatters

### DIFF
--- a/checker/fingerprint.go
+++ b/checker/fingerprint.go
@@ -1,0 +1,38 @@
+package checker
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// ComputeFingerprint produces a short, stable identifier for a change or
+// finding. It is used to match the same logical item across spec versions
+// (carry-forward of review state in oasdiff-service) and to look up review
+// records at view time. The changelog and validate commands share it so a
+// downstream tool can match findings produced by either.
+//
+// Inputs are the structured rule arguments rather than the rendered text:
+// rendered text varies with locale and copy edits to the message templates,
+// which would silently invalidate every stored fingerprint. The args carry the
+// same per-change disambiguation power without that fragility.
+func ComputeFingerprint(id, operation, path string, args []any) string {
+	h := fmt.Sprintf("%s:%s:%s:%s", id, operation, path, serializeArgs(args))
+	sum := sha256.Sum256([]byte(h))
+	return hex.EncodeToString(sum[:])[:12]
+}
+
+// serializeArgs joins the change args into a deterministic string. fmt's `%v`
+// verb sorts map keys (Go 1.12+) so nested maps remain stable; primitives and
+// slices are stable by definition.
+func serializeArgs(args []any) string {
+	if len(args) == 0 {
+		return ""
+	}
+	parts := make([]string, len(args))
+	for i, a := range args {
+		parts[i] = fmt.Sprintf("%v", a)
+	}
+	return strings.Join(parts, ";")
+}

--- a/checker/fingerprint.go
+++ b/checker/fingerprint.go
@@ -12,9 +12,6 @@ import (
 // (carry-forward of review state in oasdiff-service) and to look up review
 // records at view time. The changelog and validate commands share it so a
 // downstream tool can match findings produced by either.
-//
-// It hashes the structured rule args, not the rendered text, which changes with
-// locale and template edits and would silently invalidate stored fingerprints.
 func ComputeFingerprint(id, operation, path string, args []any) string {
 	h := fmt.Sprintf("%s:%s:%s:%s", id, operation, path, serializeArgs(args))
 	sum := sha256.Sum256([]byte(h))

--- a/checker/fingerprint.go
+++ b/checker/fingerprint.go
@@ -13,10 +13,8 @@ import (
 // records at view time. The changelog and validate commands share it so a
 // downstream tool can match findings produced by either.
 //
-// Inputs are the structured rule arguments rather than the rendered text:
-// rendered text varies with locale and copy edits to the message templates,
-// which would silently invalidate every stored fingerprint. The args carry the
-// same per-change disambiguation power without that fragility.
+// It hashes the structured rule args, not the rendered text, which changes with
+// locale and template edits and would silently invalidate stored fingerprints.
 func ComputeFingerprint(id, operation, path string, args []any) string {
 	h := fmt.Sprintf("%s:%s:%s:%s", id, operation, path, serializeArgs(args))
 	sum := sha256.Sum256([]byte(h))

--- a/checker/fingerprint.go
+++ b/checker/fingerprint.go
@@ -23,6 +23,13 @@ func ComputeFingerprint(id, operation, path string, args []any) string {
 	return hex.EncodeToString(sum[:])[:12]
 }
 
+// Fingerprint is ComputeFingerprint for a Change, reading its id, operation,
+// path, and args. Findings are not Changes, so they call ComputeFingerprint
+// directly.
+func Fingerprint(c Change) string {
+	return ComputeFingerprint(c.GetId(), c.GetOperation(), c.GetPath(), c.GetArgs())
+}
+
 // serializeArgs joins the change args into a deterministic string. fmt's `%v`
 // verb sorts map keys (Go 1.12+) so nested maps remain stable; primitives and
 // slices are stable by definition.

--- a/formatters/changes.go
+++ b/formatters/changes.go
@@ -40,7 +40,7 @@ func NewChanges(originalChanges checker.Changes, l checker.Localizer) Changes {
 			Attributes:     change.GetAttributes(),
 			BaseSource:     change.GetBaseSource(),
 			RevisionSource: change.GetRevisionSource(),
-			Fingerprint:    checker.ComputeFingerprint(id, operation, path, change.GetArgs()),
+			Fingerprint:    checker.Fingerprint(change),
 		}
 	}
 	return changes

--- a/formatters/changes.go
+++ b/formatters/changes.go
@@ -1,11 +1,6 @@
 package formatters
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
-	"fmt"
-	"strings"
-
 	"github.com/oasdiff/oasdiff/checker"
 )
 
@@ -45,38 +40,8 @@ func NewChanges(originalChanges checker.Changes, l checker.Localizer) Changes {
 			Attributes:     change.GetAttributes(),
 			BaseSource:     change.GetBaseSource(),
 			RevisionSource: change.GetRevisionSource(),
-			Fingerprint:    ComputeFingerprint(id, operation, path, change.GetArgs()),
+			Fingerprint:    checker.ComputeFingerprint(id, operation, path, change.GetArgs()),
 		}
 	}
 	return changes
-}
-
-// ComputeFingerprint produces a short, stable identifier for a change or
-// finding. It is used to match the same logical item across spec versions
-// (carry-forward of review state in oasdiff-service) and to look up review
-// records at view time. The changelog and validate commands share it so a
-// downstream tool can match findings produced by either.
-//
-// Inputs are the structured rule arguments rather than the rendered text:
-// rendered text varies with locale and copy edits to the message templates,
-// which would silently invalidate every stored fingerprint. The args carry the
-// same per-change disambiguation power without that fragility.
-func ComputeFingerprint(id, operation, path string, args []any) string {
-	h := fmt.Sprintf("%s:%s:%s:%s", id, operation, path, serializeArgs(args))
-	sum := sha256.Sum256([]byte(h))
-	return hex.EncodeToString(sum[:])[:12]
-}
-
-// serializeArgs joins the change args into a deterministic string. fmt's `%v`
-// verb sorts map keys (Go 1.12+) so nested maps remain stable; primitives and
-// slices are stable by definition.
-func serializeArgs(args []any) string {
-	if len(args) == 0 {
-		return ""
-	}
-	parts := make([]string, len(args))
-	for i, a := range args {
-		parts[i] = fmt.Sprintf("%v", a)
-	}
-	return strings.Join(parts, ";")
 }

--- a/internal/open_review.go
+++ b/internal/open_review.go
@@ -271,7 +271,7 @@ func parseReviewMeta(entries []string) (map[string]string, error) {
 }
 
 // reviewChange is one manifest entry sent alongside the encrypted bundle: a
-// change's fingerprint (see formatters.ComputeFingerprint) and its level.
+// change's fingerprint (see checker.ComputeFingerprint) and its level.
 type reviewChange struct {
 	Fingerprint string `json:"fingerprint" yaml:"fingerprint"`
 	Level       int    `json:"level" yaml:"level"`
@@ -284,7 +284,7 @@ func reviewManifest(errs checker.Changes) []reviewChange {
 	manifest := make([]reviewChange, 0, len(errs))
 	for _, change := range errs {
 		manifest = append(manifest, reviewChange{
-			Fingerprint: formatters.ComputeFingerprint(change.GetId(), change.GetOperation(), change.GetPath(), change.GetArgs()),
+			Fingerprint: checker.ComputeFingerprint(change.GetId(), change.GetOperation(), change.GetPath(), change.GetArgs()),
 			Level:       int(change.GetLevel()),
 		})
 	}

--- a/internal/open_review.go
+++ b/internal/open_review.go
@@ -284,7 +284,7 @@ func reviewManifest(errs checker.Changes) []reviewChange {
 	manifest := make([]reviewChange, 0, len(errs))
 	for _, change := range errs {
 		manifest = append(manifest, reviewChange{
-			Fingerprint: checker.ComputeFingerprint(change.GetId(), change.GetOperation(), change.GetPath(), change.GetArgs()),
+			Fingerprint: checker.Fingerprint(change),
 			Level:       int(change.GetLevel()),
 		})
 	}

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -85,10 +85,7 @@ func flattenKinErrors(source string, err error) formatters.Findings {
 			Column: columnForKinError(err),
 		},
 	}
-	// Fingerprint last so it hashes over the populated fields. validate and
-	// changelog share ComputeFingerprint so a downstream tool can match
-	// findings across spec versions; the args carry the per-finding
-	// disambiguator (checker/fingerprint.go).
+	// Fingerprint last so it hashes over the populated fields.
 	f.Fingerprint = checker.ComputeFingerprint(f.Id, f.Operation, f.Path, argsForKinError(err))
 	return formatters.Findings{f}
 }

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -88,8 +88,8 @@ func flattenKinErrors(source string, err error) formatters.Findings {
 	// Fingerprint last so it hashes over the populated fields. validate and
 	// changelog share ComputeFingerprint so a downstream tool can match
 	// findings across spec versions; the args carry the per-finding
-	// disambiguator (formatters/changes.go).
-	f.Fingerprint = formatters.ComputeFingerprint(f.Id, f.Operation, f.Path, argsForKinError(err))
+	// disambiguator (checker/fingerprint.go).
+	f.Fingerprint = checker.ComputeFingerprint(f.Id, f.Operation, f.Path, argsForKinError(err))
 	return formatters.Findings{f}
 }
 


### PR DESCRIPTION
`ComputeFingerprint` computes a change's stable identity, `sha256("id:operation:path:args")[:12]`, from `checker.Change`'s own fields. It has no formatting logic (stdlib only), yet it lived in `formatters`, so callers that just needed a fingerprint had to depend on the output-rendering package.

Move `ComputeFingerprint` and its `serializeArgs` helper to `checker/fingerprint.go`, next to the `Change` it identifies. `checker` imports none of the callers, so there is no cycle. Call sites switch to `checker.ComputeFingerprint`; `changelog`/`validate` output is byte-identical.

No behavior change.