### PR TITLE
validate: flag a parameter whose type union mixes structured and scalar

### DIFF
--- a/validate/lint_param_serialization.go
+++ b/validate/lint_param_serialization.go
@@ -1,0 +1,104 @@
+package validate
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/oasdiff/checker"
+	"github.com/oasdiff/oasdiff/formatters"
+)
+
+// AmbiguousParameterSerializationID flags a parameter whose schema type union
+// mixes a structured type (array or object) with a scalar. Style serialization
+// is defined per type and arrays/objects serialize differently from scalars,
+// so for `type: [array, integer]` a server cannot tell whether ?token=5 is the
+// array ["5"] or the integer 5. Valid JSON Schema, under-specified for OpenAPI
+// serialization: an oasdiff-native SHOULD-level lint. See oasdiff/oasdiff#1055.
+const AmbiguousParameterSerializationID = "ambiguous-parameter-serialization"
+
+// lintAmbiguousParamSerialization reports, at WARN, every parameter (query,
+// path, header, cookie) whose schema type union contains both a structured
+// type and a scalar. `null` is excluded from the check: it carries no
+// serialization of its own, so [array, null] and [string, null] are
+// unambiguous. It uses kin-openapi's WalkParameters to visit each parameter in
+// the document exactly once -- components, path items, operations, callbacks,
+// and webhooks -- so the traversal and $ref dedup are owned upstream (a shared
+// components parameter is reported once, at its definition), and the finding's
+// Section is the parameter's exact RFC 6901 JSON Pointer.
+func lintAmbiguousParamSerialization(spec *openapi3.T, source string) formatters.Findings {
+	var findings formatters.Findings
+	// The callback never errors, so WalkParameters never returns one.
+	_ = spec.WalkParameters(func(jsonPointer string, ref *openapi3.ParameterRef) error {
+		p := ref.Value // WalkParameters guarantees ref and ref.Value are non-nil
+		if p.Schema == nil || p.Schema.Value == nil || p.Schema.Value.Type == nil {
+			return nil
+		}
+		if mixed := mixedSerializationTypes(p.Schema.Value.Type.Slice()); mixed != nil {
+			findings = append(findings, newAmbiguousParamFinding(p, jsonPointer, mixed, source))
+		}
+		return nil
+	})
+	return findings
+}
+
+// mixedSerializationTypes returns the type union (null excluded, input order)
+// when it mixes a structured type with a scalar, else nil.
+func mixedSerializationTypes(types []string) []string {
+	var kept []string
+	var structured, scalar bool
+	for _, t := range types {
+		switch t {
+		case "null":
+			continue
+		case "array", "object":
+			structured = true
+		default:
+			scalar = true
+		}
+		kept = append(kept, t)
+	}
+	if structured && scalar {
+		return kept
+	}
+	return nil
+}
+
+func newAmbiguousParamFinding(p *openapi3.Parameter, section string, types []string, source string) formatters.Finding {
+	line, column := paramTypeLocation(p)
+	f := formatters.Finding{
+		Id:      AmbiguousParameterSerializationID,
+		Text:    fmt.Sprintf("parameter %q mixes a structured type with a scalar (%s): its serialization is ambiguous", p.Name, strings.Join(types, ", ")),
+		Level:   checker.WARN,
+		Section: section,
+		Source: formatters.Source{
+			File:   source,
+			Line:   line,
+			Column: column,
+		},
+	}
+	args := make([]any, len(types))
+	for i, t := range types {
+		args[i] = t
+	}
+	f.Fingerprint = checker.ComputeFingerprint(f.Id, "", section, args)
+	return f
+}
+
+// paramTypeLocation returns the line/column of the schema's type field when
+// origin tracking is enabled, falling back to the schema's own location, then
+// the parameter's, then 0.
+func paramTypeLocation(p *openapi3.Parameter) (int, int) {
+	if s := p.Schema.Value; s.Origin != nil {
+		if loc, ok := s.Origin.Fields["type"]; ok {
+			return loc.Line, loc.Column
+		}
+		if s.Origin.Key != nil {
+			return s.Origin.Key.Line, s.Origin.Key.Column
+		}
+	}
+	if p.Origin != nil && p.Origin.Key != nil {
+		return p.Origin.Key.Line, p.Origin.Key.Column
+	}
+	return 0, 0
+}

