### PR TITLE
validate: flag a required parameter or property that also has a default

### DIFF
--- a/docs/VALIDATE.md
+++ b/docs/VALIDATE.md
@@ -2,7 +2,7 @@
 
 `oasdiff validate <spec>` checks a single OpenAPI spec for per-RFC violations: invalid `type` values, missing required fields, malformed paths, bad regex patterns, unresolved `$ref`s, and similar structural problems. It validates the document against the OpenAPI and JSON Schema rules.
 
-It is not a configurable style linter (like Spectral); findings are spec-defined violations, plus a small set of oasdiff-native lints for constructs that are valid JSON Schema but under-specified for OpenAPI (duplicate enum values, ambiguous parameter serialization). Each finding is classified by severity (error, warning, or info).
+It is not a configurable style linter (like Spectral); findings are spec-defined violations, plus a small set of oasdiff-native lints for constructs that are valid OpenAPI but contradictory or under-specified (duplicate enum values, ambiguous parameter serialization, and a required parameter or property that also declares a default, where the default can never apply). Each finding is classified by severity (error, warning, or info).
 
 This is distinct from `breaking` / `changelog`, which compare two specs. `validate` looks at one spec and answers "is this a valid OpenAPI document?".
 

--- a/validate/lint_required_with_default.go
+++ b/validate/lint_required_with_default.go
@@ -1,0 +1,86 @@
+package validate
+
+import (
+	"fmt"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/oasdiff/checker"
+	"github.com/oasdiff/oasdiff/formatters"
+)
+
+// RequiredWithDefaultID flags a required parameter or property that also
+// declares a default value. The two contradict each other: `required` means the
+// value must always be present, so the `default` (the value assumed when it is
+// absent) can never apply. It is dead and misleading, and usually a mistake,
+// the author meant the field to be optional. Valid OpenAPI, an oasdiff-native
+// SHOULD-level lint.
+const RequiredWithDefaultID = "required-with-default"
+
+// lintRequiredWithDefault reports, at WARN, every required parameter and every
+// required schema property that also has a default value. Parameters are
+// visited with WalkParameters and schema properties with WalkSchemas, so each
+// is reported once at its definition and $ref dedup is owned upstream.
+func lintRequiredWithDefault(spec *openapi3.T, source string) formatters.Findings {
+	var findings formatters.Findings
+
+	// Required parameters (query, path, header, cookie) with a default.
+	_ = spec.WalkParameters(func(jsonPointer string, ref *openapi3.ParameterRef) error {
+		p := ref.Value // WalkParameters guarantees ref and ref.Value are non-nil
+		if p.Required && p.Schema != nil && p.Schema.Value != nil && p.Schema.Value.Default != nil {
+			line, column := defaultLocation(p.Schema.Value)
+			findings = append(findings, newRequiredWithDefaultFinding(
+				fmt.Sprintf("required parameter %q has a default value, which is never used because a required parameter must always be sent", p.Name),
+				jsonPointer, p.Name, line, column, source))
+		}
+		return nil
+	})
+
+	// Required schema properties with a default. A schema's `required` lists
+	// property names; the default lives on each property's own schema.
+	_ = spec.WalkSchemas(func(jsonPointer string, ref *openapi3.SchemaRef) error {
+		s := ref.Value // WalkSchemas guarantees ref and ref.Value are non-nil
+		for _, name := range s.Required {
+			prop, ok := s.Properties[name]
+			if !ok || prop.Value == nil || prop.Value.Default == nil {
+				continue
+			}
+			line, column := defaultLocation(prop.Value)
+			findings = append(findings, newRequiredWithDefaultFinding(
+				fmt.Sprintf("required property %q has a default value, which is never used because a required property must always be present", name),
+				jsonPointer+"/properties/"+name, name, line, column, source))
+		}
+		return nil
+	})
+
+	return findings
+}
+
+func newRequiredWithDefaultFinding(text, section, name string, line, column int, source string) formatters.Finding {
+	f := formatters.Finding{
+		Id:      RequiredWithDefaultID,
+		Text:    text,
+		Level:   checker.WARN,
+		Section: section,
+		Source: formatters.Source{
+			File:   source,
+			Line:   line,
+			Column: column,
+		},
+	}
+	f.Fingerprint = checker.ComputeFingerprint(f.Id, "", section, []any{name})
+	return f
+}
+
+// defaultLocation returns the line/column of the schema's `default` field when
+// origin tracking is enabled, falling back to the schema's own location, then 0.
+func defaultLocation(s *openapi3.Schema) (int, int) {
+	if s.Origin != nil {
+		if loc, ok := s.Origin.Fields["default"]; ok {
+			return loc.Line, loc.Column
+		}
+		if s.Origin.Key != nil {
+			return s.Origin.Key.Line, s.Origin.Key.Column
+		}
+	}
+	return 0, 0
+}

