### PR TITLE
test: pin OAS 3.1 Reference Object metadata override behavior

### DIFF
--- a/diff/ref_metadata_override_test.go
+++ b/diff/ref_metadata_override_test.go
@@ -1,0 +1,68 @@
+package diff_test
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/oasdiff/diff"
+	"github.com/oasdiff/oasdiff/load"
+	"github.com/stretchr/testify/require"
+)
+
+// An OAS 3.1 Reference Object metadata override ($ref sibling `description`)
+// changes the effective document: adding one must surface in the diff as a
+// description change on the referenced parameter.
+func TestDiff_RefMetadataOverride31(t *testing.T) {
+	t.Skip("3.1 Reference Object metadata overrides land upstream in kin-openapi PR #1215; unskip at the kin bump that includes it")
+	const base = `openapi: 3.1.0
+info: { title: t, version: "1" }
+paths:
+  /a:
+    get:
+      parameters:
+        - $ref: '#/components/parameters/P'
+      responses:
+        "200": { description: ok }
+components:
+  parameters:
+    P:
+      name: q
+      in: query
+      description: original
+      schema: { type: string }
+`
+	const revision = `openapi: 3.1.0
+info: { title: t, version: "1" }
+paths:
+  /a:
+    get:
+      parameters:
+        - $ref: '#/components/parameters/P'
+          description: overridden
+      responses:
+        "200": { description: ok }
+components:
+  parameters:
+    P:
+      name: q
+      in: query
+      description: original
+      schema: { type: string }
+`
+	loadSide := func(data string) *load.SpecInfo {
+		si, err := load.NewSpecInfoFromData(openapi3.NewLoader(), []byte(data), "spec.yaml")
+		require.NoError(t, err)
+		return si
+	}
+
+	d, err := diff.Get(diff.NewConfig(), loadSide(base).Spec, loadSide(revision).Spec)
+	require.NoError(t, err)
+	require.False(t, d.Empty(), "the override changes the effective document")
+
+	paramsDiff := d.PathsDiff.Modified["/a"].OperationsDiff.Modified["GET"].ParametersDiff
+	require.NotNil(t, paramsDiff)
+	descDiff := paramsDiff.Modified["query"]["q"].DescriptionDiff
+	require.NotNil(t, descDiff)
+	require.Equal(t, "original", descDiff.From)
+	require.Equal(t, "overridden", descDiff.To)
+}

--- a/validate/ref_metadata_override_test.go
+++ b/validate/ref_metadata_override_test.go
@@ -1,0 +1,55 @@
+package validate
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/require"
+)
+
+// OAS 3.1 allows a $ref sibling `description` on parameter references (a
+// Reference Object metadata override); OAS 3.0 does not. The two tests pin the
+// version split.
+
+const refSiblingDescriptionSpec = `openapi: %s
+info: { title: t, version: "1" }
+paths:
+  /a:
+    get:
+      parameters:
+        - $ref: '#/components/parameters/P'
+          description: overridden
+      responses:
+        "200": { description: ok }
+components:
+  parameters:
+    P:
+      name: q
+      in: query
+      description: original
+      schema: { type: string }
+`
+
+func findingIDsForVersion(t *testing.T, version string) []string {
+	t.Helper()
+	doc, err := openapi3.NewLoader().LoadFromData(fmt.Appendf(nil, refSiblingDescriptionSpec, version))
+	require.NoError(t, err)
+	var ids []string
+	for _, f := range Validate(doc, "test.yaml") {
+		ids = append(ids, f.Id)
+	}
+	return ids
+}
+
+// In 3.0, metadata beside $ref is not part of the Reference Object: flagged.
+func TestRefSiblingDescription_30_Flagged(t *testing.T) {
+	require.Contains(t, findingIDsForVersion(t, "3.0.0"), "extra-sibling-fields")
+}
+
+// In 3.1, `description` beside a parameter $ref is a legal metadata override:
+// no finding.
+func TestRefSiblingDescription_31_Allowed(t *testing.T) {
+	t.Skip("3.1 Reference Object metadata overrides land upstream in kin-openapi PR #1215; unskip at the kin bump that includes it")
+	require.NotContains(t, findingIDsForVersion(t, "3.1.0"), "extra-sibling-fields")
+}


### PR DESCRIPTION
kin-openapi PR getkin/kin-openapi#1215 (open) adds OAS 3.1 Reference Object `summary`/`description` overrides, applied into the resolved `Value` via a copy — so oasdiff's diff and validate see the effective document automatically, and no oasdiff code changes are needed. These tests pin the behavior we expect at the kin bump that includes it:

- **validate, 3.0** (active now): `description` beside `$ref` stays an `extra-sibling-fields` finding — also holds post-#1215, per its updated issue513 regression test.
- **validate, 3.1** (skipped pending the bump): no finding — the override is a legal Reference Object field.
- **diff, 3.1** (skipped pending the bump): adding an override surfaces as the referenced parameter's description changing `original` → `overridden` (typed assertion down to `DescriptionDiff`).

Verified in both directions: the skipped tests fail against the released kin exactly as today's behavior dictates, and pass against the #1215 branch via a local `replace`. Unskipping them is the acceptance check at the bump.