--- a/validate/lint_param_serialization_test.go
+++ b/validate/lint_param_serialization_test.go
@@ -1,0 +1,209 @@
+package validate
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/oasdiff/oasdiff/formatters"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/oasdiff/checker"
+	"github.com/stretchr/testify/require"
+)
+
+func lintParamSpec(t *testing.T, spec string) formatters.Findings {
+	t.Helper()
+	loader := openapi3.NewLoader()
+	loader.IncludeOrigin = true
+	doc, err := loader.LoadFromData([]byte(spec))
+	require.NoError(t, err)
+	return lintAmbiguousParamSerialization(doc, "test.yaml")
+}
+
+func TestLintAmbiguousParamSerialization_TypeUnions(t *testing.T) {
+	const specTemplate = `openapi: 3.1.0
+info: { title: t, version: "1" }
+paths:
+  /a:
+    get:
+      parameters:
+        - in: query
+          name: token
+          schema:
+            type: [%s]
+            items: { type: string }
+      responses:
+        "200": { description: ok }
+`
+	for _, tc := range []struct {
+		types   string
+		flagged bool
+	}{
+		{"array, integer", true},
+		{"object, string", true},
+		{"array, integer, \"null\"", true}, // null is ignored, the rest still mixes
+		{"array, \"null\"", false},         // null carries no serialization
+		{"string, \"null\"", false},
+		{"string, integer", false}, // two scalars both serialize as a single value
+		{"array", false},
+	} {
+		t.Run(tc.types, func(t *testing.T) {
+			findings := lintParamSpec(t, fmt.Sprintf(specTemplate, tc.types))
+			if !tc.flagged {
+				require.Empty(t, findings)
+				return
+			}
+			require.Len(t, findings, 1)
+			f := findings[0]
+			require.Equal(t, AmbiguousParameterSerializationID, f.Id)
+			require.Equal(t, checker.WARN, f.Level)
+			require.Equal(t, "/paths/~1a/get/parameters/0", f.Section)
+			require.Contains(t, f.Text, `parameter "token"`)
+			require.Equal(t, "test.yaml", f.Source.File)
+			require.Equal(t, 10, f.Source.Line, "points at the schema's type field")
+			require.NotEmpty(t, f.Fingerprint)
+		})
+	}
+}
+
+// A shared components parameter referenced from several operations is reported
+// once, at the components definition.
+func TestLintAmbiguousParamSerialization_SharedComponentsParam(t *testing.T) {
+	const spec = `openapi: 3.1.0
+info: { title: t, version: "1" }
+paths:
+  /a:
+    get:
+      parameters:
+        - $ref: '#/components/parameters/Token'
+      responses:
+        "200": { description: ok }
+  /b:
+    get:
+      parameters:
+        - $ref: '#/components/parameters/Token'
+      responses:
+        "200": { description: ok }
+components:
+  parameters:
+    Token:
+      in: query
+      name: token
+      schema:
+        type: [array, integer]
+        items: { type: string }
+`
+	findings := lintParamSpec(t, spec)
+	require.Len(t, findings, 1)
+	require.Equal(t, "/components/parameters/Token", findings[0].Section)
+}
+
+// Parameters without a schema (content-based) and path-item-level parameters
+// are handled; a 3.0 single-type parameter cannot express a union.
+func TestLintAmbiguousParamSerialization_Shapes(t *testing.T) {
+	const contentParam = `openapi: 3.1.0
+info: { title: t, version: "1" }
+paths:
+  /a:
+    parameters:
+      - in: query
+        name: filter
+        content:
+          application/json:
+            schema: { type: object }
+    get:
+      responses:
+        "200": { description: ok }
+`
+	require.Empty(t, lintParamSpec(t, contentParam), "content-based parameters have no style serialization")
+
+	const pathItemParam = `openapi: 3.1.0
+info: { title: t, version: "1" }
+paths:
+  /a:
+    parameters:
+      - in: query
+        name: token
+        schema:
+          type: [object, boolean]
+    get:
+      responses:
+        "200": { description: ok }
+`
+	findings := lintParamSpec(t, pathItemParam)
+	require.Len(t, findings, 1)
+	require.Equal(t, "/paths/~1a/parameters/0", findings[0].Section)
+}
+
+func TestLintAmbiguousParamSerialization_Webhooks(t *testing.T) {
+	const spec = `openapi: 3.1.0
+info: { title: t, version: "1" }
+webhooks:
+  newThing:
+    post:
+      parameters:
+        - in: header
+          name: X-Batch
+          schema:
+            type: [array, string]
+            items: { type: string }
+      responses:
+        "200": { description: ok }
+`
+	findings := lintParamSpec(t, spec)
+	require.Len(t, findings, 1)
+	require.Equal(t, "/webhooks/newThing/post/parameters/0", findings[0].Section)
+}
+
+// The lint is wired into Validate alongside the kin findings.
+func TestValidate_IncludesAmbiguousParamSerialization(t *testing.T) {
+	const spec = `openapi: 3.1.0
+info: { title: t, version: "1" }
+paths:
+  /a:
+    get:
+      parameters:
+        - in: query
+          name: token
+          schema:
+            type: [array, integer]
+            items: { type: string }
+      responses:
+        "200": { description: ok }
+`
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData([]byte(spec))
+	require.NoError(t, err)
+	var ids []string
+	for _, f := range Validate(doc, "test.yaml") {
+		ids = append(ids, f.Id)
+	}
+	require.Contains(t, ids, AmbiguousParameterSerializationID)
+}
+
+// The walker also reaches parameters inside callback operations.
+func TestLintAmbiguousParamSerialization_Callbacks(t *testing.T) {
+	const spec = `openapi: 3.1.0
+info: { title: t, version: "1" }
+paths:
+  /subscribe:
+    post:
+      callbacks:
+        onEvent:
+          '{$request.body#/url}':
+            post:
+              parameters:
+                - in: query
+                  name: attempt
+                  schema:
+                    type: [array, integer]
+                    items: { type: string }
+              responses:
+                "200": { description: ok }
+      responses:
+        "201": { description: created }
+`
+	findings := lintParamSpec(t, spec)
+	require.Len(t, findings, 1)
+	require.Equal(t, "/paths/~1subscribe/post/callbacks/onEvent/{$request.body#~1url}/post/parameters/0", findings[0].Section)
+}

