### PR TITLE
docs: validate's duplicate-enum lint; allOf's dropped keywords

### DIFF
--- a/docs/ALLOF.md
+++ b/docs/ALLOF.md
@@ -43,6 +43,8 @@ The following schema fields are not merged:
 - Discriminator
 - `$defs` (OpenAPI 3.1) — intentionally dropped from the flattened output. `$defs` is a reusable-schema namespace used as the target of `$ref` pointers. After `--flatten-allof` runs, the merged schema has no `$ref`s left to resolve, so the namespace contributes nothing to its semantics. Preserving it would only add noise (and risk silent collisions when two `allOf` subschemas define different things under the same `$defs` key).
 
+In addition, the following fields are currently **dropped** from the flattened output, even for schemas that contain no `allOf` at all: `if`/`then`/`else`, `dependentSchemas`, and `unevaluatedProperties`. This is a known limitation ([#1097](https://github.com/oasdiff/oasdiff/issues/1097)); dropping `unevaluatedProperties: false` turns a closed schema into an open one, and dropping the conditionals removes validation branches, so a change inside them disappears from a `--flatten-allof` comparison.
+
 ## Invalid input handling
 
 The merger is defensive about spec violations — values that would crash the merge or produce nonsense are silently skipped rather than reported. For example, `multipleOf` values that are zero or negative (disallowed by the OpenAPI / JSON Schema spec) are dropped from the merged result. To surface invalid values in your spec rather than rely on the merger swallowing them, validate the spec separately.

--- a/docs/VALIDATE.md
+++ b/docs/VALIDATE.md
@@ -46,7 +46,7 @@ All findings are reported in one pass (multi-error), not just the first one.
 Every finding comes from the OpenAPI / JSON Schema rules, but they are classified by impact:
 
 - **error** — the spec can't be reliably consumed: missing required fields, unresolved `$ref`s, invalid types, malformed paths, and similar structural breaks. Also `duplicate-operation-id`, since a non-unique operationId breaks code generators.
-- **warning** — structurally valid but a real risk: a 3.1-only field in an older doc, `$ref` siblings that are silently ignored, conflicting paths, duplicate parameters, and a `default` value that doesn't match its schema.
+- **warning** — structurally valid but a real risk: a 3.1-only field in an older doc, `$ref` siblings that are silently ignored, conflicting paths, duplicate parameters, a `default` value that doesn't match its schema, and duplicate enum values (JSON Schema says enum entries SHOULD be unique; a duplicate usually signals a copy-paste error).
 - **info** — informational only: an `example` that doesn't match its schema (the contract itself is valid).
 
 `--fail-on` decides which severities fail the command (see Exit codes). The classification is currently fixed; per-rule customization may be added later.

--- a/docs/VALIDATE.md
+++ b/docs/VALIDATE.md
@@ -2,7 +2,7 @@
 
 `oasdiff validate <spec>` checks a single OpenAPI spec for per-RFC violations: invalid `type` values, missing required fields, malformed paths, bad regex patterns, unresolved `$ref`s, and similar structural problems. It validates the document against the OpenAPI and JSON Schema rules.
 
-It is not a configurable style linter (like Spectral); every finding is a spec-defined violation, classified by severity (error, warning, or info).
+It is not a configurable style linter (like Spectral); findings are spec-defined violations, plus a small set of oasdiff-native lints for constructs that are valid JSON Schema but under-specified for OpenAPI (duplicate enum values, ambiguous parameter serialization). Each finding is classified by severity (error, warning, or info).
 
 This is distinct from `breaking` / `changelog`, which compare two specs. `validate` looks at one spec and answers "is this a valid OpenAPI document?".
 
@@ -46,7 +46,7 @@ All findings are reported in one pass (multi-error), not just the first one.
 Every finding comes from the OpenAPI / JSON Schema rules, but they are classified by impact:
 
 - **error** — the spec can't be reliably consumed: missing required fields, unresolved `$ref`s, invalid types, malformed paths, and similar structural breaks. Also `duplicate-operation-id`, since a non-unique operationId breaks code generators.
-- **warning** — structurally valid but a real risk: a 3.1-only field in an older doc, `$ref` siblings that are silently ignored, conflicting paths, duplicate parameters, a `default` value that doesn't match its schema, and duplicate enum values (JSON Schema says enum entries SHOULD be unique; a duplicate usually signals a copy-paste error).
+- **warning** — structurally valid but a real risk: a 3.1-only field in an older doc, `$ref` siblings that are silently ignored, conflicting paths, duplicate parameters, a `default` value that doesn't match its schema, duplicate enum values (JSON Schema says enum entries SHOULD be unique; a duplicate usually signals a copy-paste error), and a parameter whose `type` union mixes a structured type with a scalar (`type: [array, integer]` has no well-defined serialization: a server cannot tell whether `?token=5` is `["5"]` or `5`).
 - **info** — informational only: an `example` that doesn't match its schema (the contract itself is valid).
 
 `--fail-on` decides which severities fail the command (see Exit codes). The classification is currently fixed; per-rule customization may be added later.


### PR DESCRIPTION
Two accuracy fixes found while sweeping the docs after #1107:

- **VALIDATE.md** predates both oasdiff-native lints: `duplicate-enum-value` (#1023) and `ambiguous-parameter-serialization` (#1103). Both join the warning-severity examples, and the intro no longer claims every finding is a spec-defined violation.
- **ALLOF.md** listed fields as "not merged", but `if`/`then`/`else`, `dependentSchemas`, and `unevaluatedProperties` are dropped outright, even for schemas with no `allOf` — with semantic consequences (a closed schema opens; changes inside conditionals vanish from a `--flatten-allof` comparison). Stated plainly and linked to #1097.

🤖 Generated with [Claude Code](https://claude.com/claude-code)