### PR TITLE
docs: how to pass arguments safely from a script or CI

### DIFF
--- a/docs/GIT-REVISION.md
+++ b/docs/GIT-REVISION.md
@@ -39,18 +39,6 @@ Compare yesterday's `HEAD` against today's:
 oasdiff diff HEAD~1:openapi.yaml HEAD:openapi.yaml
 ```
 
-## Passing revisions from a script or CI
-
-When the revision comes from a variable rather than being typed by hand, put `--` after the flags so oasdiff treats the value as a revision and never as a flag:
-
-```bash
-oasdiff breaking $flags -- "$base" "$revision"
-```
-
-Note the ordering: `--` must come *after* the flags. Everything following it is treated as a positional argument, so flags placed after `--` are read as revisions instead.
-
-This matters when the value could originate from somewhere you do not control — a branch name, a workflow input, a config value. Without `--`, a value beginning with `-` is parsed as an oasdiff flag.
-
 ## How it works
 
 oasdiff detects the `<ref>:<path>` pattern and runs `git show <ref>:<path>` internally to retrieve the spec content. Relative `$ref`s in the spec are resolved against the spec's path, matching the behaviour of loading from a local file.

--- a/docs/GIT-REVISION.md
+++ b/docs/GIT-REVISION.md
@@ -39,6 +39,18 @@ Compare yesterday's `HEAD` against today's:
 oasdiff diff HEAD~1:openapi.yaml HEAD:openapi.yaml
 ```
 
+## Passing revisions from a script or CI
+
+When the revision comes from a variable rather than being typed by hand, put `--` after the flags so oasdiff treats the value as a revision and never as a flag:
+
+```bash
+oasdiff breaking $flags -- "$base" "$revision"
+```
+
+Note the ordering: `--` must come *after* the flags. Everything following it is treated as a positional argument, so flags placed after `--` are read as revisions instead.
+
+This matters when the value could originate from somewhere you do not control — a branch name, a workflow input, a config value. Without `--`, a value beginning with `-` is parsed as an oasdiff flag.
+
 ## How it works
 
 oasdiff detects the `<ref>:<path>` pattern and runs `git show <ref>:<path>` internally to retrieve the spec content. Relative `$ref`s in the spec are resolved against the spec's path, matching the behaviour of loading from a local file.

--- a/docs/USAGE_EXAMPLES.md
+++ b/docs/USAGE_EXAMPLES.md
@@ -115,4 +115,16 @@ docker run --rm -t -v $(pwd)/data:/data:ro tufin/oasdiff diff /data/openapi-test
 ```
 
 Replace `$(pwd)/data` by the path that contains your files.  
-Note that the spec paths must begin with `/`.  
+Note that the spec paths must begin with `/`.
+
+## Passing arguments from a script or CI
+
+When `base` and `revision` come from variables rather than being typed by hand, put `--` after the flags so their values are always read as arguments and never as flags:
+
+```bash
+oasdiff breaking $flags -- "$base" "$revision"
+```
+
+Note the ordering: `--` must come *after* the flags. Everything following it is treated as a positional argument, so any flag placed after `--` is read as a spec instead.
+
+This applies to every input type — local files, URLs, and git revisions alike. Without `--`, a value that begins with `-` is parsed as an oasdiff flag, and a value that happens to match a real flag name changes what the command does.


### PR DESCRIPTION
When `base` and `revision` come from variables rather than being typed by hand, a value beginning with `-` is parsed as a flag, and a value matching a real flag name silently changes what the command does.

Documents the `--` separator, plus the ordering rule that is easy to get wrong: `--` must come **after** the flags, since everything following it is read as a positional argument.

Placed in `USAGE_EXAMPLES.md` because it is a cookbook of invocations and this is one. It deliberately is **not** in `GIT-REVISION.md` — the guidance is not git-specific, since `base` and `revision` can be local files or URLs just as easily, and siting it there would hide it from anyone scripting oasdiff with plain file paths.

Existing examples are left alone: adding `--` throughout would be noise for anyone typing arguments by hand and would imply the plain form is unsafe, which it is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)