--- a/validate/rule_ids.go
+++ b/validate/rule_ids.go
@@ -11,6 +11,7 @@ import "slices"
 // spec-validation-error (loud, triaged). Sorted; add new IDs in order.
 var ruleIDs = []string{
 	"additional-properties-both-forms-exclusive",
+	"ambiguous-parameter-serialization",
 	"anchor-field-for-3-1-plus",
 	"authorization-url-forbidden",
 	"bearer-format-forbidden",
@@ -110,6 +111,7 @@ var ruleIDs = []string{
 // oasdiff-native lints and the unknown-error fallback. Kept apart so
 // TestRuleIDs_MatchKinCatalog can assert ruleIDs == kin's codes ∪ these.
 var nativeRuleIDs = []string{
+	AmbiguousParameterSerializationID,
 	DuplicateEnumValueID,
 	unknownValidationID,
 }

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -47,6 +47,7 @@ func Validate(spec *openapi3.T, source string) formatters.Findings {
 	}
 	// oasdiff-native SHOULD-level lints that kin-openapi does not enforce.
 	findings = append(findings, lintDuplicateEnums(spec, source)...)
+	findings = append(findings, lintAmbiguousParamSerialization(spec, source)...)
 	return findings
 }
 


### PR DESCRIPTION
Fixes #1055.

A parameter whose schema `type` union mixes a structured type (`array`/`object`) with a scalar has no well-defined style serialization: for `type: [array, integer]` a server cannot tell whether `?token=5` is `["5"]` or `5`. Valid JSON Schema, under-specified for OpenAPI serialization — so `validate` now reports it at **WARN** as `ambiguous-parameter-serialization`, an oasdiff-native lint alongside `duplicate-enum-value`.

Per the issue's scope:
- **`null` is excluded** from the union check — it carries no serialization, so `[array, null]` and `[string, null]` are unambiguous.
- **Two scalars are fine** (`[string, integer]`) — both serialize as a single value.

Implementation:
- The traversal is kin's `openapi3.WalkParameters` (getkin/kin-openapi#1224, written for this): every parameter in the document exactly once — components, path items, operations, **callbacks**, webhooks — with `$ref` dedup at the definition and RFC 6901 pointers as the finding `Section`. Mirrors how `lintDuplicateEnums` uses `WalkSchemas`.
- Source location points at the schema's `type` field via origin tracking; the id joins the validate rule registry (#1101).
- Content-based parameters (no `schema`) are skipped — no style serialization.
- **Dependency note:** bumps kin to a master pseudo-version pending the next kin release (brings the StringMap removal, hence the one-line `mappingToStringMap` type change — backward-compatible).

The issue's `application/x-www-form-urlencoded` request-body extension is left as the follow-up it suggests.