### PR TITLE
review: include the oasdiff version and platform in the encrypted review bundle

### DIFF
--- a/docs/BREAKING-CHANGES.md
+++ b/docs/BREAKING-CHANGES.md
@@ -30,7 +30,7 @@ The comparison is encrypted on your machine before upload, with a one-time key t
 The resulting URL works for 7 days. Paste it into a PR comment or Slack and reviewers can open the review without installing the CLI themselves. Anyone you give the full link to can open it (the part after the `#` is the decryption key), so treat it like a secret.
 
 ## Checks
-Oasdiff supports hundreds of checks (run `oasdiff checks` for the current list, or browse the full catalog at [oasdiff.com/checks](https://www.oasdiff.com/checks)), categorized into three levels:  
+Oasdiff supports hundreds of checks (run `oasdiff checks` for the current list, or browse the full catalog at [oasdiff.com/docs/breaking-changes](https://www.oasdiff.com/docs/breaking-changes)), categorized into three levels:  
 - `ERR` - Errors are definite breaking changes which should be avoided
 - `WARN` - Warnings are potential breaking changes which developers should be aware of, but cannot be confirmed programmatically as breaking
 - `INFO` - Non-breaking changes

--- a/docs/CHECKS.md
+++ b/docs/CHECKS.md
@@ -28,7 +28,7 @@ Checks are categorized into three severity levels:
 - `warn` — potential breaking changes which cannot be confirmed programmatically
 - `info` — non-breaking changes
 
-Run `oasdiff checks` for the current list, or browse the full catalog at [oasdiff.com/checks](https://www.oasdiff.com/checks).
+Run `oasdiff checks` for the current list, or browse the full catalog at [oasdiff.com/docs/breaking-changes](https://www.oasdiff.com/docs/breaking-changes).
 
 ## Categorization
 Every check is categorized along independent axes, emitted as fields in the `json` and `yaml` output:

--- a/internal/open_review.go
+++ b/internal/open_review.go
@@ -108,6 +108,7 @@ func uploadAndOpen(flags *Flags, stderr io.Writer, isBreaking bool, errs checker
 		Composed:         flags.getComposed(),
 		Blocks:           blocks,
 		ToolVersion:      build.Version,
+		Platform:         os.Getenv("PLATFORM"),
 	}.Encrypt()
 	if err != nil {
 		return fmt.Errorf("encrypt review: %w", err)

--- a/internal/open_review.go
+++ b/internal/open_review.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/oasdiff/build"
 	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/formatters"
 	"github.com/oasdiff/oasdiff/load"
@@ -106,6 +107,7 @@ func uploadAndOpen(flags *Flags, stderr io.Writer, isBreaking bool, errs checker
 		Mode:             mode,
 		Composed:         flags.getComposed(),
 		Blocks:           blocks,
+		ToolVersion:      build.Version,
 	}.Encrypt()
 	if err != nil {
 		return fmt.Errorf("encrypt review: %w", err)

--- a/review/encrypt_test.go
+++ b/review/encrypt_test.go
@@ -26,7 +26,7 @@ func decryptBlob(t *testing.T, blob, key []byte) []byte {
 }
 
 func TestPayloadEncrypt_RoundTrip(t *testing.T) {
-	p := Payload{RevisionSpec: "openapi: 3.0.0", Mode: "changelog", ToolVersion: "v1.25.1"}
+	p := Payload{RevisionSpec: "openapi: 3.0.0", Mode: "changelog", ToolVersion: "v1.25.1", Platform: "github-action"}
 	blob, key, err := p.Encrypt()
 	require.NoError(t, err)
 	require.Len(t, key, 32, "AES-256 needs a 256-bit key")
@@ -39,6 +39,7 @@ func TestPayloadEncrypt_RoundTrip(t *testing.T) {
 	require.Equal(t, p.RevisionSpec, got.RevisionSpec)
 	require.Equal(t, p.Mode, got.Mode)
 	require.Equal(t, p.ToolVersion, got.ToolVersion, "the producing oasdiff version travels inside the bundle")
+	require.Equal(t, p.Platform, got.Platform, "the producing platform travels inside the bundle")
 
 	// Two encryptions of the same payload must differ (fresh key + nonce), so a
 	// server seeing two identical specs can't tell they're identical.

--- a/review/encrypt_test.go
+++ b/review/encrypt_test.go
@@ -26,7 +26,7 @@ func decryptBlob(t *testing.T, blob, key []byte) []byte {
 }
 
 func TestPayloadEncrypt_RoundTrip(t *testing.T) {
-	p := Payload{RevisionSpec: "openapi: 3.0.0", Mode: "changelog"}
+	p := Payload{RevisionSpec: "openapi: 3.0.0", Mode: "changelog", ToolVersion: "v1.25.1"}
 	blob, key, err := p.Encrypt()
 	require.NoError(t, err)
 	require.Len(t, key, 32, "AES-256 needs a 256-bit key")
@@ -38,6 +38,7 @@ func TestPayloadEncrypt_RoundTrip(t *testing.T) {
 	require.NoError(t, json.Unmarshal(decryptBlob(t, blob, key), &got))
 	require.Equal(t, p.RevisionSpec, got.RevisionSpec)
 	require.Equal(t, p.Mode, got.Mode)
+	require.Equal(t, p.ToolVersion, got.ToolVersion, "the producing oasdiff version travels inside the bundle")
 
 	// Two encryptions of the same payload must differ (fresh key + nonce), so a
 	// server seeing two identical specs can't tell they're identical.

--- a/review/payload.go
+++ b/review/payload.go
@@ -28,6 +28,13 @@ type Payload struct {
 	// the filenames are empty and the blocks carry the comparison.
 	Composed bool    `json:"composed,omitempty" yaml:"composed,omitempty"`
 	Blocks   []Block `json:"blocks,omitempty" yaml:"blocks,omitempty"`
+	// ToolVersion is the oasdiff version that produced the bundle (build.Version,
+	// e.g. "v1.25.1"; "main" for a dev build). It travels inside the encrypted
+	// bundle, so the receiving review page can tell when a review came from an
+	// outdated oasdiff and nudge an upgrade. Empty for bundles from older
+	// clients that predate this field. The GitHub Action inherits it, it runs
+	// this same CLI with --open.
+	ToolVersion string `json:"tool_version,omitempty" yaml:"tool_version,omitempty"`
 }
 
 // Change is one manifest entry sent alongside the encrypted bundle in

--- a/review/payload.go
+++ b/review/payload.go
@@ -35,6 +35,12 @@ type Payload struct {
 	// clients that predate this field. The GitHub Action inherits it, it runs
 	// this same CLI with --open.
 	ToolVersion string `json:"tool_version,omitempty" yaml:"tool_version,omitempty"`
+	// Platform is where the bundle was produced, from the PLATFORM environment
+	// variable: "github-action" when the CLI runs inside the oasdiff GitHub
+	// Action (which sets it in its image), empty for a plain CLI invocation. It
+	// lets the review page tailor an upgrade nudge (bump the action vs set up
+	// the action).
+	Platform string `json:"platform,omitempty" yaml:"platform,omitempty"`
 }
 
 // Change is one manifest entry sent alongside the encrypted bundle in


### PR DESCRIPTION
Adds two fields to `review.Payload`, set by the CLI when it builds the `--open` bundle, so the review page can tailor an upgrade prompt after decryption:

- **`ToolVersion`** (`build.Version`, e.g. `v1.25.1`) — the oasdiff version that produced the bundle, so the page can tell when a review came from an outdated oasdiff.
- **`Platform`** (from the `PLATFORM` env, `github-action` inside the Action, empty for a plain CLI run) — where it was produced, so the page can say the right thing (bump the Action vs set up the Action).

Both travel **inside** the encrypted bundle, so they stay zero-knowledge. The **GitHub Action inherits both automatically**: it runs this same CLI with `--open` (free path and Pro `--review-token` path both go through `open_review.go`), and it already sets `PLATFORM=github-action` in its image, so no action change is needed.

`omitempty`, so bundles from older clients and the receiving side both degrade cleanly; a dev build sends `ToolVersion: "main"` and no platform.

Round-trip covered by `TestPayloadEncrypt_RoundTrip`. Full suite, vet, and gofmt pass.