--- a/validate/lint_required_with_default_test.go
+++ b/validate/lint_required_with_default_test.go
@@ -1,0 +1,110 @@
+package validate
+
+import (
+	"testing"
+
+	"github.com/oasdiff/oasdiff/checker"
+	"github.com/stretchr/testify/require"
+)
+
+const requiredWithDefaultSpec = `
+openapi: 3.0.0
+info: { title: t, version: "1" }
+paths:
+  /x:
+    get:
+      parameters:
+        - name: version        # required + default -> flag
+          in: query
+          required: true
+          schema:
+            type: string
+            default: v1
+        - name: page           # optional + default -> ok
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 1
+        - name: id             # required, no default -> ok
+          in: query
+          required: true
+          schema:
+            type: string
+      responses: { "200": { description: ok } }
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        region:                # required + default -> flag
+          type: string
+          default: us-east-1
+        name:                  # required, no default -> ok
+          type: string
+        note:                  # optional + default -> ok
+          type: string
+          default: ""
+        address:               # nested object; its required prop + default -> flag (recursive)
+          type: object
+          properties:
+            zip:
+              type: string
+              default: "00000"
+          required: [zip]
+      required: [region, name, address]
+`
+
+const cleanRequiredSpec = `
+openapi: 3.0.0
+info: { title: t, version: "1" }
+paths:
+  /x:
+    get:
+      parameters:
+        - name: page
+          in: query
+          schema:
+            type: integer
+            default: 1
+      responses: { "200": { description: ok } }
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        region:
+          type: string
+          default: us-east-1
+      required: []
+`
+
+// WARN on a required parameter with a default and a required property with a
+// default; leave optional-with-default and required-without-default alone.
+func TestLintRequiredWithDefault(t *testing.T) {
+	findings := lintRequiredWithDefault(mustLoad(t, requiredWithDefaultSpec), "spec.yaml")
+	require.Len(t, findings, 3) // required param, top-level required property, and the nested one
+
+	texts := map[string]bool{}
+	sections := map[string]bool{}
+	for _, f := range findings {
+		require.Equal(t, RequiredWithDefaultID, f.Id)
+		require.Equal(t, checker.WARN, f.Level)
+		require.Equal(t, "spec.yaml", f.Source.File)
+		require.NotEmpty(t, f.Fingerprint)
+		require.NotEmpty(t, f.Section)
+		texts[f.Text] = true
+		sections[f.Section] = true
+	}
+	require.True(t, texts[`required parameter "version" has a default value, which is never used because a required parameter must always be sent`])
+	require.True(t, texts[`required property "region" has a default value, which is never used because a required property must always be present`])
+	// WalkSchemas is recursive, so a required-with-default nested inside another
+	// object is caught too, at its exact JSON pointer.
+	require.True(t, sections["/components/schemas/User/properties/address/properties/zip"])
+}
+
+// A spec with only optional-with-default and required-without-default produces
+// no findings.
+func TestLintRequiredWithDefault_Clean(t *testing.T) {
+	require.Empty(t, lintRequiredWithDefault(mustLoad(t, cleanRequiredSpec), "spec.yaml"))
+}

--- a/validate/rule_ids.go
+++ b/validate/rule_ids.go
@@ -78,6 +78,7 @@ var ruleIDs = []string{
 	"property-names-field-for-3-1-plus",
 	"read-only-write-only-mutually-exclusive",
 	"request-body-content-required",
+	"required-with-default",
 	"response-description-required",
 	"responses-required",
 	"schema-field-for-3-1-plus",
@@ -113,6 +114,7 @@ var ruleIDs = []string{
 var nativeRuleIDs = []string{
 	AmbiguousParameterSerializationID,
 	DuplicateEnumValueID,
+	RequiredWithDefaultID,
 	unknownValidationID,
 }
 

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -48,6 +48,7 @@ func Validate(spec *openapi3.T, source string) formatters.Findings {
 	// oasdiff-native SHOULD-level lints that kin-openapi does not enforce.
 	findings = append(findings, lintDuplicateEnums(spec, source)...)
 	findings = append(findings, lintAmbiguousParamSerialization(spec, source)...)
+	findings = append(findings, lintRequiredWithDefault(spec, source)...)
 	return findings
 }
 


### PR DESCRIPTION
A required field and a default value contradict each other: `required` means the value must always be present, so the `default` (the value assumed when it is absent) can never apply. It is dead and misleading, docs render a mandatory marker next to a default value, and it is usually a **mistake** (the author meant the field to be optional).

Adds an oasdiff-native **WARN**-level lint, `required-with-default`, that flags it for both **required parameters** and **required schema properties**.

**Coverage.** Uses `WalkParameters` and `WalkSchemas`, so it is fully recursive: a required-with-default nested inside another object, inside array `items`, or inside a composition branch is all caught (there is a nested-case test asserting this), and a `$ref`'d definition is reported once at its definition with an exact JSON-pointer section.

**Relationship to the diff check.** This complements `new-required-request-property-with-default` (the breaking-change check), which only fires when such a field is *added* between two spec versions. The validate lint catches the anti-pattern in a *single* spec at authoring time, whether or not anything changed.

Example:

```
warning	[required-with-default] at spec.yaml:7:79
	required parameter "version" has a default value, which is never used because a required parameter must always be sent
```

Registered in `nativeRuleIDs` and the `ruleIDs` registry; VALIDATE.md updated. Full suite, `go vet`, and gofmt pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)