### PR TITLE
validate: use kin's validation-error codes instead of deriving rule IDs

### DIFF
--- a/diff/discriminator_diff.go
+++ b/diff/discriminator_diff.go
@@ -65,7 +65,7 @@ func getDiscriminatorDiffInternal(config *Config, discriminator1, discriminator2
 	return result, nil
 }
 
-func mappingToStringMap(m openapi3.StringMap[openapi3.MappingRef]) map[string]string {
+func mappingToStringMap(m map[string]openapi3.MappingRef) map[string]string {
 	result := make(map[string]string, len(m))
 	for k, v := range m {
 		result[k] = v.Ref

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	cloud.google.com/go v0.123.0
 	github.com/TwiN/go-color v1.4.1
-	github.com/getkin/kin-openapi v0.142.0
+	github.com/getkin/kin-openapi v0.143.0
 	github.com/invopop/jsonschema v0.14.0
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
-github.com/getkin/kin-openapi v0.142.0 h1:izj0vBdFprMhitfzaX8sTqztsEQyvwhssBoB6n8NO7w=
-github.com/getkin/kin-openapi v0.142.0/go.mod h1:3BH9M9XDe/y9M5DSvEocVYAYq1w0qrhJHjC/vZi0AaY=
+github.com/getkin/kin-openapi v0.143.0 h1:mIrOpir9J5x2m1vdree2rhuJ/GYGwbTVBp1kuSCJ62Y=
+github.com/getkin/kin-openapi v0.143.0/go.mod h1:3BH9M9XDe/y9M5DSvEocVYAYq1w0qrhJHjC/vZi0AaY=
 github.com/go-openapi/jsonpointer v0.22.5 h1:8on/0Yp4uTb9f4XvTrM2+1CPrV05QPZXu+rvu2o9jcA=
 github.com/go-openapi/jsonpointer v0.22.5/go.mod h1:gyUR3sCvGSWchA2sUBJGluYMbe1zazrYWIkWPjjMUY0=
 github.com/go-openapi/swag/jsonname v0.25.5 h1:8p150i44rv/Drip4vWI3kGi9+4W9TdI3US3uUYSFhSo=

--- a/validate/rule_ids.go
+++ b/validate/rule_ids.go
@@ -3,11 +3,12 @@ package validate
 import "slices"
 
 // ruleIDs is the registry of every rule ID validate can emit: the fixed, public
-// ID surface. ruleIDForKinError derives most IDs from strings kin embeds in its
-// typed errors, so without this gate an upstream rename would silently change a
-// public ID; instead, an ID not in the registry is demoted to
-// spec-validation-error, which is loud in the output and is triaged by adding
-// the new ID (or an alias) here deliberately. Sorted; add new IDs in order.
+// ID surface. Most IDs are the stable codes kin-openapi declares on its
+// validation errors (openapi3.ValidationErrorCodes), plus a few oasdiff-native
+// lint IDs. TestRuleIDs_MatchKinCatalog pins the registry to that union, so a
+// kin code added or renamed on a bump fails the build until the registry is
+// updated deliberately. At runtime, a code not in the registry is demoted to
+// spec-validation-error (loud, triaged). Sorted; add new IDs in order.
 var ruleIDs = []string{
 	"additional-properties-both-forms-exclusive",
 	"anchor-field-for-3-1-plus",
@@ -29,6 +30,8 @@ var ruleIDs = []string{
 	"duplicate-enum-value",
 	"duplicate-operation-id",
 	"duplicate-parameter",
+	"duplicate-required-field",
+	"duplicate-tag",
 	"dynamic-anchor-field-for-3-1-plus",
 	"dynamic-ref-field-for-3-1-plus",
 	"else-field-for-3-1-plus",
@@ -101,6 +104,14 @@ var ruleIDs = []string{
 	"value-or-external-value-required",
 	"webhook-nil",
 	"webhooks-field-for-3-1-plus",
+}
+
+// nativeRuleIDs are the ids validate emits that do not come from kin: the
+// oasdiff-native lints and the unknown-error fallback. Kept apart so
+// TestRuleIDs_MatchKinCatalog can assert ruleIDs == kin's codes ∪ these.
+var nativeRuleIDs = []string{
+	DuplicateEnumValueID,
+	unknownValidationID,
 }
 
 // RuleIDs returns every rule ID validate can emit, sorted.

--- a/validate/rule_ids_test.go
+++ b/validate/rule_ids_test.go
@@ -22,22 +22,25 @@ func TestRuleIDs_Registry(t *testing.T) {
 	require.Contains(t, ruleIDs, DuplicateEnumValueID)
 }
 
-// A derived ID outside the registry is demoted to spec-validation-error: an
-// upstream rename or a new validation surfaces loudly instead of silently
-// minting a new public ID.
-func TestKnownRuleID_GatesUnregisteredIDs(t *testing.T) {
-	renamed := ruleIDForKinError(&openapi3.RequiredFieldError{Field: "someRenamedKinField"})
-	require.Equal(t, "some-renamed-kin-field-required", renamed, "derivation still runs")
-	require.Equal(t, unknownValidationID, knownRuleID(renamed), "unregistered id is demoted")
-
-	known := ruleIDForKinError(&openapi3.RequiredFieldError{Field: "oAuthFlow.scopes"})
-	require.Equal(t, "oauth-flow-scopes-required", knownRuleID(known), "registered id passes through")
+// The registry is exactly kin's declared validation-error codes plus the
+// oasdiff-native ids. A kin bump that adds or renames a code fails this until
+// the registry is updated deliberately, so the public ID surface never drifts
+// silently. This replaces the old per-family derivation checks: the ids now
+// come from kin's CodedError.Code(), so kin owns the spellings and this pins
+// only that oasdiff's registry agrees with them.
+func TestRuleIDs_MatchKinCatalog(t *testing.T) {
+	want := slices.Concat(openapi3.ValidationErrorCodes(), nativeRuleIDs)
+	slices.Sort(want)
+	require.Equal(t, want, ruleIDs,
+		"registry and kin catalog diverge: reconcile ruleIDs with openapi3.ValidationErrorCodes() ∪ nativeRuleIDs")
 }
 
-// A 3.2-gated field reports a 3-2-plus id, not 3-1-plus (kin's MinVersion
-// drives the suffix).
-func TestRuleID_VersionMismatchSuffixFollowsMinVersion(t *testing.T) {
-	id := ruleIDForKinError(&openapi3.FieldVersionMismatchError{Field: "itemSchema", MinVersion: "3.2"})
-	require.Equal(t, "item-schema-field-for-3-2-plus", id)
-	require.Equal(t, id, knownRuleID(id), "the 3.2 id is registered")
+// A code the registry does not know is demoted to spec-validation-error; a
+// known code passes through. This guards oasdiff's gate; the codes themselves
+// are kin's (see TestRuleIDs_MatchKinCatalog).
+func TestKnownRuleID_GatesUnregisteredCodes(t *testing.T) {
+	const unregistered = "some-code-kin-does-not-emit"
+	require.NotContains(t, ruleIDs, unregistered)
+	require.Equal(t, unknownValidationID, knownRuleID(unregistered), "an unregistered code is demoted")
+	require.Equal(t, "oauth-flow-scopes-required", knownRuleID("oauth-flow-scopes-required"), "a registered code passes through")
 }

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"strconv"
 	"strings"
-	"unicode"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/oasdiff/oasdiff/checker"
@@ -595,163 +594,14 @@ func fieldLoc(origin *openapi3.Origin, field string) *openapi3.Location {
 	return origin.Key
 }
 
-// ruleIDForKinError dispatches a kin-openapi error to a stable
-// kebab-case rule ID. Uses the typed cluster wrappers from kin's
-// openapi3 package; one arm per cluster covers all the call-site
-// leaves wrapped by that cluster.
-//
-// kin errors not yet migrated to a cluster fall through to
-// unknownValidationID. Where a cluster carries field-name metadata,
-// the rule ID is derived from that — the per-leaf type isn't
-// consulted because (a) the cluster carries enough metadata, and (b)
-// deriving from a single field keeps the dispatch stable as kin adds
-// new leaves. Where a cluster has no useful field for derivation
-// (ServerURLTemplateError carries only the offending URL,
-// PathParametersError carries Path+Method+Missing), a static rule ID
-// is returned for the whole cluster.
+// ruleIDForKinError returns the stable code kin-openapi declares on the
+// validation error (openapi3.CodedError, one per rule), or unknownValidationID
+// for an error that carries no code. knownRuleID gates the result against the
+// registry. See TestRuleIDs_MatchKinCatalog for the registry/kin contract.
 func ruleIDForKinError(err error) string {
-	if rfe, ok := errors.AsType[*openapi3.RequiredFieldError](err); ok {
-		return ruleIDFromField(rfe.Field) + "-required"
+	var coded openapi3.CodedError
+	if errors.As(err, &coded) {
+		return coded.Code()
 	}
-
-	if fvm, ok := errors.AsType[*openapi3.FieldVersionMismatchError](err); ok {
-		return ruleIDFromField(fvm.Field) + "-field-for-" + minVersionForRuleID(fvm.MinVersion) + "-plus"
-	}
-
-	if sve, ok := errors.AsType[*openapi3.SchemaValueError](err); ok {
-		return ruleIDFromField(sve.ValueKind) + "-violates-schema"
-	}
-
-	if _, ok := errors.AsType[*openapi3.PathParametersError](err); ok {
-		return "path-parameters-mismatch"
-	}
-
-	if mef, ok := errors.AsType[*openapi3.MutuallyExclusiveFieldsError](err); ok {
-		return ruleIDFromField(mef.Field1) + "-" + ruleIDFromField(mef.Field2) + "-mutually-exclusive"
-	}
-
-	if ffe, ok := errors.AsType[*openapi3.ForbiddenFieldError](err); ok {
-		return ruleIDFromField(ffe.Field) + "-forbidden"
-	}
-
-	if _, ok := errors.AsType[*openapi3.ServerURLTemplateError](err); ok {
-		return "server-url-template-invalid"
-	}
-
-	if efr, ok := errors.AsType[*openapi3.EitherFieldRequiredError](err); ok {
-		return joinFieldsForRuleID(efr.Fields) + "-required"
-	}
-
-	if sbf, ok := errors.AsType[*openapi3.SchemaBothFormsExclusive](err); ok {
-		return ruleIDFromField(sbf.Field) + "-both-forms-exclusive"
-	}
-
-	if eofe, ok := errors.AsType[*openapi3.ExactlyOneFieldError](err); ok {
-		return joinFieldsForRuleID(eofe.Fields) + "-exactly-one"
-	}
-
-	if sec, ok := errors.AsType[*openapi3.SingleEntryContentError](err); ok {
-		return ruleIDFromField(sec.Subject) + "-content-single-entry"
-	}
-
-	if _, ok := errors.AsType[*openapi3.WebhookNilError](err); ok {
-		return "webhook-nil"
-	}
-
-	if _, ok := errors.AsType[*openapi3.PathParameterRequiredError](err); ok {
-		return "path-parameter-required"
-	}
-
-	if _, ok := errors.AsType[*openapi3.DuplicateOperationIDError](err); ok {
-		return "duplicate-operation-id"
-	}
-
-	if _, ok := errors.AsType[*openapi3.ExtraSiblingFieldsError](err); ok {
-		return "extra-sibling-fields"
-	}
-
-	if _, ok := errors.AsType[*openapi3.SchemaTypeError](err); ok {
-		return "schema-type-unsupported"
-	}
-
-	if _, ok := errors.AsType[*openapi3.InvalidParameterInError](err); ok {
-		return "parameter-in-invalid"
-	}
-
-	if _, ok := errors.AsType[*openapi3.SchemaPatternRegexError](err); ok {
-		return "schema-pattern-regex-invalid"
-	}
-
-	if _, ok := errors.AsType[*openapi3.InvalidSecuritySchemeTypeError](err); ok {
-		return "security-scheme-type-invalid"
-	}
-
-	if _, ok := errors.AsType[*openapi3.InvalidHTTPSchemeError](err); ok {
-		return "security-scheme-http-scheme-invalid"
-	}
-
-	if _, ok := errors.AsType[*openapi3.UnresolvedRefError](err); ok {
-		return "unresolved-ref"
-	}
-
-	if _, ok := errors.AsType[*openapi3.APIKeyInInvalidError](err); ok {
-		return "security-scheme-apikey-in-invalid"
-	}
-
-	if _, ok := errors.AsType[*openapi3.PathMustStartWithSlashError](err); ok {
-		return "path-must-start-with-slash"
-	}
-
-	if _, ok := errors.AsType[*openapi3.ConflictingPathsError](err); ok {
-		return "conflicting-paths"
-	}
-
-	if _, ok := errors.AsType[*openapi3.DuplicateParameterError](err); ok {
-		return "duplicate-parameter"
-	}
-
-	if _, ok := errors.AsType[*openapi3.InvalidSerializationMethodError](err); ok {
-		return "serialization-method-invalid"
-	}
-
 	return unknownValidationID
-}
-
-// joinFieldsForRuleID renders an N-field "any/exactly one of" rule ID
-// fragment as kebab-case fields joined by "-or-" (e.g. ["value",
-// "externalValue"] → "value-or-external-value"). The caller appends
-// the cluster-specific suffix ("-required", "-exactly-one", ...).
-// minVersionForRuleID renders a kin MinVersion ("3.1", "3.2") as a rule-id
-// segment ("3-1", "3-2"). An unexpected value yields an id outside the
-// registry, which knownRuleID demotes to spec-validation-error.
-func minVersionForRuleID(v string) string {
-	return strings.ReplaceAll(v, ".", "-")
-}
-
-func joinFieldsForRuleID(fields []string) string {
-	parts := make([]string, len(fields))
-	for i, f := range fields {
-		parts[i] = ruleIDFromField(f)
-	}
-	return strings.Join(parts, "-or-")
-}
-
-// ruleIDFromField normalises a field path into a kebab-case identifier.
-// Strips a leading "$" (for JSON Schema keywords like "$defs"),
-// replaces "." with "-" (for paths like "info.version"), and inserts
-// "-" before each uppercase letter (for camelCase like "prefixItems").
-func ruleIDFromField(field string) string {
-	field = strings.TrimPrefix(field, "$")
-	field = strings.ReplaceAll(field, ".", "-")
-	// acronyms: camel-splitting "oAuthFlow" would yield "o-auth-flow"
-	field = strings.ReplaceAll(field, "oAuth", "oauth")
-	field = strings.ReplaceAll(field, "openId", "openid")
-	var b strings.Builder
-	for i, r := range field {
-		if i > 0 && unicode.IsUpper(r) {
-			b.WriteByte('-')
-		}
-		b.WriteRune(unicode.ToLower(r))
-	}
-	return b.String()
 }


### PR DESCRIPTION
Stacked on #1105 (the v0.143.0 bump). Consumes getkin/kin-openapi#1223: kin now declares a stable code on every validation error via `openapi3.CodedError`.

- Replaces the ~26-arm `ruleIDForKinError` dispatch and the `ruleIDFromField` / `joinFieldsForRuleID` / `minVersionForRuleID` derivation with one `errors.As` to `CodedError.Code()`. The codes were minted upstream to match oasdiff's existing spellings, so the golden validate IDs are unchanged (the `internal` golden tests pass untouched).
- `duplicate-required-field` and `duplicate-tag`, which oasdiff had no dispatch arm for and demoted to `spec-validation-error`, now surface with their real codes; added to the registry.
- The old derivation drift guard becomes a contract test: the registry equals `openapi3.ValidationErrorCodes()` ∪ `nativeRuleIDs`. A kin bump that adds or renames a code fails the build until the registry is reconciled deliberately. The runtime `knownRuleID` gate stays as the backstop for a code the registry does not yet know.

Net: the whole string-deriving layer (camel-splitting, the acronym special-cases) is deleted; kin owns the spellings, oasdiff owns the gate and the native lints.