### PR TITLE
docs: point the online catalog link to /docs/breaking-changes

### DIFF
--- a/docs/BREAKING-CHANGES.md
+++ b/docs/BREAKING-CHANGES.md
@@ -30,7 +30,7 @@ The comparison is encrypted on your machine before upload, with a one-time key t
 The resulting URL works for 7 days. Paste it into a PR comment or Slack and reviewers can open the review without installing the CLI themselves. Anyone you give the full link to can open it (the part after the `#` is the decryption key), so treat it like a secret.
 
 ## Checks
-Oasdiff supports hundreds of checks (run `oasdiff checks` for the current list, or browse the full catalog at [oasdiff.com/checks](https://www.oasdiff.com/checks)), categorized into three levels:  
+Oasdiff supports hundreds of checks (run `oasdiff checks` for the current list, or browse the full catalog at [oasdiff.com/docs/breaking-changes](https://www.oasdiff.com/docs/breaking-changes)), categorized into three levels:  
 - `ERR` - Errors are definite breaking changes which should be avoided
 - `WARN` - Warnings are potential breaking changes which developers should be aware of, but cannot be confirmed programmatically as breaking
 - `INFO` - Non-breaking changes

--- a/docs/CHECKS.md
+++ b/docs/CHECKS.md
@@ -28,7 +28,7 @@ Checks are categorized into three severity levels:
 - `warn` — potential breaking changes which cannot be confirmed programmatically
 - `info` — non-breaking changes
 
-Run `oasdiff checks` for the current list, or browse the full catalog at [oasdiff.com/checks](https://www.oasdiff.com/checks).
+Run `oasdiff checks` for the current list, or browse the full catalog at [oasdiff.com/docs/breaking-changes](https://www.oasdiff.com/docs/breaking-changes).
 
 ## Categorization
 Every check is categorized along independent axes, emitted as fields in the `json` and `yaml` output:


### PR DESCRIPTION
The `/checks` filter page is being retired in favor of `oasdiff.com/docs/breaking-changes` (the canonical, server-rendered, searchable catalog). Repoints the two "browse the full catalog" links in `CHECKS.md` and `BREAKING-CHANGES.md`.

(The `/checks` URL still 301-redirects there, so old links keep working; this just avoids the hop.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)