### PR TITLE
deps: bump kin-openapi to v0.143.0

### DIFF
--- a/diff/discriminator_diff.go
+++ b/diff/discriminator_diff.go
@@ -65,7 +65,7 @@ func getDiscriminatorDiffInternal(config *Config, discriminator1, discriminator2
 	return result, nil
 }
 
-func mappingToStringMap(m openapi3.StringMap[openapi3.MappingRef]) map[string]string {
+func mappingToStringMap(m map[string]openapi3.MappingRef) map[string]string {
 	result := make(map[string]string, len(m))
 	for k, v := range m {
 		result[k] = v.Ref

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	cloud.google.com/go v0.123.0
 	github.com/TwiN/go-color v1.4.1
-	github.com/getkin/kin-openapi v0.142.0
+	github.com/getkin/kin-openapi v0.143.0
 	github.com/invopop/jsonschema v0.14.0
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
-github.com/getkin/kin-openapi v0.142.0 h1:izj0vBdFprMhitfzaX8sTqztsEQyvwhssBoB6n8NO7w=
-github.com/getkin/kin-openapi v0.142.0/go.mod h1:3BH9M9XDe/y9M5DSvEocVYAYq1w0qrhJHjC/vZi0AaY=
+github.com/getkin/kin-openapi v0.143.0 h1:mIrOpir9J5x2m1vdree2rhuJ/GYGwbTVBp1kuSCJ62Y=
+github.com/getkin/kin-openapi v0.143.0/go.mod h1:3BH9M9XDe/y9M5DSvEocVYAYq1w0qrhJHjC/vZi0AaY=
 github.com/go-openapi/jsonpointer v0.22.5 h1:8on/0Yp4uTb9f4XvTrM2+1CPrV05QPZXu+rvu2o9jcA=
 github.com/go-openapi/jsonpointer v0.22.5/go.mod h1:gyUR3sCvGSWchA2sUBJGluYMbe1zazrYWIkWPjjMUY0=
 github.com/go-openapi/swag/jsonname v0.25.5 h1:8p150i44rv/Drip4vWI3kGi9+4W9TdI3US3uUYSFhSo=


### PR DESCRIPTION
Bumps `getkin/kin-openapi` from v0.142.0 to v0.143.0.

The only source change: v0.143.0 removes the exported `openapi3.StringMap[V]` type (getkin/kin-openapi#1219), so `mappingToStringMap` takes `map[string]openapi3.MappingRef` instead of `openapi3.StringMap[openapi3.MappingRef]`. The body is unchanged, and the two are equivalent (the named type was already assignable to the unnamed map).

Full build and test suite pass against the released tag (`GOWORK=off`).

The release also lands three APIs consumed in follow-up PRs, so this bump is the foundation for them:
- `T.WalkParameters` (#1224) — used by the ambiguous-parameter-serialization lint (#1103)
- arbitrary-key `$ref` origin fix (#1227) — unskips the cross-file source tests on the review-blocks branch (#1068)
- stable validation-error codes (#1223) — the `validate` rule-ID migration