### PR TITLE
docs: document that source locations require a YAML spec

### DIFF
--- a/docs/SOURCE-LOCATOR.md
+++ b/docs/SOURCE-LOCATOR.md
@@ -3,6 +3,8 @@
 oasdiff can correlate breaking changes and changelog entries with the exact line and column in the OpenAPI spec file where the change occurred.  
 This enables inline annotations on GitHub pull requests, pointing reviewers directly to the relevant lines.
 
+Source locations require a spec in YAML format. See [Limitations](#limitations).
+
 ## What it does
 
 When source location tracking is enabled, reported changes include:
@@ -16,13 +18,35 @@ Changes that represent a modification (e.g., maxLength increased) will have both
 
 ### Multi-file specs
 
-When a spec uses `$ref` to import schemas from other YAML or JSON files, source locations point to the file where the changed element actually lives, with the precise line and column. The `file` field on `BaseSource` and `RevisionSource` reflects the imported file, not just the top-level spec entry point, and inline GitHub Actions annotations use that path.
+When a spec uses `$ref` to import schemas from other YAML files, source locations point to the file where the changed element actually lives, with the precise line and column. The `file` field on `BaseSource` and `RevisionSource` reflects the imported file, not just the top-level spec entry point, and inline GitHub Actions annotations use that path.
+
+Imported JSON files behave differently. See [Limitations](#limitations).
+
+## Limitations
+
+### Specs in JSON format
+
+Source locations are available only for specs that oasdiff parses as YAML. A spec parsed as JSON carries no position information, so:
+
+- In `-f json` and `-f yaml` output, `baseSource` and `revisionSource` are usually omitted entirely. Where one is present, it carries a `file` with no `line` or `column`.
+- GitHub Actions annotations are emitted without `line` and `col`, so GitHub attaches them to the file rather than to the changed line.
+- `oasdiff validate` reports findings with a file but no line or column.
+
+This follows the content of the file, not its extension. A `.yaml` file that contains JSON is parsed as JSON and behaves the same way.
+
+In a multi-file spec, a change inside an imported JSON file does not simply lose its location. It falls back to the nearest enclosing element that has one, which is usually the `$ref` site in the parent file. The reported `file` and `line` can therefore point at a different file from the one that changed.
+
+To get precise locations today, convert the spec to YAML. If source location support for JSON specs would be useful to you, add a 👍 to [issue #1128](https://github.com/oasdiff/oasdiff/issues/1128) so we can gauge demand.
 
 ## Output formats
+
+`-f` selects the format oasdiff writes its report in. It is unrelated to the format the spec itself is written in.
 
 Source locations are available in:
 - **JSON** (`-f json`) and **YAML** (`-f yaml`) output as `baseSource` and `revisionSource` fields on each change
 - **GitHub Actions** (`-f githubactions`) output includes `revisionSource` fields to use as inline annotations on the "Files changed" tab of PRs. Note that `baseSource` isn't displayed because GitHub can only display annotations on the latest version of the file.
+
+In each of these, the values are populated only for a spec parsed as YAML. See [Limitations](#limitations).
 
 ### Precision levels
 


### PR DESCRIPTION
Source locations are populated only when a spec is parsed as YAML. A spec parsed as JSON carries no position information, so its changes and validation findings are reported without a line or column.

`SOURCE-LOCATOR.md` promised the opposite. The multi-file section stated explicitly that a `$ref` to a JSON file reports the file where the changed element lives, with the precise line and column.

## Why the multi-file case matters most

That is the case that fails worst, because the result is not a missing location but an incorrect one. Given a YAML root that `$ref`s a component file, changing a property inside the component reports:

- component in YAML: `file=r/thing.yaml,line=9,col=7`, the element that changed
- component in JSON: `file=r/openapi.yaml,line=5,col=5`, the `$ref` site in the root

When the imported file has no positions, the location falls back to the nearest enclosing element that has one. A reviewer following that annotation lands on a line that did not change.

## What this PR changes

- Adds a `## Limitations` section covering the affected outputs (`baseSource` / `revisionSource` in `-f json` and `-f yaml`, GitHub Actions annotations, and `validate` findings), the multi-file fallback, and the YAML workaround.
- Notes that the behavior follows file **content**, not extension: a `.yaml` file containing JSON is parsed as JSON and behaves the same way.
- Corrects the multi-file paragraph, which named JSON as supported.
- Disambiguates `## Output formats`, where `-f json` could be misread as describing a JSON input spec.
- Points readers at #1128 to signal demand for JSON support.

Documentation only. No behavior change.

Refs #1128

🤖 Generated with [Claude Code](https://claude.com/claude-code)