### PR TITLE
Add OASDIFF_INTERNAL to tag a review as a test review

### DIFF
--- a/internal/open_review.go
+++ b/internal/open_review.go
@@ -39,16 +39,27 @@ func oasdiffSiteURL() string {
 	return "https://www.oasdiff.com"
 }
 
-// internalReviewMarker returns "?internal=1" when OASDIFF_INTERNAL=1 is set,
-// otherwise "". Setting it tags a review as a test review, both on the upload
-// and in the opened URL, so the web app can tell an author checking their own
-// changes apart from a real user's review. Unset (the default) for every
-// normal run.
-func internalReviewMarker() string {
-	if os.Getenv("OASDIFF_INTERNAL") == "1" {
-		return "?internal=1"
+// internalReview reports whether OASDIFF_INTERNAL=1 is set. When it is, siteURL
+// tags the upload and the opened URL with an internal marker, so the web app
+// can tell a review an author opens to check their own changes apart from a
+// real user's review. Off by default, so a normal run is unchanged.
+func internalReview() bool {
+	return os.Getenv("OASDIFF_INTERNAL") == "1"
+}
+
+// siteURL builds a URL under the web product (see oasdiffSiteURL) from path
+// segments, each escaped as a single segment, adding the internal-review
+// marker query when internalReview is set. The caller sets any #fragment.
+func siteURL(segments ...string) (*url.URL, error) {
+	u, err := url.Parse(oasdiffSiteURL())
+	if err != nil {
+		return nil, err
 	}
-	return ""
+	u = u.JoinPath(segments...)
+	if internalReview() {
+		u.RawQuery = url.Values{"internal": {"1"}}.Encode()
+	}
+	return u, nil
 }
 
 // oasdiffAPIBaseURL is the backend API base, used only by the authenticated
@@ -137,16 +148,16 @@ func uploadAndOpen(flags *Flags, stderr io.Writer, isBreaking bool, errs checker
 		return err
 	}
 
+	u, err := siteURL("review", "e", reviewID)
+	if err != nil {
+		return err
+	}
 	// The key rides in the URL #fragment. Browsers never transmit the
 	// fragment to a server (not in the request path, query, or Referer), so
 	// neither the server nor any intermediary sees the key -- only code
 	// running in the visitor's own browser can read it.
-	reviewURL := fmt.Sprintf("%s/review/e/%s%s#k=%s",
-		oasdiffSiteURL(),
-		url.PathEscape(reviewID),
-		internalReviewMarker(),
-		base64.RawURLEncoding.EncodeToString(key),
-	)
+	u.Fragment = "k=" + base64.RawURLEncoding.EncodeToString(key)
+	reviewURL := u.String()
 
 	_, _ = fmt.Fprintf(stderr, "\nOpening %s (expires %s)\n", reviewURL, expiresAt.Format("2006-01-02 15:04 MST"))
 	if err := openBrowser(reviewURL); err != nil {
@@ -193,7 +204,11 @@ func specSetDocsAndSources(specs []*load.SpecInfo) ([]*openapi3.T, map[string]st
 // it cannot read, so it has nothing to attribute to a user. The body is the
 // raw blob; the response is JSON {review_id, expires_at}.
 func postEncryptedReview(blob []byte) (string, time.Time, error) {
-	endpoint := oasdiffSiteURL() + "/api/encrypted-review" + internalReviewMarker()
+	u, err := siteURL("api", "encrypted-review")
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	endpoint := u.String()
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, endpoint, bytes.NewReader(blob))
 	if err != nil {
 		return "", time.Time{}, err

--- a/internal/open_review.go
+++ b/internal/open_review.go
@@ -39,6 +39,18 @@ func oasdiffSiteURL() string {
 	return "https://www.oasdiff.com"
 }
 
+// internalReviewMarker returns "?internal=1" when OASDIFF_INTERNAL=1 is set,
+// otherwise "". Setting it tags a review as a test review, both on the upload
+// and in the opened URL, so the web app can tell an author checking their own
+// changes apart from a real user's review. Unset (the default) for every
+// normal run.
+func internalReviewMarker() string {
+	if os.Getenv("OASDIFF_INTERNAL") == "1" {
+		return "?internal=1"
+	}
+	return ""
+}
+
 // oasdiffAPIBaseURL is the backend API base, used only by the authenticated
 // review upload (the free path posts to oasdiffSiteURL). Override with
 // OASDIFF_API_URL; defaults to api.oasdiff.com.
@@ -129,9 +141,10 @@ func uploadAndOpen(flags *Flags, stderr io.Writer, isBreaking bool, errs checker
 	// fragment to a server (not in the request path, query, or Referer), so
 	// neither the server nor any intermediary sees the key -- only code
 	// running in the visitor's own browser can read it.
-	reviewURL := fmt.Sprintf("%s/review/e/%s#k=%s",
+	reviewURL := fmt.Sprintf("%s/review/e/%s%s#k=%s",
 		oasdiffSiteURL(),
 		url.PathEscape(reviewID),
+		internalReviewMarker(),
 		base64.RawURLEncoding.EncodeToString(key),
 	)
 
@@ -180,7 +193,7 @@ func specSetDocsAndSources(specs []*load.SpecInfo) ([]*openapi3.T, map[string]st
 // it cannot read, so it has nothing to attribute to a user. The body is the
 // raw blob; the response is JSON {review_id, expires_at}.
 func postEncryptedReview(blob []byte) (string, time.Time, error) {
-	endpoint := oasdiffSiteURL() + "/api/encrypted-review"
+	endpoint := oasdiffSiteURL() + "/api/encrypted-review" + internalReviewMarker()
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, endpoint, bytes.NewReader(blob))
 	if err != nil {
 		return "", time.Time{}, err

--- a/internal/open_review_unix_test.go
+++ b/internal/open_review_unix_test.go
@@ -127,6 +127,30 @@ func TestPostEncryptedReview_ServerError(t *testing.T) {
 	require.Contains(t, err.Error(), "413")
 }
 
+func TestInternalReviewMarker(t *testing.T) {
+	require.Empty(t, internalReviewMarker(), "unset by default")
+	t.Setenv("OASDIFF_INTERNAL", "0")
+	require.Empty(t, internalReviewMarker(), "only \"1\" enables the marker")
+	t.Setenv("OASDIFF_INTERNAL", "1")
+	require.Equal(t, "?internal=1", internalReviewMarker())
+}
+
+func TestPostEncryptedReview_InternalMarkerOnUpload(t *testing.T) {
+	var gotQuery string
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/encrypted-review", r.URL.Path)
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"review_id":"abc-123","expires_at":1700000000}`))
+	}))
+	defer stub.Close()
+	t.Setenv("OASDIFF_URL", stub.URL)
+	t.Setenv("OASDIFF_INTERNAL", "1")
+
+	_, _, err := postEncryptedReview([]byte{review.BlobVersion, 9, 9, 9})
+	require.NoError(t, err)
+	require.Equal(t, "internal=1", gotQuery, "OASDIFF_INTERNAL tags the upload so it can be excluded from review stats")
+}
+
 // keyFragmentRe extracts the base64url key from a #k= fragment.
 var keyFragmentRe = regexp.MustCompile(`#k=([A-Za-z0-9_-]+)`)
 

--- a/internal/open_review_unix_test.go
+++ b/internal/open_review_unix_test.go
@@ -127,12 +127,12 @@ func TestPostEncryptedReview_ServerError(t *testing.T) {
 	require.Contains(t, err.Error(), "413")
 }
 
-func TestInternalReviewMarker(t *testing.T) {
-	require.Empty(t, internalReviewMarker(), "unset by default")
+func TestInternalReview(t *testing.T) {
+	require.False(t, internalReview(), "unset by default")
 	t.Setenv("OASDIFF_INTERNAL", "0")
-	require.Empty(t, internalReviewMarker(), "only \"1\" enables the marker")
+	require.False(t, internalReview(), "only \"1\" enables the marker")
 	t.Setenv("OASDIFF_INTERNAL", "1")
-	require.Equal(t, "?internal=1", internalReviewMarker())
+	require.True(t, internalReview())
 }
 
 func TestPostEncryptedReview_InternalMarkerOnUpload(t *testing.T) {


### PR DESCRIPTION
Setting `OASDIFF_INTERNAL=1` appends `?internal=1` to the encrypted-review upload and to the opened `/review/e` URL that `--open` prints and launches.

This lets a review an author opens to check their own changes be distinguished from a real user's review by the receiving web app. It is unset by default, so a normal run is completely unchanged, and there is no CLI flag: it is an environment-only marker, the same pattern as the existing `PLATFORM` variable that travels in the bundle.

Covered by unit tests for the marker helper and for the upload path carrying `?internal=1`.