### PR TITLE
security: stop git parsing a revision as an option

### DIFF
--- a/load/git.go
+++ b/load/git.go
@@ -172,6 +172,30 @@ func hintMissingObject(gitRef string, err error) error {
 
 // refBeforeColon returns the "<ref>" portion of a "<ref>:<path>" git revision,
 // or the whole string when there is no colon.
+// ErrRefLooksLikeOption is returned for a git revision starting with "-".
+//
+// Refs are passed to git as operands. Without protection git parses a
+// leading-dash operand as an OPTION, which is a real capability and not a
+// theoretical one: "--output=<path>" on git show writes git's output to that
+// path, giving an arbitrary file overwrite as the invoking user, and
+// "--upload-pack=<program>" on git fetch makes git execute that program.
+//
+// Every call site also passes --end-of-options, which instructs git to treat
+// everything after it as an operand. This check is the belt to that braces: it
+// does not depend on the git version (--end-of-options landed in git 2.24), and
+// it fails with a clear message instead of a confusing git error.
+//
+// No legitimate git revision begins with "-".
+var ErrRefLooksLikeOption = errors.New("git revision must not start with '-'")
+
+// checkRef rejects a revision that git would parse as an option.
+func checkRef(ref string) error {
+	if strings.HasPrefix(ref, "-") {
+		return fmt.Errorf("%w: %q", ErrRefLooksLikeOption, ref)
+	}
+	return nil
+}
+
 func refBeforeColon(gitRef string) string {
 	if before, _, found := strings.Cut(gitRef, ":"); found {
 		return before
@@ -185,7 +209,10 @@ func refBeforeColon(gitRef string) string {
 // is why it runs only under the opt-in --fetch flag. It mirrors the manual
 // "git fetch origin <ref>" that hintMissingObject suggests when --fetch is off.
 func gitFetch(ref string) error {
-	if out, err := exec.Command("git", "fetch", "origin", ref).CombinedOutput(); err != nil {
+	if err := checkRef(ref); err != nil {
+		return err
+	}
+	if out, err := exec.Command("git", "fetch", "--end-of-options", "origin", ref).CombinedOutput(); err != nil {
 		return fmt.Errorf("%s", strings.TrimSpace(string(out)))
 	}
 	return nil
@@ -195,7 +222,10 @@ func gitFetch(ref string) error {
 // local repository, via "git cat-file -e". Returns false when the object is
 // absent or when git cannot run.
 func commitExistsLocally(ref string) bool {
-	return exec.Command("git", "cat-file", "-e", ref).Run() == nil
+	if checkRef(ref) != nil {
+		return false
+	}
+	return exec.Command("git", "cat-file", "-e", "--end-of-options", ref).Run() == nil
 }
 
 // blobHashFromRef returns (hex, true) when the part before `:` in gitRef names
@@ -205,10 +235,10 @@ func commitExistsLocally(ref string) bool {
 // per spec load on the git path, which git serves in single-digit milliseconds.
 func blobHashFromRef(gitRef string) (string, bool) {
 	ref, _, found := strings.Cut(gitRef, ":")
-	if !found {
+	if !found || checkRef(ref) != nil {
 		return "", false
 	}
-	out, err := exec.Command("git", "cat-file", "-t", ref).Output()
+	out, err := exec.Command("git", "cat-file", "-t", "--end-of-options", ref).Output()
 	if err != nil {
 		return "", false
 	}
@@ -220,7 +250,10 @@ func blobHashFromRef(gitRef string) (string, bool) {
 
 // gitShow runs "git show <ref>" and returns its stdout, or a descriptive error.
 func gitShow(ref string) ([]byte, error) {
-	out, err := exec.Command("git", "show", ref).Output()
+	if err := checkRef(ref); err != nil {
+		return nil, err
+	}
+	out, err := exec.Command("git", "show", "--end-of-options", ref).Output()
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {

--- a/load/git_test.go
+++ b/load/git_test.go
@@ -1,0 +1,43 @@
+package load
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Refs reach git as operands, so a leading dash is parsed as an OPTION rather
+// than a revision. That is a real capability, not a theoretical one:
+// "git show --output=<path> <rev>" writes to that path (arbitrary file
+// overwrite as the invoking user), and "git fetch --upload-pack=<program>"
+// makes git execute the program. Verified against git 2.49.
+//
+// Call sites pass --end-of-options; checkRef is the version-independent belt to
+// that braces, and gives a clear error instead of a confusing git one.
+func TestCheckRefRejectsOptionLikeRevisions(t *testing.T) {
+	for _, ref := range []string{
+		"--output=/tmp/pwned",
+		"--upload-pack=/bin/sh",
+		"-x",
+		"--end-of-options",
+	} {
+		t.Run(ref, func(t *testing.T) {
+			require.Error(t, checkRef(ref), "a ref git would parse as an option must be rejected")
+		})
+	}
+}
+
+func TestCheckRefAllowsRealRevisions(t *testing.T) {
+	for _, ref := range []string{
+		"HEAD",
+		"main",
+		"origin/main",
+		"v1.2.3",
+		"b09dd8d44cc05f88ad3364434f662e2e2e33db37",
+		"feature/dash-in-name",
+	} {
+		t.Run(ref, func(t *testing.T) {
+			require.NoError(t, checkRef(ref))
+		})
+	}
+}


### PR DESCRIPTION
Fixes the git option-injection issue disclosed in GHSA-m3wq-w7x2-4q6m.

Git revisions reached git as operands, so a revision starting with `-` was parsed as an option (`git show --output=<path>` gives an arbitrary file overwrite; `git fetch --upload-pack=<prog>` executes a program).

Two layers: `--end-of-options` on every git invocation, plus `checkRef` rejecting dash-leading revisions before git runs.

Released to users as **v1.26.1**, cut as a minimal patch directly off the `v1.26.0` tag (branch `release/v1.26.1`) so the security fix ships without the unrelated behaviour changes already on main. This PR carries the same commit onto main for future releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)