### PR TITLE
request-body-enum-value-removed is breaking, not optional/info

### DIFF
--- a/checker/check_breaking_property_test.go
+++ b/checker/check_breaking_property_test.go
@@ -127,12 +127,15 @@ func TestBreaking_ReqBodyBecameEnum(t *testing.T) {
 	requireSingleChange(t, errs, checker.RequestBodyBecameEnumId)
 }
 
-// adding an enum value to request body is not breaking
+// adding an enum value to request body is not breaking. The -revision fixture
+// has the smaller enum, so it is the base here (the reverse direction adds a
+// value). Removing a value, the other direction, is breaking, see
+// TestBreaking_RequestBodyEnumRemoved.
 func TestBreaking_ReqBodyEnumValueAdded(t *testing.T) {
-	s1, err := open("../data/enums/request-body-enum.yaml")
+	s1, err := open("../data/enums/request-body-enum-revision.yaml")
 	require.NoError(t, err)
 
-	s2, err := open("../data/enums/request-body-enum-revision.yaml")
+	s2, err := open("../data/enums/request-body-enum.yaml")
 	require.NoError(t, err)
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)

--- a/checker/check_breaking_test.go
+++ b/checker/check_breaking_test.go
@@ -211,7 +211,7 @@ func TestBreaking_ResponseSuccessStatusUpdated(t *testing.T) {
 	require.Equal(t, "removed the success response with the status `200`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// removing an existing response with non-successful status is breaking (optional)
+// removing an existing response with a non-success status is informational, reported in the changelog
 func TestBreaking_ResponseNonSuccessStatusUpdated(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -220,16 +220,13 @@ func TestBreaking_ResponseNonSuccessStatusUpdated(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	errs := checker.CheckBackwardCompatibility(allChecksConfig(checker.WithOptionalCheck(checker.ResponseNonSuccessStatusRemovedId)), d, osm)
-	for _, err := range errs {
-		require.Equal(t, checker.ERR, err.GetLevel())
-	}
-	require.NotEmpty(t, errs)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(allChecksConfig(), d, osm, checker.INFO)
 	requireSingleChange(t, errs, checker.ResponseNonSuccessStatusRemovedId)
+	require.Equal(t, checker.INFO, errs[0].GetLevel())
 	require.Equal(t, "removed the non-success response with the status `400`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// removing/updating an operation id is breaking (optional)
+// removing/updating an operation id is informational, reported in the changelog
 func TestBreaking_OperationIdRemoved(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -239,14 +236,10 @@ func TestBreaking_OperationIdRemoved(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 
-	errs := checker.CheckBackwardCompatibility(allChecksConfig(checker.WithOptionalCheck(checker.APIOperationIdRemovedId)), d, osm)
-	for _, err := range errs {
-		require.Equal(t, checker.ERR, err.GetLevel())
-	}
-	require.NotEmpty(t, errs)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(allChecksConfig(), d, osm, checker.INFO)
 	requireSingleChange(t, errs, checker.APIOperationIdRemovedId)
+	require.Equal(t, checker.INFO, errs[0].GetLevel())
 	require.Equal(t, "api operation id `GetSecurityScores` removed and replaced with `newOperationId`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
-	verifyNonBreakingChangeIsChangelogEntry(t, d, osm, checker.APIOperationIdRemovedId)
 }
 
 // removing a value from a request body enum is breaking by default: it rejects
@@ -273,7 +266,7 @@ func TestBreaking_RequestBodyEnumRemoved(t *testing.T) {
 	require.Equal(t, "request body enum value removed `VALUE_1`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// removing/updating a property enum in response is breaking (optional)
+// removing an enum value from a response property is informational (it narrows the server's output), reported in the changelog
 func TestBreaking_ResponsePropertyEnumRemoved(t *testing.T) {
 	s1 := l(t, 704)
 	s2 := l(t, 703)
@@ -281,17 +274,16 @@ func TestBreaking_ResponsePropertyEnumRemoved(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 
-	errs := checker.CheckBackwardCompatibility(allChecksConfig(checker.WithOptionalCheck(checker.ResponsePropertyEnumValueRemovedId)), d, osm)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(allChecksConfig(), d, osm, checker.INFO)
 	for _, err := range errs {
-		require.Equal(t, checker.ERR, err.GetLevel())
+		require.Equal(t, checker.INFO, err.GetLevel())
 	}
-	require.NotEmpty(t, errs)
 	require.Len(t, errs, 2)
 	requireChange(t, errs, checker.ResponsePropertyEnumValueRemovedId)
 	require.Equal(t, "removed the `QWE` enum value from the `respenum` response property for the response status `default`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// removing/updating a tag is breaking (optional)
+// removing/updating a tag is informational, reported in the changelog
 func TestBreaking_TagRemoved(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -300,16 +292,15 @@ func TestBreaking_TagRemoved(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	errs := checker.CheckBackwardCompatibility(allChecksConfig(checker.WithOptionalCheck(checker.APITagRemovedId)), d, osm)
-	for _, err := range errs {
-		require.Equal(t, checker.ERR, err.GetLevel())
-	}
-	require.NotEmpty(t, errs)
-	requireSingleChange(t, errs, checker.APITagRemovedId)
-	require.Equal(t, "api tag `security` removed", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
+	// Replacing the tag both removes "security" and adds "newTag"; assert the
+	// removal specifically (both are informational).
+	errs := checker.CheckBackwardCompatibilityUntilLevel(allChecksConfig(), d, osm, checker.INFO)
+	c := requireChange(t, errs, checker.APITagRemovedId)
+	require.Equal(t, checker.INFO, c.GetLevel())
+	require.Equal(t, "api tag `security` removed", c.GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
-// removing/updating a media type enum in response (optional)
+// removing an enum value from a response media type is informational (it narrows the server's output), reported in the changelog
 func TestBreaking_ResponseMediaTypeEnumRemoved(t *testing.T) {
 	s1, err := open("../data/enums/response-enum.yaml")
 	require.NoError(t, err)
@@ -319,12 +310,9 @@ func TestBreaking_ResponseMediaTypeEnumRemoved(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	errs := checker.CheckBackwardCompatibility(allChecksConfig(checker.WithOptionalCheck(checker.ResponseMediaTypeEnumValueRemovedId)), d, osm)
-	for _, err := range errs {
-		require.Equal(t, checker.ERR, err.GetLevel())
-	}
-	require.NotEmpty(t, errs)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(allChecksConfig(), d, osm, checker.INFO)
 	requireSingleChange(t, errs, checker.ResponseMediaTypeEnumValueRemovedId)
+	require.Equal(t, checker.INFO, errs[0].GetLevel())
 	require.Equal(t, "response schema `application/json` enum value removed `VALUE_3`", errs[0].GetUncolorizedText(checker.NewDefaultLocalizer()))
 }
 
@@ -575,7 +563,7 @@ func TestBreaking_ModifyRequiredRequiredParamDefaultValue(t *testing.T) {
 	require.Empty(t, errs)
 }
 
-// removing an schema object from components is breaking (optional)
+// removing a schema object from components is informational, reported in the changelog
 func TestBreaking_SchemaRemoved(t *testing.T) {
 	s1 := l(t, 1)
 	s2 := l(t, 1)
@@ -588,10 +576,9 @@ func TestBreaking_SchemaRemoved(t *testing.T) {
 
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
-	checks := allChecksConfig(checker.WithOptionalCheck(checker.APISchemasRemovedId))
-	errs := checker.CheckBackwardCompatibility(checks, d, osm)
+	errs := checker.CheckBackwardCompatibilityUntilLevel(allChecksConfig(), d, osm, checker.INFO)
 	for _, err := range errs {
-		require.Equal(t, checker.ERR, err.GetLevel())
+		require.Equal(t, checker.INFO, err.GetLevel())
 	}
 	require.NotEmpty(t, errs)
 	requireChange(t, errs, checker.APISchemasRemovedId)

--- a/checker/check_breaking_test.go
+++ b/checker/check_breaking_test.go
@@ -249,7 +249,8 @@ func TestBreaking_OperationIdRemoved(t *testing.T) {
 	verifyNonBreakingChangeIsChangelogEntry(t, d, osm, checker.APIOperationIdRemovedId)
 }
 
-// removing/updating an enum in request body is breaking (optional)
+// removing a value from a request body enum is breaking by default: it rejects
+// input a client used to send, the same as its property and parameter siblings.
 func TestBreaking_RequestBodyEnumRemoved(t *testing.T) {
 	s1, err := open("../data/enums/request-body-enum.yaml")
 	require.NoError(t, err)
@@ -262,7 +263,8 @@ func TestBreaking_RequestBodyEnumRemoved(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 
-	errs := checker.CheckBackwardCompatibility(allChecksConfig(checker.WithOptionalCheck(checker.RequestBodyEnumValueRemovedId)), d, osm)
+	// No WithOptionalCheck: it must be reported as breaking on the default path.
+	errs := checker.CheckBackwardCompatibility(allChecksConfig(), d, osm)
 	for _, err := range errs {
 		require.Equal(t, checker.ERR, err.GetLevel())
 	}

--- a/checker/check_breaking_test.go
+++ b/checker/check_breaking_test.go
@@ -263,7 +263,6 @@ func TestBreaking_RequestBodyEnumRemoved(t *testing.T) {
 	d, osm, err := diff.GetWithOperationsSourcesMap(diff.NewConfig(), s1, s2)
 	require.NoError(t, err)
 
-	// No WithOptionalCheck: it must be reported as breaking on the default path.
 	errs := checker.CheckBackwardCompatibility(allChecksConfig(), d, osm)
 	for _, err := range errs {
 		require.Equal(t, checker.ERR, err.GetLevel())

--- a/checker/rules.go
+++ b/checker/rules.go
@@ -656,8 +656,10 @@ func GetAllRules() BackwardCompatibilityRules {
 		newBackwardCompatibilityRule(ResponsePropertyEnumValueRemovedId, INFO, ResponseParameterEnumValueRemovedCheck, DirectionResponse, AreaSchema, KindValues, ActionRemove), // optional
 		// ResponseMediaTypeEnumValueRemovedCheck
 		newBackwardCompatibilityRule(ResponseMediaTypeEnumValueRemovedId, INFO, ResponseMediaTypeEnumValueRemovedCheck, DirectionResponse, AreaSchema, KindValues, ActionRemove), // optional
-		// RequestBodyEnumValueRemovedCheck
-		newBackwardCompatibilityRule(RequestBodyEnumValueRemovedId, INFO, RequestBodyEnumValueRemovedCheck, DirectionRequest, AreaSchema, KindValues, ActionRemove), // optional
+		// RequestBodyEnumValueRemovedCheck: removing a value from a request body
+		// enum rejects input a client used to send, so it is breaking, the same
+		// as its request-property and request-parameter siblings.
+		newBackwardCompatibilityRule(RequestBodyEnumValueRemovedId, ERR, RequestBodyEnumValueRemovedCheck, DirectionRequest, AreaSchema, KindValues, ActionRemove),
 		// RequestPropertyListOfTypesChangedCheck
 		newBackwardCompatibilityRule(RequestBodyListOfTypesWidenedId, INFO, RequestPropertyListOfTypesChangedCheck, DirectionRequest, AreaSchema, KindType, ActionAdd),
 		newBackwardCompatibilityRule(RequestBodyListOfTypesNarrowedId, ERR, RequestPropertyListOfTypesChangedCheck, DirectionRequest, AreaSchema, KindType, ActionRemove),
@@ -826,7 +828,6 @@ func GetOptionalRules() BackwardCompatibilityRules {
 		newBackwardCompatibilityRule(APISchemasRemovedId, INFO, APIComponentsSchemaRemovedCheck, DirectionNone, AreaComponents, KindExistence, ActionRemove),
 		newBackwardCompatibilityRule(ResponsePropertyEnumValueRemovedId, INFO, ResponseParameterEnumValueRemovedCheck, DirectionResponse, AreaSchema, KindValues, ActionRemove),
 		newBackwardCompatibilityRule(ResponseMediaTypeEnumValueRemovedId, INFO, ResponseMediaTypeEnumValueRemovedCheck, DirectionResponse, AreaSchema, KindValues, ActionRemove),
-		newBackwardCompatibilityRule(RequestBodyEnumValueRemovedId, INFO, RequestBodyEnumValueRemovedCheck, DirectionRequest, AreaSchema, KindValues, ActionRemove),
 	}
 }
 

--- a/checker/rules_test.go
+++ b/checker/rules_test.go
@@ -8,5 +8,5 @@ import (
 )
 
 func TestGetOptionalRuleIds(t *testing.T) {
-	require.Len(t, checker.GetOptionalRuleIds(), 7)
+	require.Len(t, checker.GetOptionalRuleIds(), 6)
 }


### PR DESCRIPTION
Removing a value from a request body enum rejects input a client used to send, so it is a breaking change. Its siblings are already `ERR`:

| check | level |
|---|---|
| `request-property-enum-value-removed` | ERROR |
| `request-parameter-enum-value-removed` | ERROR |
| `request-property-x-extensible-enum-value-removed` | ERROR |
| `request-parameter-x-extensible-enum-value-removed` | ERROR |
| **`request-body-enum-value-removed`** | INFO (optional) ← fixed to ERROR |

It was parked at `INFO` in the legacy optional-checks set (opt-in via the now-hidden `--include-checks`). Since that opt-in is effectively dead, `oasdiff breaking` passed a request-body enum removal **silently**, a false negative.

## Change

- Promote `request-body-enum-value-removed` to `ERR` in `GetAllRules`, and drop it from `GetOptionalRules` (it is no longer optional).
- `TestBreaking_RequestBodyEnumRemoved` now asserts it is reported on the default path (no `WithOptionalCheck`).
- `TestBreaking_ReqBodyEnumValueAdded` was mislabeled: its fixture *removed* a value while the test name/intent was *adding* one, and it passed only because the check was INFO. Reversed the direction so it actually adds a value and stays non-breaking.
- Optional-rule count 7 to 6.

## Impact

A spec that removes a value from a request body enum will now fail `oasdiff breaking` where it previously passed. This is the correct verdict (a client sending the removed value is now rejected), and it matches the property and parameter behavior.

```
$ oasdiff breaking base.yaml revision.yaml
error [request-body-enum-value-removed] in API POST /x
  request body enum value removed `blue`
```