### PR TITLE
chore: apply gopls modernize suggestions

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -2,6 +2,7 @@ package checker
 
 //go:generate go-localize -input localizations_src -output localizations
 import (
+	"maps"
 	"slices"
 
 	"github.com/oasdiff/oasdiff/diff"
@@ -81,9 +82,7 @@ func clonePathsDiffForCheck(d *diff.Diff) *diff.Diff {
 				pdElem.OperationsDiff.Deleted = slices.Clone(v.OperationsDiff.Deleted)
 				if v.OperationsDiff.Modified != nil {
 					pdElem.OperationsDiff.Modified = make(diff.ModifiedOperations, len(v.OperationsDiff.Modified))
-					for ok, ov := range v.OperationsDiff.Modified {
-						pdElem.OperationsDiff.Modified[ok] = ov
-					}
+					maps.Copy(pdElem.OperationsDiff.Modified, v.OperationsDiff.Modified)
 				}
 			}
 			cloned.PathsDiff.Modified[k] = &pdElem

--- a/checker/list_of_types_core_test.go
+++ b/checker/list_of_types_core_test.go
@@ -114,7 +114,7 @@ func TestListOfTypesIntegration_EdgeCases(t *testing.T) {
 	// Should have some list-of-types changes but not for complex schemas
 	var listOfTypesChanges []checker.ApiChange
 	for _, err := range errs {
-		if containsString([]string{
+		if slices.Contains([]string{
 			checker.ResponsePropertyListOfTypesWidenedId,
 			checker.ResponsePropertyListOfTypesNarrowedId,
 		}, err.GetId()) {
@@ -143,7 +143,7 @@ func TestListOfTypesIntegration_ParameterChanges(t *testing.T) {
 	// No changes expected for identical files
 	var paramChanges []checker.ApiChange
 	for _, err := range errs {
-		if containsString([]string{
+		if slices.Contains([]string{
 			checker.RequestParameterListOfTypesNarrowedId,
 			checker.RequestParameterListOfTypesWidenedId,
 		}, err.GetId()) {
@@ -283,10 +283,6 @@ func TestListOfTypesIntegration_JoinTypesInMessages(t *testing.T) {
 	}
 }
 
-func containsString(slice []string, item string) bool {
-	return slices.Contains(slice, item)
-}
-
 // Test core function behavior with various scenarios
 func TestListOfTypesCoreScenarios(t *testing.T) {
 	t.Run("empty_list_diff_no_changes", func(t *testing.T) {
@@ -305,7 +301,7 @@ func TestListOfTypesCoreScenarios(t *testing.T) {
 		// Should have no changes since specs are identical
 		listOfTypesChanges := 0
 		for _, err := range errs {
-			if containsString([]string{
+			if slices.Contains([]string{
 				checker.RequestPropertyListOfTypesNarrowedId,
 				checker.RequestPropertyListOfTypesWidenedId,
 			}, err.GetId()) {
@@ -338,7 +334,7 @@ func TestListOfTypesCoreScenarios(t *testing.T) {
 		hasResponseChanges := false
 
 		for _, err := range responseErrs {
-			if containsString([]string{
+			if slices.Contains([]string{
 				checker.ResponsePropertyListOfTypesNarrowedId,
 				checker.ResponsePropertyListOfTypesWidenedId,
 			}, err.GetId()) {
@@ -365,7 +361,7 @@ func TestListOfTypesCoreScenarios(t *testing.T) {
 
 		hasRequestChanges := false
 		for _, err := range requestErrs {
-			if containsString([]string{
+			if slices.Contains([]string{
 				checker.RequestPropertyListOfTypesNarrowedId,
 				checker.RequestPropertyListOfTypesWidenedId,
 			}, err.GetId()) {
@@ -478,7 +474,7 @@ func TestListOfTypesSpecificPaths(t *testing.T) {
 		// Should find parameter changes (narrowing from multiple types to single)
 		foundParamChanges := false
 		for _, err := range errs {
-			if containsString([]string{
+			if slices.Contains([]string{
 				checker.RequestParameterListOfTypesNarrowedId,
 				checker.RequestParameterListOfTypesWidenedId,
 			}, err.GetId()) {
@@ -509,7 +505,7 @@ func TestListOfTypesSpecificPaths(t *testing.T) {
 		// Should find response body widening (adding integer type)
 		foundResponseBodyChanges := false
 		for _, err := range responseErrs {
-			if containsString([]string{
+			if slices.Contains([]string{
 				checker.ResponseBodyListOfTypesNarrowedId,
 				checker.ResponseBodyListOfTypesWidenedId,
 			}, err.GetId()) {
@@ -520,7 +516,7 @@ func TestListOfTypesSpecificPaths(t *testing.T) {
 		// Also check if we can find property-level changes
 		foundResponsePropertyChanges := false
 		for _, err := range responseErrs {
-			if containsString([]string{
+			if slices.Contains([]string{
 				checker.ResponsePropertyListOfTypesNarrowedId,
 				checker.ResponsePropertyListOfTypesWidenedId,
 			}, err.GetId()) {
@@ -564,7 +560,7 @@ func TestListOfTypesSpecificPaths(t *testing.T) {
 		// Count list-of-types specific changes (should be 0 for identical specs)
 		listOfTypesChanges := 0
 		for _, err := range append(append(requestPropertyErrs, responsePropertyErrs...), parameterErrs...) {
-			if containsString([]string{
+			if slices.Contains([]string{
 				checker.RequestPropertyListOfTypesNarrowedId,
 				checker.RequestPropertyListOfTypesWidenedId,
 				checker.ResponsePropertyListOfTypesNarrowedId,
@@ -612,7 +608,7 @@ func TestListOfTypesSpecificPaths(t *testing.T) {
 				require.NotNil(t, err.GetArgs(), "Change args should not be nil")
 
 				// If it's a list-of-types change, verify args format
-				if containsString([]string{
+				if slices.Contains([]string{
 					checker.RequestPropertyListOfTypesNarrowedId,
 					checker.RequestPropertyListOfTypesWidenedId,
 					checker.ResponsePropertyListOfTypesNarrowedId,
@@ -763,7 +759,7 @@ func TestListOfTypesUncoveredPaths(t *testing.T) {
 		// Should find parameter property changes (narrowing - removing types from parameter property)
 		foundParamPropertyChanges := false
 		for _, err := range errs {
-			if containsString([]string{
+			if slices.Contains([]string{
 				checker.RequestParameterPropertyListOfTypesNarrowedId,
 				checker.RequestParameterPropertyListOfTypesWidenedId,
 			}, err.GetId()) {
@@ -859,7 +855,7 @@ func TestListOfTypesRemainingUncoveredLines(t *testing.T) {
 		foundResponseBodyChanges := false
 
 		for _, err := range requestErrs {
-			if containsString([]string{
+			if slices.Contains([]string{
 				checker.RequestBodyListOfTypesNarrowedId,
 				checker.RequestBodyListOfTypesWidenedId,
 			}, err.GetId()) {
@@ -869,7 +865,7 @@ func TestListOfTypesRemainingUncoveredLines(t *testing.T) {
 		}
 
 		for _, err := range responseErrs {
-			if containsString([]string{
+			if slices.Contains([]string{
 				checker.ResponseBodyListOfTypesNarrowedId,
 				checker.ResponseBodyListOfTypesWidenedId,
 			}, err.GetId()) {

--- a/checker/list_of_types_core_test.go
+++ b/checker/list_of_types_core_test.go
@@ -2,6 +2,7 @@ package checker_test
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 
@@ -283,12 +284,7 @@ func TestListOfTypesIntegration_JoinTypesInMessages(t *testing.T) {
 }
 
 func containsString(slice []string, item string) bool {
-	for _, s := range slice {
-		if s == item {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(slice, item)
 }
 
 // Test core function behavior with various scenarios

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -127,9 +127,7 @@ func GetPathsDiff(config *Config, s1, s2 []*load.SpecInfo) (*Diff, *OperationsSo
 	}
 
 	operationsSources := *operationsSources1
-	for k, v := range *operationsSources2 {
-		operationsSources[k] = v
-	}
+	maps.Copy(operationsSources, *operationsSources2)
 	return result, &operationsSources, nil
 }
 

--- a/flatten/allof/merge_allof.go
+++ b/flatten/allof/merge_allof.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"reflect"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
@@ -1164,12 +1165,7 @@ func areFormatsNumeric(values []string) bool {
 }
 
 func containsString(list []string, search string) bool {
-	for _, item := range list {
-		if item == search {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(list, search)
 }
 
 func filterEmptyStrings(input []string) []string {
@@ -1232,7 +1228,7 @@ func findIntersectionOfArrays(arrays [][]any) []any {
 func flattenArray(arrays [][]string) []string {
 	var result []string
 
-	for i := 0; i < len(arrays); i++ {
+	for i := range arrays {
 		for j := 0; j < len(arrays[i]); j++ {
 			result = append(result, arrays[i][j])
 		}

--- a/flatten/allof/merge_allof.go
+++ b/flatten/allof/merge_allof.go
@@ -944,7 +944,7 @@ func mergeProps(state *state, schema *openapi3.Schema, collection *SchemaCollect
 	propsToSchemasMap := map[string]openapi3.SchemaRefs{}
 	for _, schema := range collection.Properties {
 		for propKey, schemaRef := range schema {
-			if containsString(propsToMerge, propKey) {
+			if slices.Contains(propsToMerge, propKey) {
 				propsToSchemasMap[propKey] = append(propsToSchemasMap[propKey], schemaRef)
 			}
 		}
@@ -1162,10 +1162,6 @@ func areFormatsNumeric(values []string) bool {
 		}
 	}
 	return true
-}
-
-func containsString(list []string, search string) bool {
-	return slices.Contains(list, search)
 }
 
 func filterEmptyStrings(input []string) []string {

--- a/flatten/allof/merge_allof_test.go
+++ b/flatten/allof/merge_allof_test.go
@@ -1133,7 +1133,9 @@ func TestMerge_MaxContains_WithAbsentSibling(t *testing.T) {
 }
 
 // uint64Ptr is a small helper for *uint64 literal in tests.
-func uint64Ptr(v uint64) *uint64 { return &v }
+//
+//go:fix inline
+func uint64Ptr(v uint64) *uint64 { return new(v) }
 
 // merge multiple Not inside AllOf
 func TestMerge_Not(t *testing.T) {

--- a/flatten/allof/merge_allof_test.go
+++ b/flatten/allof/merge_allof_test.go
@@ -1133,9 +1133,7 @@ func TestMerge_MaxContains_WithAbsentSibling(t *testing.T) {
 }
 
 // uint64Ptr is a small helper for *uint64 literal in tests.
-//
-//go:fix inline
-func uint64Ptr(v uint64) *uint64 { return new(v) }
+func uint64Ptr(v uint64) *uint64 { return &v }
 
 // merge multiple Not inside AllOf
 func TestMerge_Not(t *testing.T) {

--- a/formatters/changes_test.go
+++ b/formatters/changes_test.go
@@ -64,7 +64,7 @@ func TestNewChanges_FingerprintIndependentOfLocale(t *testing.T) {
 		Source: &load.Source{}, Args: []any{"v1"},
 	}
 	english := formatters.NewChanges(checker.Changes{change}, MockLocalizer)[0]
-	other := formatters.NewChanges(checker.Changes{change}, func(originalKey string, args ...interface{}) string {
+	other := formatters.NewChanges(checker.Changes{change}, func(originalKey string, args ...any) string {
 		return "completely different rendering: " + originalKey
 	})[0]
 

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -122,8 +122,7 @@ func getErrDisallowedExternalRef(err error) *ReturnError {
 // a genuine load failure. Centralised so every spec-loading site stays a single
 // line at the call site.
 func asFlattenError(err error) *load.FlattenError {
-	var flatErr *load.FlattenError
-	if errors.As(err, &flatErr) {
+	if flatErr, ok := errors.AsType[*load.FlattenError](err); ok {
 		return flatErr
 	}
 	return nil

--- a/load/load.go
+++ b/load/load.go
@@ -211,11 +211,11 @@ func commitExistsLocally(ref string) bool {
 // the input has no `:` separator. The cost is one extra `git cat-file -t` call
 // per spec load on the git path, which git serves in single-digit milliseconds.
 func blobHashFromRef(gitRef string) (string, bool) {
-	idx := strings.Index(gitRef, ":")
-	if idx < 0 {
+	before, _, ok := strings.Cut(gitRef, ":")
+	if !ok {
 		return "", false
 	}
-	ref := gitRef[:idx]
+	ref := before
 	out, err := exec.Command("git", "cat-file", "-t", ref).Output()
 	if err != nil {
 		return "", false


### PR DESCRIPTION
Ran gopls's `modernize` analyzer (`go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest ./...`) and applied the safe, unambiguous suggestions:

- `m[k]=v` loop → `maps.Copy` (`checker/checker.go`, `diff/diff.go`)
- loop → `slices.Contains` (`checker` test, `flatten/allof`)
- `strings.Index` + slice → `strings.Cut` (`load/load.go`)
- `for i := 0; i < n; i++` → `range n` (`flatten/allof`)
- `interface{}` → `any` (`formatters` test)
- `errors.As` → `errors.AsType` (`internal/errors.go`, a used-var case)

No behavior change; `go build`, `go vet`, and the affected package tests pass.

**Deliberately excluded:**
- `validate/validate.go`'s ~90 `errors.AsType` hints. The analyzer's `-fix` leaves unused variable declarations wherever the matched error is only type-checked (not used), so it doesn't compile as-is. That's a large, homogeneous stylistic change worth deciding on its own, not folding into a mechanical cleanup.
- `checker/localizations/localizations.go` (two hints). It's generated by the third-party `go-localize` tool, so the idioms come from its template, not this repo; CI's linter skips generated files anyway.