### PR TITLE
docs: bring CUSTOMIZING-CHECKS up to the rules registry

### DIFF
--- a/docs/CUSTOMIZING-CHECKS.md
+++ b/docs/CUSTOMIZING-CHECKS.md
@@ -4,7 +4,7 @@
 1. Create a new go file under [checker](../checker), named after the use case, for example `check_request_property_became_nullable.go`.
 2. Define the check ids as constants at the top of the file. Each id is a unique kebab-case string, for example `request-property-became-nullable`. Related ids (request/response, body/property, added/removed) live in the same file.
 3. Write the check function. Use the existing plumbing rather than walking the diff by hand:
-   - `walkModifiedRequestBodySchemas` / `walkModifiedResponseSchemas` visit each modified media type, and `info.walkProperties` visits every modified property (including inside allOf/oneOf/anyOf/items). Build changes with `info.newChange` / `p.newChange`.
+   - `walkModifiedRequestBodySchemas` / `walkModifiedResponseSchemas` call your function once per modified media type with a `mediaTypeInfo`; its `walkProperties` method visits every modified property under that media type (including inside allOf/oneOf/anyOf/items). Build changes with `info.newChange` at the body level and `p.newChange` at the property level.
    - Operation-level checks iterate the diff directly and build changes with `opInfo.NewApiChange`.
    - A change computed from a schema node should carry that node: the walkers do it automatically; parameter checks chain `.WithSchema(schemaDiff)`. This lets a recognized schema transition (for example, a schema wrapped in a nullable `oneOf`) claim the change so one transition is reported once, not once per raw field it touches. See [checker/transition_claims.go](../checker/transition_claims.go).
 

--- a/docs/CUSTOMIZING-CHECKS.md
+++ b/docs/CUSTOMIZING-CHECKS.md
@@ -1,25 +1,30 @@
-# How to Add Custom Breaking-Changes Checks
+# How to Add Breaking-Changes Checks
 
-## Unit Test
-1. Add a unit test for your scenario in one of the test files under [checker](../checker) with a comment "BC: \<use-case\> is breaking"
-2. Add any accompanying OpenAPI specs under [data](../data)
+## Write the Check Function
+1. Create a new go file under [checker](../checker), named after the use case, for example `check_request_property_became_nullable.go`.
+2. Define the check ids as constants at the top of the file. Each id is a unique kebab-case string, for example `request-property-became-nullable`. Related ids (request/response, body/property, added/removed) live in the same file.
+3. Write the check function. Use the existing plumbing rather than walking the diff by hand:
+   - `walkModifiedRequestBodySchemas` / `walkModifiedResponseSchemas` visit each modified media type, and `info.walkProperties` visits every modified property (including inside allOf/oneOf/anyOf/items). Build changes with `info.newChange` / `p.newChange`.
+   - Operation-level checks iterate the diff directly and build changes with `opInfo.NewApiChange`.
+   - A change computed from a schema node should carry that node: the walkers do it automatically; parameter checks chain `.WithSchema(schemaDiff)`. This lets a recognized schema transition (for example, a schema wrapped in a nullable `oneOf`) claim the change so one transition is reported once, not once per raw field it touches. See [checker/transition_claims.go](../checker/transition_claims.go).
+
+## Register the Rules
+Add one rule per id to `GetAllRules()` in [checker/rules.go](../checker/rules.go):
+
+```go
+newBackwardCompatibilityRule(RequestParameterBecameNotNullableId, ERR, RequestParameterBecameNullableCheck, DirectionRequest, AreaParameters, KindRequiredness, ActionChange),
+```
+
+- **Level**: `ERR` for breaking changes, `WARN` for potentially breaking, `INFO` for backward compatible. Requests and responses are usually contravariant: what is breaking on one side is often the opposite action on the other (adding a required request property breaks clients; on the response side it is removing a property that does).
+- **Direction / Area / Kind / Action** classify the rule in the taxonomy. `TestRuleSymmetry` audits it: a rule with no mirror across an axis fails the build unless the asymmetry is waived with a reason in [checker/rule_symmetry_test.go](../checker/rule_symmetry_test.go). When you add a check, add its mirror too, or record why it is intentionally absent.
 
 ## Localized Messages
-1. Add localized texts under [checker/localizations_src](../checker/localizations_src)
-2. Update [localization source file](../checker/localizations/localizations.go):
-    ```
-    go-localize -input checker/localizations_src -output checker/localizations
-    ```   
-    To install go-localize:
-    ```
-    go install github.com/m1/go-localize@latest
-    ```
-3. Make sure that [checker/localizations/localizations.go](../checker/localizations/localizations.go) contains the new messages
+1. For each id, add two keys in **all four locales** under [checker/localizations_src](../checker/localizations_src) (en, es, pt-br, ru): the message (`request-parameter-became-not-nullable: the %s request parameter %s became not nullable`) and the description (`request-parameter-became-not-nullable-description: ...`), which the `oasdiff checks` command and the rule catalog display. If a translation isn't ready, copy the English text as a placeholder so the key exists.
+2. Run `make localize` to regenerate [checker/localizations/localizations.go](../checker/localizations/localizations.go).
 
-## Write the Checker Function
-1. Create new go file under [checker](../checker) and name it by the breaking change use case
-2. Create a check func inside the file and name it accordingly
-3. Add the checker func to the defaultChecks or optionalChecks list
+## Tests
+1. Add a unit test in a file mirroring your check file's name, with OpenAPI spec fixtures under [data](../data). Assert the exact set of reported ids, not just presence, so unrelated findings fail the test.
+2. Bump `numOfChecks` and `numOfIds` in [checker/config_test.go](../checker/config_test.go).
 
 ## Example
-See this example of adding a custom check: https://github.com/oasdiff/oasdiff/pull/208/files
+A complete, current example, new ids, registration, four-locale messages and descriptions, fixtures and tests: [#1093](https://github.com/oasdiff/oasdiff/pull/1093).


### PR DESCRIPTION
The doc predated the rules registry: it pointed at `defaultChecks`/`optionalChecks` (removed long ago), a manual `go-localize` invocation instead of `make localize`, and a 2022 example PR.

Rewritten to the current flow, in order: the check function (walker plumbing, id constants, `WithSchema` and the transition claim table), registration in `GetAllRules` with the Direction/Area/Kind/Action taxonomy and the `TestRuleSymmetry` mirror-or-waiver rule, messages **and** `-description` keys in all four locales via `make localize`, the `numOfChecks`/`numOfIds` counters, and #1093 as a complete current example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)