### PR TITLE
checks: one listing per rule set, and list the validate rules (#927)

### DIFF
--- a/docs/BREAKING-CHANGES.md
+++ b/docs/BREAKING-CHANGES.md
@@ -30,7 +30,7 @@ The comparison is encrypted on your machine before upload, with a one-time key t
 The resulting URL works for 7 days. Paste it into a PR comment or Slack and reviewers can open the review without installing the CLI themselves. Anyone you give the full link to can open it (the part after the `#` is the decryption key), so treat it like a secret.
 
 ## Checks
-Oasdiff supports hundreds of checks (run `oasdiff checks` for the current list, or browse the full catalog at [oasdiff.com/docs/breaking-changes](https://www.oasdiff.com/docs/breaking-changes)), categorized into three levels:  
+Oasdiff supports hundreds of checks (run `oasdiff checks changelog` for the current list, or browse the full catalog at [oasdiff.com/docs/breaking-changes](https://www.oasdiff.com/docs/breaking-changes)), categorized into three levels:  
 - `ERR` - Errors are definite breaking changes which should be avoided
 - `WARN` - Warnings are potential breaking changes which developers should be aware of, but cannot be confirmed programmatically as breaking
 - `INFO` - Non-breaking changes
@@ -40,7 +40,7 @@ Oasdiff supports hundreds of checks (run `oasdiff checks` for the current list, 
 
 To see the full list of checks and their descriptions, run:
 ```
-oasdiff checks
+oasdiff checks changelog
 ```
 See also [Customizing Severity Levels](#customizing-severity-levels)
 
@@ -146,7 +146,7 @@ Currently English, Russian and Brazilian Portuguese are supported.
 
 ## Customizing Severity Levels
 Oasdiff allows you to change the default severity levels according to your needs.  
-For example, the default severity level of the `api-security-removed` check is `INFO`. You can verify this by running `oasdiff checks`.  
+For example, the default severity level of the `api-security-removed` check is `INFO`. You can verify this by running `oasdiff checks changelog`.  
 To change the `api-security-removed` check's severity level to `ERR` use the following command:
 ```
 oasdiff changelog data/checker/api_security_added_revision.yaml data/checker/api_security_added_base.yaml --severity-levels oasdiff-levels.txt
@@ -166,7 +166,7 @@ Checks can be customized with the following levels:
 
 ## Customizing Breaking Changes Checks
 If you encounter a change that isn't reported, you may:
-1. Run `oasdiff checks` to see if the check is available, and [customize the level as needed](#customizing-severity-levels).  
+1. Run `oasdiff checks changelog` to see if the check is available, and [customize the level as needed](#customizing-severity-levels).  
 2. Add a [custom check](CUSTOMIZING-CHECKS.md)
 
 ## Known Limitations

--- a/docs/CHECKS.md
+++ b/docs/CHECKS.md
@@ -1,11 +1,16 @@
 # Checks
-The `oasdiff checks` command displays all checks that oasdiff uses to detect API changes.
-Checks are the individual rules that `oasdiff breaking` and `oasdiff changelog` apply when comparing two OpenAPI specs.
+The `oasdiff checks` command displays the rules oasdiff applies. There is one listing per rule set:
+
+- `oasdiff checks changelog` — the checks that `oasdiff breaking` and `oasdiff changelog` apply when comparing two specs. The rest of this page describes these.
+- `oasdiff checks validate` — the rules `oasdiff validate` reports for a single spec.
+
 This command is typically used to explore what oasdiff can detect or to identify check IDs for ignoring or customizing specific rules.
+
+`oasdiff checks` on its own prints the two subcommands: a listing always names its rule set.
 
 ## Example: display all checks
 ```
-oasdiff checks
+oasdiff checks changelog
 ```
 
 ## Output Formats
@@ -18,9 +23,9 @@ Additional formats can be generated using the `--format` flag:
 ## Filtering by Severity
 Use `--severity` to show only checks at a given level:
 ```
-oasdiff checks --severity error
-oasdiff checks --severity warn
-oasdiff checks --severity info
+oasdiff checks changelog --severity error
+oasdiff checks changelog --severity warn
+oasdiff checks changelog --severity info
 ```
 
 Checks are categorized into three severity levels:
@@ -28,7 +33,7 @@ Checks are categorized into three severity levels:
 - `warn` — potential breaking changes which cannot be confirmed programmatically
 - `info` — non-breaking changes
 
-Run `oasdiff checks` for the current list, or browse the full catalog at [oasdiff.com/docs/breaking-changes](https://www.oasdiff.com/docs/breaking-changes).
+Run `oasdiff checks changelog` for the current list, or browse the full catalog at [oasdiff.com/docs/breaking-changes](https://www.oasdiff.com/docs/breaking-changes).
 
 ## Categorization
 Every check is categorized along independent axes, emitted as fields in the `json` and `yaml` output:
@@ -41,8 +46,8 @@ Every check is categorized along independent axes, emitted as fields in the `jso
 ## Filtering by Tag
 Use `--tags` to show only checks in a specific area, kind, action, or direction:
 ```
-oasdiff checks --tags request,parameters
-oasdiff checks --tags schema,constraints
+oasdiff checks changelog --tags request,parameters
+oasdiff checks changelog --tags schema,constraints
 ```
 
 Available tags: `request`, `response`, `add`, `remove`, `change`, `generalize`, `specialize`, `increase`, `decrease`, `set`, `schema`, `parameters`, `requestBody`, `responses`, `paths`, `headers`, `security`, `tags`, `components`, `existence`, `requiredness`, `mutability`, `type`, `constraints`, `values`, `structure`, `lifecycle`.
@@ -52,9 +57,19 @@ Multiple tags are combined with AND — only checks that match all specified tag
 ## Localization
 Use `--lang` to view check descriptions in a supported language:
 ```
-oasdiff checks --lang ru
+oasdiff checks changelog --lang ru
 ```
 Supported languages: `en` (default), `ru`, `pt-br`, `es`.
+
+Only the changelog listing takes `--lang`. The validate rule descriptions are not localized.
+
+## Validate checks
+`oasdiff checks validate` lists the rules `oasdiff validate` reports, with the same `--format` and `--severity` flags:
+```
+oasdiff checks validate
+oasdiff checks validate --severity error --format json
+```
+It takes no `--tags` (validate rules carry none) and no `--lang`.
 
 ## Using Check IDs
 Each check has a unique ID (e.g. `api-path-removed-without-deprecation`) which can be used to:

--- a/docs/CUSTOMIZING-CHECKS.md
+++ b/docs/CUSTOMIZING-CHECKS.md
@@ -19,7 +19,7 @@ newBackwardCompatibilityRule(RequestParameterBecameNotNullableId, ERR, RequestPa
 - **Direction / Area / Kind / Action** classify the rule in the taxonomy. `TestRuleSymmetry` audits it: a rule with no mirror across an axis fails the build unless the asymmetry is waived with a reason in [checker/rule_symmetry_test.go](../checker/rule_symmetry_test.go). When you add a check, add its mirror too, or record why it is intentionally absent.
 
 ## Localized Messages
-1. For each id, add two keys in **all four locales** under [checker/localizations_src](../checker/localizations_src) (en, es, pt-br, ru): the message (`request-parameter-became-not-nullable: the %s request parameter %s became not nullable`) and the description (`request-parameter-became-not-nullable-description: ...`), which the `oasdiff checks` command and the rule catalog display. If a translation isn't ready, copy the English text as a placeholder so the key exists.
+1. For each id, add two keys in **all four locales** under [checker/localizations_src](../checker/localizations_src) (en, es, pt-br, ru): the message (`request-parameter-became-not-nullable: the %s request parameter %s became not nullable`) and the description (`request-parameter-became-not-nullable-description: ...`), which the `oasdiff checks changelog` command and the rule catalog display. If a translation isn't ready, copy the English text as a placeholder so the key exists.
 2. Run `make localize` to regenerate [checker/localizations/localizations.go](../checker/localizations/localizations.go).
 
 ## Tests

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,7 +70,8 @@ The top-level subcommands.
 - [`flatten`](ALLOF.md) — replace `allOf` schemas with a merged equivalent
 - [`upgrade`](OPENAPI-31.md#converting-a-spec-with-oasdiff-upgrade) — canonicalize an OpenAPI 3.0 spec to the latest 3.x
 - [`validate`](VALIDATE.md) — check a single spec for per-RFC violations (invalid types, missing required fields, bad regex, unresolved `$ref`s)
-- [`checks`](CHECKS.md) — list the rules oasdiff uses to classify changes ([customize them](CUSTOMIZING-CHECKS.md))
+- [`checks changelog`](CHECKS.md) — list the rules `breaking` and `changelog` use to classify changes ([customize them](CUSTOMIZING-CHECKS.md))
+- [`checks validate`](CHECKS.md#validate-checks) — list the rules `validate` reports
 - [`schema`](BREAKING-CHANGES.md#json-schema) — print a JSON Schema for the `breaking`/`changelog` json output
 - [`git-diff-driver`](GIT-DIFF-DRIVER.md) — run as a git external diff driver so `git log --patch` renders an OpenAPI changelog inline
 

--- a/formatters/checks.go
+++ b/formatters/checks.go
@@ -2,14 +2,21 @@ package formatters
 
 import "cmp"
 
+// Check is one rule in a `oasdiff checks` listing.
+//
+// Every field except Id is omitempty: the changelog and breaking-change rules
+// populate all of them (TestChecks_AllFieldsPopulated pins that), so their
+// output is unchanged, while a listing that only has IDs to report
+// (`oasdiff checks validate`, where a rule's text and severity are determined
+// at runtime) renders as ids alone instead of rows of empty strings.
 type Check struct {
 	Id          string `json:"id" yaml:"id"`
-	Level       string `json:"level" yaml:"level"`
-	Direction   string `json:"direction" yaml:"direction"`
-	Area        string `json:"area" yaml:"area"`
-	Kind        string `json:"kind" yaml:"kind"`
-	Action      string `json:"action" yaml:"action"`
-	Description string `json:"description" yaml:"description"`
+	Level       string `json:"level,omitempty" yaml:"level,omitempty"`
+	Direction   string `json:"direction,omitempty" yaml:"direction,omitempty"`
+	Area        string `json:"area,omitempty" yaml:"area,omitempty"`
+	Kind        string `json:"kind,omitempty" yaml:"kind,omitempty"`
+	Action      string `json:"action,omitempty" yaml:"action,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 	Mitigation  string `json:"mitigation,omitempty" yaml:"mitigation,omitempty"`
 }
 

--- a/formatters/checks.go
+++ b/formatters/checks.go
@@ -4,11 +4,11 @@ import "cmp"
 
 // Check is one rule in a `oasdiff checks` listing.
 //
-// Every field except Id is omitempty: the changelog and breaking-change rules
-// populate all of them (TestChecks_AllFieldsPopulated pins that), so their
-// output is unchanged, while a listing that only has IDs to report
-// (`oasdiff checks validate`, where a rule's text and severity are determined
-// at runtime) renders as ids alone instead of rows of empty strings.
+// Every field except Id is omitempty. The changelog and breaking-change rules
+// populate all of them (TestChecks_AllRuleFieldsPopulated pins that), so their
+// output is unchanged; the validate rules have an id, a description and a
+// level but no direction, area, kind or action, and those are omitted rather
+// than rendered as empty strings.
 type Check struct {
 	Id          string `json:"id" yaml:"id"`
 	Level       string `json:"level,omitempty" yaml:"level,omitempty"`

--- a/formatters/checks_test.go
+++ b/formatters/checks_test.go
@@ -34,10 +34,10 @@ func TestChecks_SortFunc_Equal(t *testing.T) {
 	require.Equal(t, 0, result)
 }
 
-// Check's fields are omitempty so an IDs-only listing (`oasdiff checks
-// validate`) doesn't render rows of empty strings. That is only safe while the
-// changelog and breaking-change rules populate every field: an empty one would
-// silently disappear from json/yaml rather than show as "".
+// Check's fields are omitempty so the validate listing, which has no direction,
+// area, kind or action, doesn't render rows of empty strings. That is only safe
+// while the changelog and breaking-change rules populate every field: an empty
+// one would silently disappear from json/yaml rather than show as "".
 //
 // This pins the invariant at the source, so a new rule missing an area, kind,
 // action or description fails here instead of quietly changing machine output.

--- a/formatters/checks_test.go
+++ b/formatters/checks_test.go
@@ -1,9 +1,11 @@
 package formatters_test
 
 import (
+	"encoding/json"
 	"slices"
 	"testing"
 
+	"github.com/oasdiff/oasdiff/checker"
 	"github.com/oasdiff/oasdiff/formatters"
 	"github.com/stretchr/testify/require"
 )
@@ -30,4 +32,54 @@ func TestChecks_SortFunc_Equal(t *testing.T) {
 
 	result := checks.SortFunc(checks[0], checks[1])
 	require.Equal(t, 0, result)
+}
+
+// Check's fields are omitempty so an IDs-only listing (`oasdiff checks
+// validate`) doesn't render rows of empty strings. That is only safe while the
+// changelog and breaking-change rules populate every field: an empty one would
+// silently disappear from json/yaml rather than show as "".
+//
+// This pins the invariant at the source, so a new rule missing an area, kind,
+// action or description fails here instead of quietly changing machine output.
+func TestChecks_AllRuleFieldsPopulated(t *testing.T) {
+	localizer := checker.NewLocalizer("en")
+
+	for _, rule := range checker.GetAllRules() {
+		require.NotEmpty(t, rule.Id, "rule id")
+		require.NotEmpty(t, rule.Level.String(), "level for %s", rule.Id)
+		require.NotEmpty(t, rule.Direction.String(), "direction for %s", rule.Id)
+		require.NotEmpty(t, rule.Area.String(), "area for %s", rule.Id)
+		require.NotEmpty(t, rule.Kind.String(), "kind for %s", rule.Id)
+		require.NotEmpty(t, rule.Action.String(), "action for %s", rule.Id)
+		require.NotEmpty(t, localizer(rule.Description), "description for %s", rule.Id)
+	}
+}
+
+// A fully populated check keeps every field: omitempty must not drop anything
+// the changelog listing reports today.
+func TestChecks_FullCheckRendersAllFields(t *testing.T) {
+	checks := formatters.Checks{{
+		Id: "some-rule", Level: "error", Direction: "request", Area: "schema",
+		Kind: "type", Action: "change", Description: "d", Mitigation: "m",
+	}}
+
+	out, err := formatters.JSONFormatter{}.RenderChecks(checks, formatters.NewRenderOpts())
+	require.NoError(t, err)
+
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal(out, &got))
+	require.Len(t, got, 1)
+	for _, field := range []string{"id", "level", "direction", "area", "kind", "action", "description", "mitigation"} {
+		require.Contains(t, got[0], field, "field %s must survive omitempty when populated", field)
+	}
+}
+
+// An IDs-only check renders as just the id, which is the point of omitempty.
+func TestChecks_IdOnlyCheckOmitsEmptyFields(t *testing.T) {
+	out, err := formatters.JSONFormatter{}.RenderChecks(formatters.Checks{{Id: "some-rule"}}, formatters.NewRenderOpts())
+	require.NoError(t, err)
+
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal(out, &got))
+	require.Equal(t, []map[string]any{{"id": "some-rule"}}, got)
 }

--- a/formatters/format_text.go
+++ b/formatters/format_text.go
@@ -3,8 +3,6 @@ package formatters
 import (
 	"bytes"
 	"fmt"
-	"slices"
-	"strings"
 	"text/tabwriter"
 
 	"github.com/TwiN/go-color"
@@ -51,33 +49,13 @@ func (f TEXTFormatter) RenderChangelog(changes checker.Changes, opts RenderOpts)
 	return result.Bytes(), nil
 }
 
-// RenderChecks prints one row per check. Columns follow the same rule as
-// Check's omitempty json tags: a column that is empty for every row is left out
-// rather than printed as a blank column under a header promising data. That
-// keeps an IDs-only listing (`oasdiff checks validate`, where a rule's text and
-// severity are only known at runtime) to a plain list of ids, while the
-// changelog listing, which populates both, is unchanged.
 func (f TEXTFormatter) RenderChecks(checks Checks, opts RenderOpts) ([]byte, error) {
 	result := bytes.NewBuffer(nil)
 
-	withDescription := slices.ContainsFunc(checks, func(c Check) bool { return c.Description != "" })
-	withLevel := slices.ContainsFunc(checks, func(c Check) bool { return c.Level != "" })
-
-	row := func(id, description, level string) string {
-		cells := []string{id}
-		if withDescription {
-			cells = append(cells, description)
-		}
-		if withLevel {
-			cells = append(cells, level)
-		}
-		return strings.Join(cells, "\t")
-	}
-
 	w := tabwriter.NewWriter(result, 1, 1, 1, ' ', 0)
-	_, _ = fmt.Fprintln(w, row("ID", "DESCRIPTION", "LEVEL"))
+	_, _ = fmt.Fprintln(w, "ID\tDESCRIPTION\tLEVEL")
 	for _, check := range checks {
-		_, _ = fmt.Fprintln(w, row(check.Id, f.Localizer(check.Description), check.Level))
+		_, _ = fmt.Fprintln(w, check.Id+"\t"+f.Localizer(check.Description)+"\t"+check.Level)
 	}
 	_ = w.Flush()
 

--- a/formatters/format_text.go
+++ b/formatters/format_text.go
@@ -3,6 +3,8 @@ package formatters
 import (
 	"bytes"
 	"fmt"
+	"slices"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/TwiN/go-color"
@@ -49,13 +51,33 @@ func (f TEXTFormatter) RenderChangelog(changes checker.Changes, opts RenderOpts)
 	return result.Bytes(), nil
 }
 
+// RenderChecks prints one row per check. Columns follow the same rule as
+// Check's omitempty json tags: a column that is empty for every row is left out
+// rather than printed as a blank column under a header promising data. That
+// keeps an IDs-only listing (`oasdiff checks validate`, where a rule's text and
+// severity are only known at runtime) to a plain list of ids, while the
+// changelog listing, which populates both, is unchanged.
 func (f TEXTFormatter) RenderChecks(checks Checks, opts RenderOpts) ([]byte, error) {
 	result := bytes.NewBuffer(nil)
 
+	withDescription := slices.ContainsFunc(checks, func(c Check) bool { return c.Description != "" })
+	withLevel := slices.ContainsFunc(checks, func(c Check) bool { return c.Level != "" })
+
+	row := func(id, description, level string) string {
+		cells := []string{id}
+		if withDescription {
+			cells = append(cells, description)
+		}
+		if withLevel {
+			cells = append(cells, level)
+		}
+		return strings.Join(cells, "\t")
+	}
+
 	w := tabwriter.NewWriter(result, 1, 1, 1, ' ', 0)
-	_, _ = fmt.Fprintln(w, "ID\tDESCRIPTION\tLEVEL")
+	_, _ = fmt.Fprintln(w, row("ID", "DESCRIPTION", "LEVEL"))
 	for _, check := range checks {
-		_, _ = fmt.Fprintln(w, check.Id+"\t"+f.Localizer(check.Description)+"\t"+check.Level)
+		_, _ = fmt.Fprintln(w, row(check.Id, f.Localizer(check.Description), check.Level))
 	}
 	_ = w.Flush()
 

--- a/formatters/format_text_test.go
+++ b/formatters/format_text_test.go
@@ -82,28 +82,3 @@ func TestTextFormatter_NotImplemented(t *testing.T) {
 	_, err = textFormatter.RenderSummary(nil, formatters.NewRenderOpts())
 	assert.Error(t, err)
 }
-
-// An IDs-only listing (oasdiff checks validate) prints just the ID column: a
-// DESCRIPTION or LEVEL header over blank cells would promise data that a
-// validate rule has no static value for.
-func TestTextFormatter_RenderChecks_IdOnlyDropsEmptyColumns(t *testing.T) {
-	out, err := formatters.TEXTFormatter{Localizer: MockLocalizer}.RenderChecks(
-		formatters.Checks{{Id: "some-rule"}, {Id: "other-rule"}}, formatters.NewRenderOpts())
-	require.NoError(t, err)
-
-	require.NotContains(t, string(out), "DESCRIPTION")
-	require.NotContains(t, string(out), "LEVEL")
-	require.Contains(t, string(out), "ID")
-	require.Contains(t, string(out), "some-rule")
-}
-
-// A populated listing keeps every column.
-func TestTextFormatter_RenderChecks_KeepsPopulatedColumns(t *testing.T) {
-	out, err := formatters.TEXTFormatter{Localizer: MockLocalizer}.RenderChecks(
-		formatters.Checks{{Id: "some-rule", Description: "d", Level: "error"}}, formatters.NewRenderOpts())
-	require.NoError(t, err)
-
-	for _, want := range []string{"ID", "DESCRIPTION", "LEVEL", "some-rule", "error"} {
-		require.Contains(t, string(out), want)
-	}
-}

--- a/formatters/format_text_test.go
+++ b/formatters/format_text_test.go
@@ -82,3 +82,28 @@ func TestTextFormatter_NotImplemented(t *testing.T) {
 	_, err = textFormatter.RenderSummary(nil, formatters.NewRenderOpts())
 	assert.Error(t, err)
 }
+
+// An IDs-only listing (oasdiff checks validate) prints just the ID column: a
+// DESCRIPTION or LEVEL header over blank cells would promise data that a
+// validate rule has no static value for.
+func TestTextFormatter_RenderChecks_IdOnlyDropsEmptyColumns(t *testing.T) {
+	out, err := formatters.TEXTFormatter{Localizer: MockLocalizer}.RenderChecks(
+		formatters.Checks{{Id: "some-rule"}, {Id: "other-rule"}}, formatters.NewRenderOpts())
+	require.NoError(t, err)
+
+	require.NotContains(t, string(out), "DESCRIPTION")
+	require.NotContains(t, string(out), "LEVEL")
+	require.Contains(t, string(out), "ID")
+	require.Contains(t, string(out), "some-rule")
+}
+
+// A populated listing keeps every column.
+func TestTextFormatter_RenderChecks_KeepsPopulatedColumns(t *testing.T) {
+	out, err := formatters.TEXTFormatter{Localizer: MockLocalizer}.RenderChecks(
+		formatters.Checks{{Id: "some-rule", Description: "d", Level: "error"}}, formatters.NewRenderOpts())
+	require.NoError(t, err)
+
+	for _, want := range []string{"ID", "DESCRIPTION", "LEVEL", "some-rule", "error"} {
+		require.Contains(t, string(out), want)
+	}
+}

--- a/internal/checks.go
+++ b/internal/checks.go
@@ -2,16 +2,12 @@ package internal
 
 import (
 	"fmt"
-	"io"
 	"slices"
 
 	"github.com/oasdiff/oasdiff/checker"
-	"github.com/oasdiff/oasdiff/checker/localizations"
 	"github.com/oasdiff/oasdiff/formatters"
 	"github.com/spf13/cobra"
 )
-
-const checksChangelogCmd = "checks changelog"
 
 // getChecksCmd groups the per-rule-set listings and lists no rules itself:
 // naming one rule set by omission stopped being tenable once `checks validate`
@@ -37,27 +33,6 @@ func getChecksCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(getChecksChangelogCmd(), getChecksValidateCmd())
-
-	return &cmd
-}
-
-// getChecksChangelogCmd lists the breaking-change and changelog rules, the
-// counterpart of `checks validate`.
-func getChecksChangelogCmd() *cobra.Command {
-
-	cmd := cobra.Command{
-		Use:               "changelog",
-		Short:             "Display changelog and breaking-change checks",
-		Long:              `Display a list of all supported changelog and breaking-change checks.`,
-		Args:              cobra.NoArgs,
-		ValidArgsFunction: cobra.NoFileCompletions,
-		RunE:              getRun(runChecks),
-	}
-
-	// Registered per command rather than inherited: viper binds a command's own
-	// persistent flags (see bindFlags), so an inherited flag would parse but
-	// never reach the config.
-	addChecksChangelogFlags(&cmd)
 
 	return &cmd
 }
@@ -117,25 +92,6 @@ func noSubcommandArgs(cmd *cobra.Command, args []string) error {
 	return err
 }
 
-// addChecksChangelogFlags registers the flags for the changelog listing.
-// --lang belongs here and not on the validate listing: these descriptions are
-// localized, and --tags likewise, since only these rules carry tags.
-func addChecksChangelogFlags(cmd *cobra.Command) {
-	addChecksFormatFlags(cmd)
-	addChecksSeverityFlag(cmd)
-	enumWithOptions(cmd, newEnumSliceValue(getAllTags(), nil), "tags", "t", "include only checks with all specified tags")
-	enumWithOptions(cmd, newEnumValue(localizations.GetSupportedLanguages(), localizations.LangDefault), "lang", "l", "language for localized output")
-}
-
-// addChecksValidateFlags registers the flags for the validate listing: output
-// and severity only. The descriptions are plain English rather than localized
-// (a finding's text comes from the parser at runtime), so --lang would have
-// nothing to translate, and validate rules carry no tags.
-func addChecksValidateFlags(cmd *cobra.Command) {
-	addChecksFormatFlags(cmd)
-	addChecksSeverityFlag(cmd)
-}
-
 // addChecksFormatFlags registers the output format flag every listing needs.
 func addChecksFormatFlags(cmd *cobra.Command) {
 	enumWithOptions(cmd, newEnumValue(formatters.SupportedFormatsByContentType(formatters.OutputChecks), string(formatters.FormatText)), "format", "f", "output format")
@@ -163,66 +119,4 @@ func matchSeverity(severity []string, level checker.Level) bool {
 		return slices.Contains(severity, "info")
 	}
 	return true
-}
-
-func runChecks(flags *Flags, stdout io.Writer) (bool, *ReturnError) {
-	return false, outputChecks(stdout, flags, checker.GetAllRules())
-}
-
-func outputChecks(stdout io.Writer, flags *Flags, rules []checker.BackwardCompatibilityRule) *ReturnError {
-
-	format := flags.getFormat()
-
-	// formatter lookup
-	formatter, err := formatters.Lookup(format, formatters.FormatterOpts{
-		Language: flags.getLang(),
-	})
-	if err != nil {
-		return getErrUnsupportedFormat(format, checksChangelogCmd)
-	}
-
-	localizer := checker.NewLocalizer(flags.getLang())
-
-	// filter rules
-	severity := flags.getSeverity()
-	checks := make(formatters.Checks, 0, len(rules))
-	for _, rule := range rules {
-		if !matchSeverity(severity, rule.Level) {
-			continue
-		}
-
-		// tags
-		if !matchTags(flags.getTags(), rule) {
-			continue
-		}
-
-		commentKey := rule.Id + "-comment"
-		mitigation := localizer(commentKey)
-		if mitigation == commentKey {
-			mitigation = ""
-		}
-
-		checks = append(checks, formatters.Check{
-			Id:          rule.Id,
-			Level:       rule.Level.String(),
-			Direction:   rule.Direction.String(),
-			Area:        rule.Area.String(),
-			Kind:        rule.Kind.String(),
-			Action:      rule.Action.String(),
-			Description: localizer(rule.Description),
-			Mitigation:  mitigation,
-		})
-	}
-
-	// render
-	slices.SortFunc(checks, checks.SortFunc)
-	bytes, err := formatter.RenderChecks(checks, formatters.NewRenderOpts())
-	if err != nil {
-		return getErrFailedPrint("checks "+format, err)
-	}
-
-	// print output
-	_, _ = fmt.Fprintf(stdout, "%s\n", bytes)
-
-	return nil
 }

--- a/internal/checks.go
+++ b/internal/checks.go
@@ -17,21 +17,20 @@ const checksChangelogCmd = "checks changelog"
 // naming one rule set by omission stopped being tenable once `checks validate`
 // existed, so the rule set is always explicit. Run bare it prints the help.
 //
-// It has a RunE only so that it stays Runnable, which is what makes cobra
-// reach Args and reject `checks <typo>` with a non-zero exit. A non-runnable
-// parent returns flag.ErrHelp before Args is ever evaluated, so a typo'd
-// subcommand would print help and exit 0, which a script cannot detect.
-// DisableFlagsInUseLine keeps `[flags]` out of the usage: the flags belong to
-// the subcommands.
+// The RunE, DisableFlagsInUseLine and Args below work around a cobra
+// limitation; see noSubcommandArgs.
 func getChecksCmd() *cobra.Command {
 
 	cmd := cobra.Command{
-		Use:                   "checks",
-		Short:                 "Display checks",
-		Long:                  `Display the rules oasdiff applies, one listing per rule set.`,
+		Use:               "checks",
+		Short:             "Display checks",
+		Long:              `Display the rules oasdiff applies, one listing per rule set.`,
+		ValidArgsFunction: cobra.NoFileCompletions,
+
+		// These three go together and work around a cobra limitation;
+		// see noSubcommandArgs for what to delete when it is fixed.
 		Args:                  noSubcommandArgs,
 		DisableFlagsInUseLine: true,
-		ValidArgsFunction:     cobra.NoFileCompletions,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},
@@ -67,12 +66,40 @@ func getChecksChangelogCmd() *cobra.Command {
 // subcommand, reported exactly as cobra reports one at the top level, so the
 // same mistake reads the same at either depth.
 //
-// Reporting it here rather than letting cobra do it: cobra only prints that
-// form when it fails to *find* a command, and `checks <typo>` resolves to
-// `checks` with a leftover argument, which otherwise prints the whole help.
-// The two lines are emitted the way cobra emits them (ErrPrefix + the hint as
-// its own line, not as part of the error string), so the error text stays free
-// of trailing punctuation and the output is byte-identical.
+// WORKAROUND for a cobra limitation, to be removed when cobra fixes it.
+//
+// The problem: a command with subcommands and no Run/RunE is not Runnable, and
+// cobra's execute() returns flag.ErrHelp at its `!c.Runnable()` check *before*
+// it validates Args (command.go:956 vs 969 in v1.10.2). ExecuteC then turns
+// flag.ErrHelp into a nil error, so `oasdiff checks <typo>` prints the help and
+// exits 0. A script cannot tell that from success, and it disagrees with
+// `oasdiff <typo>`, which exits non-zero.
+//
+// The workaround, in three parts:
+//  1. RunE, which does nothing but print the help, so the command is Runnable
+//     and cobra reaches Args at all.
+//  2. noSubcommandArgs, which rejects a stray argument in cobra's own
+//     unknown-command shape.
+//  3. DisableFlagsInUseLine, because a Runnable command puts its UseLine in the
+//     usage block, and without this it reads `oasdiff checks [flags]` while the
+//     flags actually live on the subcommands.
+//
+// Upstream: reported since 2020 in https://github.com/spf13/cobra/issues/1156
+// (also #706, #981, #2130). https://github.com/spf13/cobra/pull/2167 proposes
+// an ErrorOnUnknownSubcommand field and has been awaiting review since 2024.
+//
+// To remove once cobra ships it: set ErrorOnUnknownSubcommand on this command,
+// restore `Args: cobra.NoArgs`, and drop all three parts above plus
+// noSubcommandArgs and its tests. The usage block then loses its
+// `oasdiff checks` line and reads `oasdiff checks [command]` alone, which is
+// what it should have said all along.
+//
+// Why the message is printed here rather than left to cobra: cobra only prints
+// that form when it fails to *find* a command, and `checks <typo>` resolves to
+// `checks` with a leftover argument, which otherwise prints the whole help. The
+// two lines are emitted the way cobra emits them (ErrPrefix + the hint as its
+// own line, not as part of the error string), so the error text stays free of
+// trailing punctuation and the output is byte-identical.
 func noSubcommandArgs(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
 		return nil

--- a/internal/checks.go
+++ b/internal/checks.go
@@ -29,7 +29,7 @@ func getChecksCmd() *cobra.Command {
 		Use:                   "checks",
 		Short:                 "Display checks",
 		Long:                  `Display the rules oasdiff applies, one listing per rule set.`,
-		Args:                  cobra.NoArgs,
+		Args:                  noSubcommandArgs,
 		DisableFlagsInUseLine: true,
 		ValidArgsFunction:     cobra.NoFileCompletions,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -61,6 +61,33 @@ func getChecksChangelogCmd() *cobra.Command {
 	addChecksChangelogFlags(&cmd)
 
 	return &cmd
+}
+
+// noSubcommandArgs rejects a stray argument to `checks` as an unknown
+// subcommand, reported exactly as cobra reports one at the top level, so the
+// same mistake reads the same at either depth.
+//
+// Reporting it here rather than letting cobra do it: cobra only prints that
+// form when it fails to *find* a command, and `checks <typo>` resolves to
+// `checks` with a leftover argument, which otherwise prints the whole help.
+// The two lines are emitted the way cobra emits them (ErrPrefix + the hint as
+// its own line, not as part of the error string), so the error text stays free
+// of trailing punctuation and the output is byte-identical.
+func noSubcommandArgs(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return nil
+	}
+
+	err := fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
+	cmd.PrintErrln(cmd.ErrPrefix(), err.Error())
+	cmd.PrintErrf("Run '%v --help' for usage.\n", cmd.CommandPath())
+
+	// Already reported, so cobra must not print it again or follow it with the
+	// usage block.
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	return err
 }
 
 // addChecksChangelogFlags registers the flags for the changelog listing.

--- a/internal/checks.go
+++ b/internal/checks.go
@@ -11,37 +11,35 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const checksCmd = "checks"
+const checksChangelogCmd = "checks changelog"
 
+// getChecksCmd groups the per-rule-set listings and has no body of its own:
+// naming one rule set by omission stopped being tenable once `checks validate`
+// existed, so the rule set is always explicit. Run bare, cobra prints the help
+// listing the subcommands.
 func getChecksCmd() *cobra.Command {
 
 	cmd := cobra.Command{
-		Use:               "checks [flags]",
+		Use:               "checks",
 		Short:             "Display checks",
-		Long:              `Display a list of all supported checks.`,
+		Long:              `Display the rules oasdiff applies, one listing per rule set.`,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions, // see https://github.com/spf13/cobra/issues/1969
-		RunE:              getRun(runChecks),
 	}
-
-	addChecksRuleFlags(&cmd)
 
 	cmd.AddCommand(getChecksChangelogCmd(), getChecksValidateCmd())
 
 	return &cmd
 }
 
-// getChecksChangelogCmd is the explicit form of bare `oasdiff checks`: it lists
-// the breaking-change and changelog rules. It exists so the two rule sets are
-// addressed symmetrically (`checks changelog` alongside `checks validate`)
-// rather than one being the unnamed default. Bare `oasdiff checks` keeps
-// working and behaves identically.
+// getChecksChangelogCmd lists the breaking-change and changelog rules, the
+// counterpart of `checks validate`.
 func getChecksChangelogCmd() *cobra.Command {
 
 	cmd := cobra.Command{
 		Use:               "changelog",
 		Short:             "Display changelog and breaking-change checks",
-		Long:              `Display a list of all supported changelog and breaking-change checks. Same as 'oasdiff checks' with no subcommand.`,
+		Long:              `Display a list of all supported changelog and breaking-change checks.`,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
 		RunE:              getRun(runChecks),
@@ -50,23 +48,57 @@ func getChecksChangelogCmd() *cobra.Command {
 	// Registered per command rather than inherited: viper binds a command's own
 	// persistent flags (see bindFlags), so an inherited flag would parse but
 	// never reach the config.
-	addChecksRuleFlags(&cmd)
+	addChecksChangelogFlags(&cmd)
 
 	return &cmd
 }
 
-// addChecksRuleFlags registers the flags for listing the changelog and
-// breaking-change rules, shared by `checks` and `checks changelog`.
-func addChecksRuleFlags(cmd *cobra.Command) {
+// addChecksChangelogFlags registers the flags for the changelog listing.
+// --lang belongs here and not on the validate listing: these descriptions are
+// localized, and --tags likewise, since only these rules carry tags.
+func addChecksChangelogFlags(cmd *cobra.Command) {
 	addChecksFormatFlags(cmd)
-	enumWithOptions(cmd, newEnumSliceValue([]string{"info", "warn", "error"}, nil), "severity", "s", "include only checks with any of specified severities")
+	addChecksSeverityFlag(cmd)
 	enumWithOptions(cmd, newEnumSliceValue(getAllTags(), nil), "tags", "t", "include only checks with all specified tags")
+	enumWithOptions(cmd, newEnumValue(localizations.GetSupportedLanguages(), localizations.LangDefault), "lang", "l", "language for localized output")
 }
 
-// addChecksFormatFlags registers the output flags every checks listing needs.
+// addChecksValidateFlags registers the flags for the validate listing: output
+// and severity only. The descriptions are plain English rather than localized
+// (a finding's text comes from the parser at runtime), so --lang would have
+// nothing to translate, and validate rules carry no tags.
+func addChecksValidateFlags(cmd *cobra.Command) {
+	addChecksFormatFlags(cmd)
+	addChecksSeverityFlag(cmd)
+}
+
+// addChecksFormatFlags registers the output format flag every listing needs.
 func addChecksFormatFlags(cmd *cobra.Command) {
-	enumWithOptions(cmd, newEnumValue(localizations.GetSupportedLanguages(), localizations.LangDefault), "lang", "l", "language for localized output")
 	enumWithOptions(cmd, newEnumValue(formatters.SupportedFormatsByContentType(formatters.OutputChecks), string(formatters.FormatText)), "format", "f", "output format")
+}
+
+// addChecksSeverityFlag registers --severity, which both listings support now
+// that a validate rule has a severity of its own.
+func addChecksSeverityFlag(cmd *cobra.Command) {
+	enumWithOptions(cmd, newEnumSliceValue([]string{"info", "warn", "error"}, nil), "severity", "s", "include only checks with any of specified severities")
+}
+
+// matchSeverity reports whether level passes the --severity filter. An empty
+// filter matches every rule. The flag's values are the short forms, which do
+// not all match Level.String(), so this switches on the level itself.
+func matchSeverity(severity []string, level checker.Level) bool {
+	if len(severity) == 0 {
+		return true
+	}
+	switch level {
+	case checker.ERR:
+		return slices.Contains(severity, "error")
+	case checker.WARN:
+		return slices.Contains(severity, "warn")
+	case checker.INFO:
+		return slices.Contains(severity, "info")
+	}
+	return true
 }
 
 func runChecks(flags *Flags, stdout io.Writer) (bool, *ReturnError) {
@@ -82,7 +114,7 @@ func outputChecks(stdout io.Writer, flags *Flags, rules []checker.BackwardCompat
 		Language: flags.getLang(),
 	})
 	if err != nil {
-		return getErrUnsupportedFormat(format, checksCmd)
+		return getErrUnsupportedFormat(format, checksChangelogCmd)
 	}
 
 	localizer := checker.NewLocalizer(flags.getLang())
@@ -91,17 +123,8 @@ func outputChecks(stdout io.Writer, flags *Flags, rules []checker.BackwardCompat
 	severity := flags.getSeverity()
 	checks := make(formatters.Checks, 0, len(rules))
 	for _, rule := range rules {
-		// severity
-		if len(severity) > 0 {
-			if rule.Level == checker.ERR && !slices.Contains(severity, "error") {
-				continue
-			}
-			if rule.Level == checker.WARN && !slices.Contains(severity, "warn") {
-				continue
-			}
-			if rule.Level == checker.INFO && !slices.Contains(severity, "info") {
-				continue
-			}
+		if !matchSeverity(severity, rule.Level) {
+			continue
 		}
 
 		// tags

--- a/internal/checks.go
+++ b/internal/checks.go
@@ -24,12 +24,49 @@ func getChecksCmd() *cobra.Command {
 		RunE:              getRun(runChecks),
 	}
 
-	enumWithOptions(&cmd, newEnumValue(localizations.GetSupportedLanguages(), localizations.LangDefault), "lang", "l", "language for localized output")
-	enumWithOptions(&cmd, newEnumValue(formatters.SupportedFormatsByContentType(formatters.OutputChecks), string(formatters.FormatText)), "format", "f", "output format")
-	enumWithOptions(&cmd, newEnumSliceValue([]string{"info", "warn", "error"}, nil), "severity", "s", "include only checks with any of specified severities")
-	enumWithOptions(&cmd, newEnumSliceValue(getAllTags(), nil), "tags", "t", "include only checks with all specified tags")
+	addChecksRuleFlags(&cmd)
+
+	cmd.AddCommand(getChecksChangelogCmd(), getChecksValidateCmd())
 
 	return &cmd
+}
+
+// getChecksChangelogCmd is the explicit form of bare `oasdiff checks`: it lists
+// the breaking-change and changelog rules. It exists so the two rule sets are
+// addressed symmetrically (`checks changelog` alongside `checks validate`)
+// rather than one being the unnamed default. Bare `oasdiff checks` keeps
+// working and behaves identically.
+func getChecksChangelogCmd() *cobra.Command {
+
+	cmd := cobra.Command{
+		Use:               "changelog",
+		Short:             "Display changelog and breaking-change checks",
+		Long:              `Display a list of all supported changelog and breaking-change checks. Same as 'oasdiff checks' with no subcommand.`,
+		Args:              cobra.NoArgs,
+		ValidArgsFunction: cobra.NoFileCompletions,
+		RunE:              getRun(runChecks),
+	}
+
+	// Registered per command rather than inherited: viper binds a command's own
+	// persistent flags (see bindFlags), so an inherited flag would parse but
+	// never reach the config.
+	addChecksRuleFlags(&cmd)
+
+	return &cmd
+}
+
+// addChecksRuleFlags registers the flags for listing the changelog and
+// breaking-change rules, shared by `checks` and `checks changelog`.
+func addChecksRuleFlags(cmd *cobra.Command) {
+	addChecksFormatFlags(cmd)
+	enumWithOptions(cmd, newEnumSliceValue([]string{"info", "warn", "error"}, nil), "severity", "s", "include only checks with any of specified severities")
+	enumWithOptions(cmd, newEnumSliceValue(getAllTags(), nil), "tags", "t", "include only checks with all specified tags")
+}
+
+// addChecksFormatFlags registers the output flags every checks listing needs.
+func addChecksFormatFlags(cmd *cobra.Command) {
+	enumWithOptions(cmd, newEnumValue(localizations.GetSupportedLanguages(), localizations.LangDefault), "lang", "l", "language for localized output")
+	enumWithOptions(cmd, newEnumValue(formatters.SupportedFormatsByContentType(formatters.OutputChecks), string(formatters.FormatText)), "format", "f", "output format")
 }
 
 func runChecks(flags *Flags, stdout io.Writer) (bool, *ReturnError) {

--- a/internal/checks.go
+++ b/internal/checks.go
@@ -13,18 +13,28 @@ import (
 
 const checksChangelogCmd = "checks changelog"
 
-// getChecksCmd groups the per-rule-set listings and has no body of its own:
+// getChecksCmd groups the per-rule-set listings and lists no rules itself:
 // naming one rule set by omission stopped being tenable once `checks validate`
-// existed, so the rule set is always explicit. Run bare, cobra prints the help
-// listing the subcommands.
+// existed, so the rule set is always explicit. Run bare it prints the help.
+//
+// It has a RunE only so that it stays Runnable, which is what makes cobra
+// reach Args and reject `checks <typo>` with a non-zero exit. A non-runnable
+// parent returns flag.ErrHelp before Args is ever evaluated, so a typo'd
+// subcommand would print help and exit 0, which a script cannot detect.
+// DisableFlagsInUseLine keeps `[flags]` out of the usage: the flags belong to
+// the subcommands.
 func getChecksCmd() *cobra.Command {
 
 	cmd := cobra.Command{
-		Use:               "checks",
-		Short:             "Display checks",
-		Long:              `Display the rules oasdiff applies, one listing per rule set.`,
-		Args:              cobra.NoArgs,
-		ValidArgsFunction: cobra.NoFileCompletions, // see https://github.com/spf13/cobra/issues/1969
+		Use:                   "checks",
+		Short:                 "Display checks",
+		Long:                  `Display the rules oasdiff applies, one listing per rule set.`,
+		Args:                  cobra.NoArgs,
+		DisableFlagsInUseLine: true,
+		ValidArgsFunction:     cobra.NoFileCompletions,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
 	}
 
 	cmd.AddCommand(getChecksChangelogCmd(), getChecksValidateCmd())

--- a/internal/checks_changelog.go
+++ b/internal/checks_changelog.go
@@ -1,0 +1,107 @@
+package internal
+
+import (
+	"fmt"
+	"io"
+	"slices"
+
+	"github.com/oasdiff/oasdiff/checker"
+	"github.com/oasdiff/oasdiff/checker/localizations"
+	"github.com/oasdiff/oasdiff/formatters"
+	"github.com/spf13/cobra"
+)
+
+const checksChangelogCmd = "checks changelog"
+
+// getChecksChangelogCmd lists the breaking-change and changelog rules, the
+// counterpart of `checks validate`.
+func getChecksChangelogCmd() *cobra.Command {
+
+	cmd := cobra.Command{
+		Use:               "changelog",
+		Short:             "Display changelog and breaking-change checks",
+		Long:              `Display a list of all supported changelog and breaking-change checks.`,
+		Args:              cobra.NoArgs,
+		ValidArgsFunction: cobra.NoFileCompletions,
+		RunE:              getRun(runChecksChangelog),
+	}
+
+	// Registered per command rather than inherited: viper binds a command's own
+	// persistent flags (see bindFlags), so an inherited flag would parse but
+	// never reach the config.
+	addChecksChangelogFlags(&cmd)
+
+	return &cmd
+}
+
+// addChecksChangelogFlags registers the flags for the changelog listing.
+// --lang belongs here and not on the validate listing: these descriptions are
+// localized, and --tags likewise, since only these rules carry tags.
+func addChecksChangelogFlags(cmd *cobra.Command) {
+	addChecksFormatFlags(cmd)
+	addChecksSeverityFlag(cmd)
+	enumWithOptions(cmd, newEnumSliceValue(getAllTags(), nil), "tags", "t", "include only checks with all specified tags")
+	enumWithOptions(cmd, newEnumValue(localizations.GetSupportedLanguages(), localizations.LangDefault), "lang", "l", "language for localized output")
+}
+
+func runChecksChangelog(flags *Flags, stdout io.Writer) (bool, *ReturnError) {
+	return false, outputChangelogRules(stdout, flags, checker.GetAllRules())
+}
+
+func outputChangelogRules(stdout io.Writer, flags *Flags, rules []checker.BackwardCompatibilityRule) *ReturnError {
+
+	format := flags.getFormat()
+
+	// formatter lookup
+	formatter, err := formatters.Lookup(format, formatters.FormatterOpts{
+		Language: flags.getLang(),
+	})
+	if err != nil {
+		return getErrUnsupportedFormat(format, checksChangelogCmd)
+	}
+
+	localizer := checker.NewLocalizer(flags.getLang())
+
+	// filter rules
+	severity := flags.getSeverity()
+	checks := make(formatters.Checks, 0, len(rules))
+	for _, rule := range rules {
+		if !matchSeverity(severity, rule.Level) {
+			continue
+		}
+
+		// tags
+		if !matchTags(flags.getTags(), rule) {
+			continue
+		}
+
+		commentKey := rule.Id + "-comment"
+		mitigation := localizer(commentKey)
+		if mitigation == commentKey {
+			mitigation = ""
+		}
+
+		checks = append(checks, formatters.Check{
+			Id:          rule.Id,
+			Level:       rule.Level.String(),
+			Direction:   rule.Direction.String(),
+			Area:        rule.Area.String(),
+			Kind:        rule.Kind.String(),
+			Action:      rule.Action.String(),
+			Description: localizer(rule.Description),
+			Mitigation:  mitigation,
+		})
+	}
+
+	// render
+	slices.SortFunc(checks, checks.SortFunc)
+	bytes, err := formatter.RenderChecks(checks, formatters.NewRenderOpts())
+	if err != nil {
+		return getErrFailedPrint(checksChangelogCmd+" "+format, err)
+	}
+
+	// print output
+	_, _ = fmt.Fprintf(stdout, "%s\n", bytes)
+
+	return nil
+}

--- a/internal/checks_changelog_test.go
+++ b/internal/checks_changelog_test.go
@@ -1,0 +1,23 @@
+package internal_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/oasdiff/oasdiff/internal"
+	"github.com/stretchr/testify/require"
+)
+
+// The listing flags moved to the subcommand, so they have to work there.
+func Test_ChecksChangelogAcceptsTheListingFlags(t *testing.T) {
+	var stdout bytes.Buffer
+	require.Zero(t, internal.Run(
+		cmdToArgs("oasdiff checks changelog -l ru --tags decrease,parameters --severity info,warn,error --format json"),
+		&stdout, io.Discard))
+
+	var checks []map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &checks))
+	require.NotEmpty(t, checks)
+}

--- a/internal/checks_test.go
+++ b/internal/checks_test.go
@@ -24,6 +24,15 @@ func Test_ChecksRequiresASubcommand(t *testing.T) {
 	require.NotContains(t, out, "api-deprecated-sunset-missing")
 }
 
+// A typo'd subcommand is a user error, so it has to be reported like one: a
+// script redirecting the output would otherwise write help text to its target
+// and see success.
+func Test_ChecksUnknownSubcommandFails(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	require.NotZero(t, internal.Run(cmdToArgs("oasdiff checks chnagelog"), &stdout, &stderr))
+	require.Contains(t, stderr.String(), `unknown command "chnagelog" for "oasdiff checks"`)
+}
+
 // The parent carries no listing flags, so an old `oasdiff checks --format json`
 // fails loudly rather than quietly producing nothing for a caller piping it.
 func Test_ChecksWithListingFlagsFails(t *testing.T) {

--- a/internal/checks_test.go
+++ b/internal/checks_test.go
@@ -1,0 +1,71 @@
+package internal_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/oasdiff/oasdiff/internal"
+	"github.com/stretchr/testify/require"
+)
+
+// `oasdiff checks` names no rule set, so it has no listing of its own: it
+// prints the help pointing at the two that do.
+func Test_ChecksRequiresASubcommand(t *testing.T) {
+	var stdout bytes.Buffer
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks"), &stdout, io.Discard))
+
+	out := stdout.String()
+	require.Contains(t, out, "oasdiff checks [command]")
+	require.Contains(t, out, "changelog")
+	require.Contains(t, out, "validate")
+	// No listing: the rules themselves are only reachable through a subcommand.
+	require.NotContains(t, out, "api-deprecated-sunset-missing")
+}
+
+// The parent carries no listing flags, so an old `oasdiff checks --format json`
+// fails loudly rather than quietly producing nothing for a caller piping it.
+func Test_ChecksWithListingFlagsFails(t *testing.T) {
+	for _, cmd := range []string{
+		"oasdiff checks --format json",
+		"oasdiff checks --severity error",
+		"oasdiff checks --tags request",
+	} {
+		t.Run(cmd, func(t *testing.T) {
+			require.NotZero(t, internal.Run(cmdToArgs(cmd), io.Discard, io.Discard))
+		})
+	}
+}
+
+func Test_ChecksSubcommandsListTheirRules(t *testing.T) {
+	for _, cmd := range []string{
+		"oasdiff checks changelog --format json",
+		"oasdiff checks validate --format json",
+	} {
+		t.Run(cmd, func(t *testing.T) {
+			var stdout bytes.Buffer
+			require.Zero(t, internal.Run(cmdToArgs(cmd), &stdout, io.Discard))
+
+			var checks []map[string]any
+			require.NoError(t, json.Unmarshal(stdout.Bytes(), &checks))
+			require.NotEmpty(t, checks)
+			for _, c := range checks {
+				require.NotEmpty(t, c["id"])
+				require.NotEmpty(t, c["level"], "every rule reports a severity")
+			}
+		})
+	}
+}
+
+// The listing flags moved to the subcommand, so they have to work there.
+func Test_ChecksChangelogAcceptsTheListingFlags(t *testing.T) {
+	var stdout bytes.Buffer
+	require.Zero(t, internal.Run(
+		cmdToArgs("oasdiff checks changelog -l ru --tags decrease,parameters --severity info,warn,error --format json"),
+		&stdout, io.Discard))
+
+	var checks []map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &checks))
+	require.NotEmpty(t, checks)
+}

--- a/internal/checks_test.go
+++ b/internal/checks_test.go
@@ -30,7 +30,26 @@ func Test_ChecksRequiresASubcommand(t *testing.T) {
 func Test_ChecksUnknownSubcommandFails(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	require.NotZero(t, internal.Run(cmdToArgs("oasdiff checks chnagelog"), &stdout, &stderr))
-	require.Contains(t, stderr.String(), `unknown command "chnagelog" for "oasdiff checks"`)
+	// Same shape as the top-level form, so the same mistake reads the same at
+	// either depth: the error, then the hint, and no wall of usage text.
+	require.Equal(t,
+		"Error: unknown command \"chnagelog\" for \"oasdiff checks\"\nRun 'oasdiff checks --help' for usage.\n",
+		stderr.String())
+	require.Empty(t, stdout.String())
+}
+
+// The top-level form is the reference for the message above.
+func Test_UnknownCommandShapeMatchesTopLevel(t *testing.T) {
+	var top, nested bytes.Buffer
+	require.NotZero(t, internal.Run(cmdToArgs("oasdiff bogus"), io.Discard, &top))
+	require.NotZero(t, internal.Run(cmdToArgs("oasdiff checks bogus"), io.Discard, &nested))
+
+	require.Equal(t,
+		"Error: unknown command \"bogus\" for \"oasdiff\"\nRun 'oasdiff --help' for usage.\n",
+		top.String())
+	require.Equal(t,
+		"Error: unknown command \"bogus\" for \"oasdiff checks\"\nRun 'oasdiff checks --help' for usage.\n",
+		nested.String())
 }
 
 // The parent carries no listing flags, so an old `oasdiff checks --format json`

--- a/internal/checks_test.go
+++ b/internal/checks_test.go
@@ -85,15 +85,3 @@ func Test_ChecksSubcommandsListTheirRules(t *testing.T) {
 		})
 	}
 }
-
-// The listing flags moved to the subcommand, so they have to work there.
-func Test_ChecksChangelogAcceptsTheListingFlags(t *testing.T) {
-	var stdout bytes.Buffer
-	require.Zero(t, internal.Run(
-		cmdToArgs("oasdiff checks changelog -l ru --tags decrease,parameters --severity info,warn,error --format json"),
-		&stdout, io.Discard))
-
-	var checks []map[string]any
-	require.NoError(t, json.Unmarshal(stdout.Bytes(), &checks))
-	require.NotEmpty(t, checks)
-}

--- a/internal/checks_validate.go
+++ b/internal/checks_validate.go
@@ -35,11 +35,20 @@ func getChecksValidateCmd() *cobra.Command {
 	return &cmd
 }
 
-func runChecksValidate(flags *Flags, stdout io.Writer) (bool, *ReturnError) {
-	return false, outputValidateRuleIDs(stdout, flags)
+// addChecksValidateFlags registers the flags for the validate listing: output
+// and severity only. The descriptions are plain English rather than localized
+// (a finding's text comes from the parser at runtime), so --lang would have
+// nothing to translate, and validate rules carry no tags.
+func addChecksValidateFlags(cmd *cobra.Command) {
+	addChecksFormatFlags(cmd)
+	addChecksSeverityFlag(cmd)
 }
 
-func outputValidateRuleIDs(stdout io.Writer, flags *Flags) *ReturnError {
+func runChecksValidate(flags *Flags, stdout io.Writer) (bool, *ReturnError) {
+	return false, outputValidateRules(stdout, flags)
+}
+
+func outputValidateRules(stdout io.Writer, flags *Flags) *ReturnError {
 
 	format := flags.getFormat()
 

--- a/internal/checks_validate.go
+++ b/internal/checks_validate.go
@@ -1,0 +1,72 @@
+package internal
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/oasdiff/oasdiff/formatters"
+	"github.com/oasdiff/oasdiff/validate"
+	"github.com/spf13/cobra"
+)
+
+const checksValidateCmd = "checks validate"
+
+// getChecksValidateCmd lists the rule IDs `oasdiff validate` can report, the
+// counterpart of `oasdiff checks` for the breaking-change rules.
+//
+// IDs only, no descriptions or levels: a validate finding takes its text from
+// the parser's typed error and its severity from the classifier at runtime, so
+// unlike a breaking-change rule there is nothing static to list beyond the ID.
+// The IDs are stable API, which is what a CI dashboard needs.
+func getChecksValidateCmd() *cobra.Command {
+
+	cmd := cobra.Command{
+		Use:   "validate",
+		Short: "Display validate rule IDs",
+		Long: `Display the rule IDs that 'oasdiff validate' can report.
+
+IDs are stable: new ones may be added in later releases, but an existing ID is
+never renamed or repurposed, so external tooling can depend on them.`,
+		Args:              cobra.NoArgs,
+		ValidArgsFunction: cobra.NoFileCompletions,
+		RunE:              getRun(runChecksValidate),
+	}
+
+	// severity / tags do not apply: a validate rule has no static level or tags.
+	addChecksFormatFlags(&cmd)
+
+	return &cmd
+}
+
+func runChecksValidate(flags *Flags, stdout io.Writer) (bool, *ReturnError) {
+	return false, outputValidateRuleIDs(stdout, flags)
+}
+
+func outputValidateRuleIDs(stdout io.Writer, flags *Flags) *ReturnError {
+
+	format := flags.getFormat()
+
+	formatter, err := formatters.Lookup(format, formatters.FormatterOpts{
+		Language: flags.getLang(),
+	})
+	if err != nil {
+		return getErrUnsupportedFormat(format, checksValidateCmd)
+	}
+
+	// RuleIDs() is already sorted. Level is left empty: a validate rule's
+	// severity is decided per finding at runtime, not statically.
+	ids := validate.RuleIDs()
+	checks := make(formatters.Checks, 0, len(ids))
+	for _, id := range ids {
+		checks = append(checks, formatters.Check{Id: id, Description: validate.RuleDescription(id)})
+	}
+
+	bytes, err := formatter.RenderChecks(checks, formatters.NewRenderOpts())
+	if err != nil {
+		return getErrFailedPrint(checksValidateCmd+" "+format, err)
+	}
+
+	_, _ = fmt.Fprintf(stdout, "%s\n", bytes)
+
+	return nil
+}

--- a/internal/checks_validate.go
+++ b/internal/checks_validate.go
@@ -14,7 +14,7 @@ import (
 const checksValidateCmd = "checks validate"
 
 // getChecksValidateCmd lists the rules `oasdiff validate` can report, the
-// counterpart of `oasdiff checks` for the breaking-change rules.
+// counterpart of `oasdiff checks changelog` for the breaking-change rules.
 //
 // The IDs are stable API, which is what a CI dashboard needs.
 func getChecksValidateCmd() *cobra.Command {

--- a/internal/checks_validate.go
+++ b/internal/checks_validate.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/oasdiff/oasdiff/checker/localizations"
+
 	"github.com/oasdiff/oasdiff/formatters"
 	"github.com/oasdiff/oasdiff/validate"
 	"github.com/spf13/cobra"
@@ -18,12 +20,9 @@ const checksValidateCmd = "checks validate"
 func getChecksValidateCmd() *cobra.Command {
 
 	cmd := cobra.Command{
-		Use:   "validate",
-		Short: "Display validate rule IDs",
-		Long: `Display the rule IDs that 'oasdiff validate' can report.
-
-IDs are stable: new ones may be added in later releases, but an existing ID is
-never renamed or repurposed, so external tooling can depend on them.`,
+		Use:               "validate",
+		Short:             "Display validate checks",
+		Long:              `Display a list of all supported validate checks.`,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
 		RunE:              getRun(runChecksValidate),
@@ -31,7 +30,7 @@ never renamed or repurposed, so external tooling can depend on them.`,
 
 	// No severity / tags filters: unlike a breaking-change rule, a validate rule
 	// carries no tags, and there is no --severity-levels equivalent to reflect.
-	addChecksFormatFlags(&cmd)
+	addChecksValidateFlags(&cmd)
 
 	return &cmd
 }
@@ -44,8 +43,10 @@ func outputValidateRuleIDs(stdout io.Writer, flags *Flags) *ReturnError {
 
 	format := flags.getFormat()
 
+	// The default language, not flags.getLang(): these descriptions are plain
+	// English, so the validate listing registers no --lang to read.
 	formatter, err := formatters.Lookup(format, formatters.FormatterOpts{
-		Language: flags.getLang(),
+		Language: localizations.LangDefault,
 	})
 	if err != nil {
 		return getErrUnsupportedFormat(format, checksValidateCmd)
@@ -54,13 +55,18 @@ func outputValidateRuleIDs(stdout io.Writer, flags *Flags) *ReturnError {
 	// RuleIDs() is already sorted. Level comes from the same mapping the
 	// runtime classifier uses, so the listing cannot advertise a severity a
 	// finding won't carry.
+	severity := flags.getSeverity()
 	ids := validate.RuleIDs()
 	checks := make(formatters.Checks, 0, len(ids))
 	for _, id := range ids {
+		level := validate.RuleLevel(id)
+		if !matchSeverity(severity, level) {
+			continue
+		}
 		checks = append(checks, formatters.Check{
 			Id:          id,
 			Description: validate.RuleDescription(id),
-			Level:       validate.RuleLevel(id).String(),
+			Level:       level.String(),
 		})
 	}
 

--- a/internal/checks_validate.go
+++ b/internal/checks_validate.go
@@ -11,12 +11,9 @@ import (
 
 const checksValidateCmd = "checks validate"
 
-// getChecksValidateCmd lists the rule IDs `oasdiff validate` can report, the
+// getChecksValidateCmd lists the rules `oasdiff validate` can report, the
 // counterpart of `oasdiff checks` for the breaking-change rules.
 //
-// IDs only, no descriptions or levels: a validate finding takes its text from
-// the parser's typed error and its severity from the classifier at runtime, so
-// unlike a breaking-change rule there is nothing static to list beyond the ID.
 // The IDs are stable API, which is what a CI dashboard needs.
 func getChecksValidateCmd() *cobra.Command {
 
@@ -32,7 +29,8 @@ never renamed or repurposed, so external tooling can depend on them.`,
 		RunE:              getRun(runChecksValidate),
 	}
 
-	// severity / tags do not apply: a validate rule has no static level or tags.
+	// No severity / tags filters: unlike a breaking-change rule, a validate rule
+	// carries no tags, and there is no --severity-levels equivalent to reflect.
 	addChecksFormatFlags(&cmd)
 
 	return &cmd
@@ -53,12 +51,17 @@ func outputValidateRuleIDs(stdout io.Writer, flags *Flags) *ReturnError {
 		return getErrUnsupportedFormat(format, checksValidateCmd)
 	}
 
-	// RuleIDs() is already sorted. Level is left empty: a validate rule's
-	// severity is decided per finding at runtime, not statically.
+	// RuleIDs() is already sorted. Level comes from the same mapping the
+	// runtime classifier uses, so the listing cannot advertise a severity a
+	// finding won't carry.
 	ids := validate.RuleIDs()
 	checks := make(formatters.Checks, 0, len(ids))
 	for _, id := range ids {
-		checks = append(checks, formatters.Check{Id: id, Description: validate.RuleDescription(id)})
+		checks = append(checks, formatters.Check{
+			Id:          id,
+			Description: validate.RuleDescription(id),
+			Level:       validate.RuleLevel(id).String(),
+		})
 	}
 
 	bytes, err := formatter.RenderChecks(checks, formatters.NewRenderOpts())

--- a/internal/run_test.go
+++ b/internal/run_test.go
@@ -460,7 +460,7 @@ func Test_AutoUpgradeDiff_SameVersionIsHarmless(t *testing.T) {
 }
 
 func Test_Checks(t *testing.T) {
-	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru --tags decrease,parameters --severity info,warn,error"), io.Discard, io.Discard))
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog -l ru --tags decrease,parameters --severity info,warn,error"), io.Discard, io.Discard))
 }
 
 func Test_Color(t *testing.T) {

--- a/internal/tags_test.go
+++ b/internal/tags_test.go
@@ -9,44 +9,44 @@ import (
 )
 
 func Test_ChecksNoTags(t *testing.T) {
-	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru"), io.Discard, io.Discard))
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog -l ru"), io.Discard, io.Discard))
 }
 
 func Test_ChecksTagsDirection(t *testing.T) {
-	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru --tags request"), io.Discard, io.Discard))
-	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru --tags response"), io.Discard, io.Discard))
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog -l ru --tags request"), io.Discard, io.Discard))
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog -l ru --tags response"), io.Discard, io.Discard))
 }
 
 func Test_ChecksTagsAction(t *testing.T) {
-	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru --tags add"), io.Discard, io.Discard))
-	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru --tags remove"), io.Discard, io.Discard))
-	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru --tags change"), io.Discard, io.Discard))
-	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru --tags generalize"), io.Discard, io.Discard))
-	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru --tags specialize"), io.Discard, io.Discard))
-	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru --tags increase"), io.Discard, io.Discard))
-	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru --tags decrease"), io.Discard, io.Discard))
-	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru --tags set"), io.Discard, io.Discard))
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog -l ru --tags add"), io.Discard, io.Discard))
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog -l ru --tags remove"), io.Discard, io.Discard))
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog -l ru --tags change"), io.Discard, io.Discard))
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog -l ru --tags generalize"), io.Discard, io.Discard))
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog -l ru --tags specialize"), io.Discard, io.Discard))
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog -l ru --tags increase"), io.Discard, io.Discard))
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog -l ru --tags decrease"), io.Discard, io.Discard))
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog -l ru --tags set"), io.Discard, io.Discard))
 }
 
 func Test_ChecksTagsArea(t *testing.T) {
-	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru --tags schema"), io.Discard, io.Discard))
-	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru --tags parameters"), io.Discard, io.Discard))
-	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru --tags requestBody"), io.Discard, io.Discard))
-	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru --tags responses"), io.Discard, io.Discard))
-	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru --tags paths"), io.Discard, io.Discard))
-	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru --tags headers"), io.Discard, io.Discard))
-	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru --tags security"), io.Discard, io.Discard))
-	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru --tags tags"), io.Discard, io.Discard))
-	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru --tags components"), io.Discard, io.Discard))
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog -l ru --tags schema"), io.Discard, io.Discard))
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog -l ru --tags parameters"), io.Discard, io.Discard))
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog -l ru --tags requestBody"), io.Discard, io.Discard))
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog -l ru --tags responses"), io.Discard, io.Discard))
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog -l ru --tags paths"), io.Discard, io.Discard))
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog -l ru --tags headers"), io.Discard, io.Discard))
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog -l ru --tags security"), io.Discard, io.Discard))
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog -l ru --tags tags"), io.Discard, io.Discard))
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog -l ru --tags components"), io.Discard, io.Discard))
 }
 
 func Test_ChecksTagsKind(t *testing.T) {
-	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru --tags existence"), io.Discard, io.Discard))
-	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru --tags requiredness"), io.Discard, io.Discard))
-	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru --tags mutability"), io.Discard, io.Discard))
-	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru --tags type"), io.Discard, io.Discard))
-	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru --tags constraints"), io.Discard, io.Discard))
-	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru --tags values"), io.Discard, io.Discard))
-	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru --tags structure"), io.Discard, io.Discard))
-	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks -l ru --tags lifecycle"), io.Discard, io.Discard))
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog -l ru --tags existence"), io.Discard, io.Discard))
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog -l ru --tags requiredness"), io.Discard, io.Discard))
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog -l ru --tags mutability"), io.Discard, io.Discard))
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog -l ru --tags type"), io.Discard, io.Discard))
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog -l ru --tags constraints"), io.Discard, io.Discard))
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog -l ru --tags values"), io.Discard, io.Discard))
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog -l ru --tags structure"), io.Discard, io.Discard))
+	require.Zero(t, internal.Run(cmdToArgs("oasdiff checks changelog -l ru --tags lifecycle"), io.Discard, io.Discard))
 }

--- a/validate/lint_duplicate_enum.go
+++ b/validate/lint_duplicate_enum.go
@@ -44,7 +44,7 @@ func newDuplicateEnumFinding(s *openapi3.Schema, section string, dups []string, 
 	f := formatters.Finding{
 		Id:      DuplicateEnumValueID,
 		Text:    fmt.Sprintf("enum contains duplicate value(s): %s", strings.Join(quoted, ", ")),
-		Level:   checker.WARN,
+		Level:   RuleLevel(DuplicateEnumValueID),
 		Section: section,
 		Source: formatters.Source{
 			File:   source,

--- a/validate/lint_param_serialization.go
+++ b/validate/lint_param_serialization.go
@@ -69,7 +69,7 @@ func newAmbiguousParamFinding(p *openapi3.Parameter, section string, types []str
 	f := formatters.Finding{
 		Id:      AmbiguousParameterSerializationID,
 		Text:    fmt.Sprintf("parameter %q mixes a structured type with a scalar (%s): its serialization is ambiguous", p.Name, strings.Join(types, ", ")),
-		Level:   checker.WARN,
+		Level:   RuleLevel(AmbiguousParameterSerializationID),
 		Section: section,
 		Source: formatters.Source{
 			File:   source,

--- a/validate/lint_required_with_default.go
+++ b/validate/lint_required_with_default.go
@@ -59,7 +59,7 @@ func newRequiredWithDefaultFinding(text, section, name string, line, column int,
 	f := formatters.Finding{
 		Id:      RequiredWithDefaultID,
 		Text:    text,
-		Level:   checker.WARN,
+		Level:   RuleLevel(RequiredWithDefaultID),
 		Section: section,
 		Source: formatters.Source{
 			File:   source,

--- a/validate/lint_type_format_mismatch.go
+++ b/validate/lint_type_format_mismatch.go
@@ -125,7 +125,7 @@ func newTypeFormatMismatchFinding(s *openapi3.Schema, section, owner, source str
 		Id: TypeFormatMismatchID,
 		Text: fmt.Sprintf("format %q is defined for type %q, not %q, so it is ignored",
 			s.Format, owner, declared),
-		Level:   checker.WARN,
+		Level:   RuleLevel(TypeFormatMismatchID),
 		Section: section,
 		Source: formatters.Source{
 			File:   source,

--- a/validate/rule_descriptions.go
+++ b/validate/rule_descriptions.go
@@ -1,0 +1,139 @@
+package validate
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Descriptions for the rules `oasdiff validate` can report, used by
+// `oasdiff checks validate` to say what each ID means.
+//
+// Plain English, not localized: unlike the changelog rules, a validate finding
+// takes its message from the parser at runtime, so there is no localized
+// message file to hang these off. They describe the rule, not the specific
+// violation; the finding's own text names the offending field.
+//
+// Style follows the changelog rule descriptions: short, lowercase, no trailing
+// period.
+//
+// Not every ID is listed. The version-gate rules (`<field>-field-for-3-1-plus`
+// and friends) are described by versionGateDescription, which derives the text
+// from the ID, so a new one added upstream is described without a change here.
+var ruleDescriptions = map[string]string{
+	// Document structure
+	"openapi-required":             "openapi version field is missing",
+	"info-required":                "info object is missing",
+	"info-title-required":          "info title is missing",
+	"info-version-required":        "info version is missing",
+	"license-name-required":        "license name is missing",
+	"paths-required":               "paths object is missing or not an object",
+	"json-schema-dialect-required": "jsonSchemaDialect value is missing",
+	"external-docs-url-required":   "external documentation url is missing",
+	"unresolved-ref":               "a $ref could not be resolved",
+	"extra-sibling-fields":         "fields alongside a $ref are ignored",
+	"spec-validation-error":        "a spec violation with no more specific rule",
+
+	// Paths and operations
+	"path-must-start-with-slash":    "path key does not start with a slash",
+	"conflicting-paths":             "two paths differ only by parameter name and cannot be told apart",
+	"path-parameters-mismatch":      "path template and declared path parameters disagree",
+	"path-parameter-required":       "a path parameter is not marked required",
+	"duplicate-operation-id":        "the same operationId is used by more than one operation",
+	"operation-responses-required":  "operation has no responses object",
+	"responses-required":            "responses object is missing",
+	"response-description-required": "response has no description",
+	"request-body-content-required": "request body has no content",
+
+	// Parameters and headers
+	"parameter-name-required":        "parameter name is missing",
+	"parameter-in-invalid":           "parameter location is not query, header, path or cookie",
+	"duplicate-parameter":            "the same parameter is declared more than once",
+	"parameter-content-single-entry": "parameter content must hold exactly one media type",
+	"header-content-single-entry":    "header content must hold exactly one media type",
+	"content-or-schema-exactly-one":  "parameter or header must use either content or schema, not both",
+	"name-forbidden":                 "header must not declare a name field",
+	"in-forbidden":                   "header must not declare an in field",
+	"serialization-method-invalid":   "style and explode combination is not valid for this parameter",
+
+	// Schemas
+	"schema-type-unsupported":                     "schema type is not a valid JSON Schema type",
+	"schema-items-required":                       "array schema is missing items",
+	"schema-pattern-regex-invalid":                "pattern is not a valid regular expression",
+	"read-only-write-only-mutually-exclusive":     "schema is both readOnly and writeOnly",
+	"additional-properties-both-forms-exclusive":  "additionalProperties is given as both a boolean and a schema",
+	"unevaluated-items-both-forms-exclusive":      "unevaluatedItems is given as both a boolean and a schema",
+	"unevaluated-properties-both-forms-exclusive": "unevaluatedProperties is given as both a boolean and a schema",
+	"duplicate-required-field":                    "the same property is listed more than once in required",
+	"default-violates-schema":                     "default value does not satisfy its own schema",
+	"example-violates-schema":                     "example does not satisfy its schema",
+	"default-required":                            "a default value is missing where one is required",
+
+	// Schema constraint coherence (oasdiff-native)
+	"multiple-of-not-positive":              "multipleOf is not greater than zero",
+	"subschemas-empty":                      "allOf, anyOf or oneOf is empty",
+	"minimum-exceeds-maximum":               "minimum is greater than maximum, so no value can validate",
+	"min-length-exceeds-max-length":         "minLength is greater than maxLength, so no value can validate",
+	"min-items-exceeds-max-items":           "minItems is greater than maxItems, so no array can validate",
+	"min-properties-exceeds-max-properties": "minProperties is greater than maxProperties, so no object can validate",
+	"min-contains-exceeds-max-contains":     "minContains is greater than maxContains, so no array can validate",
+	"enum-empty":                            "enum is empty, so no value can validate",
+	"const-not-in-enum":                     "const is not one of the enum values, so no value can validate",
+	"duplicate-enum-value":                  "enum lists the same value more than once",
+	"type-format-mismatch":                  "format belongs to a different type and is ignored",
+	"required-with-default":                 "a required parameter or property also has a default, which is never used",
+	"ambiguous-parameter-serialization":     "parameter type mixes a structured type with a scalar, so its serialization is ambiguous",
+
+	// Examples and links
+	"example-examples-mutually-exclusive":           "example and examples are both set",
+	"value-external-value-mutually-exclusive":       "example sets both value and externalValue",
+	"value-or-external-value-required":              "example sets neither value nor externalValue",
+	"operation-id-operation-ref-mutually-exclusive": "link sets both operationId and operationRef",
+	"operation-id-or-operation-ref-required":        "link sets neither operationId nor operationRef",
+	"url-identifier-mutually-exclusive":             "license sets both url and identifier",
+
+	// Security
+	"security-scheme-type-invalid":          "security scheme type is not valid",
+	"security-scheme-name-required":         "api key security scheme is missing its name",
+	"security-scheme-apikey-in-invalid":     "api key location is not query, header or cookie",
+	"security-scheme-http-scheme-invalid":   "http security scheme is missing its scheme",
+	"openid-connect-url-required":           "openIdConnect security scheme is missing its url",
+	"bearer-format-forbidden":               "bearerFormat is set on a non-bearer security scheme",
+	"flows-required":                        "oauth2 security scheme is missing its flows",
+	"flows-forbidden":                       "flows is set on a non-oauth2 security scheme",
+	"oauth-flow-authorization-url-required": "oauth flow is missing its authorization url",
+	"oauth-flow-token-url-required":         "oauth flow is missing its token url",
+	"oauth-flow-scopes-required":            "oauth flow is missing its scopes",
+	"authorization-url-forbidden":           "authorization url is set on a flow that does not use one",
+	"token-url-forbidden":                   "token url is set on a flow that does not use one",
+
+	// Servers, tags, webhooks
+	"server-url-required":         "server url is missing",
+	"server-url-template-invalid": "server url template is malformed or has an undeclared variable",
+	"duplicate-tag":               "the same tag name is declared more than once",
+	"webhook-nil":                 "webhooks holds an empty path item",
+}
+
+// versionGateRe matches the version-gate rule IDs kin emits for a field that
+// only exists in a later OpenAPI version, e.g. "const-field-for-3-1-plus".
+var versionGateRe = regexp.MustCompile(`^[a-z0-9-]+-field-for-(\d+)-(\d+)-plus$`)
+
+// versionGateDescription describes a version-gate rule, or returns "" when the
+// id is not one. Derived from the ID rather than listed per field so a new
+// version-gated field added upstream is described without a change here. The
+// finding's own text names the field.
+func versionGateDescription(id string) string {
+	m := versionGateRe.FindStringSubmatch(id)
+	if m == nil {
+		return ""
+	}
+	return "field is only valid in OpenAPI " + m[1] + "." + m[2] + " or later"
+}
+
+// RuleDescription returns a short description of what a validate rule reports,
+// or "" for an unknown ID.
+func RuleDescription(id string) string {
+	if d, ok := ruleDescriptions[id]; ok {
+		return d
+	}
+	return versionGateDescription(strings.TrimSpace(id))
+}

--- a/validate/rule_ids_test.go
+++ b/validate/rule_ids_test.go
@@ -44,3 +44,24 @@ func TestKnownRuleID_GatesUnregisteredCodes(t *testing.T) {
 	require.Equal(t, unknownValidationID, knownRuleID(unregistered), "an unregistered code is demoted")
 	require.Equal(t, "oauth-flow-scopes-required", knownRuleID("oauth-flow-scopes-required"), "a registered code passes through")
 }
+
+// Every rule the command can list has a description, so `oasdiff checks
+// validate` never prints a blank cell. A kin bump that adds a code fails
+// TestRuleIDs_MatchKinCatalog first; this then requires it to be described.
+func TestRuleDescriptions_CoverEveryRuleID(t *testing.T) {
+	for _, id := range RuleIDs() {
+		require.NotEmpty(t, RuleDescription(id), "rule %q has no description", id)
+	}
+}
+
+func TestRuleDescription_UnknownID(t *testing.T) {
+	require.Empty(t, RuleDescription("not-a-rule"))
+}
+
+// The version-gate description is derived from the ID, so a newly gated field
+// upstream is described without touching the table.
+func TestRuleDescription_VersionGateIsDerived(t *testing.T) {
+	require.Equal(t, "field is only valid in OpenAPI 3.1 or later", RuleDescription("const-field-for-3-1-plus"))
+	require.Equal(t, "field is only valid in OpenAPI 3.2 or later", RuleDescription("item-schema-field-for-3-2-plus"))
+	require.Equal(t, "field is only valid in OpenAPI 3.1 or later", RuleDescription("some-future-field-for-3-1-plus"))
+}

--- a/validate/rule_levels.go
+++ b/validate/rule_levels.go
@@ -1,0 +1,62 @@
+package validate
+
+import "github.com/oasdiff/oasdiff/checker"
+
+// Severities for the rules `oasdiff validate` can report.
+//
+// A rule's severity is a property of the rule, not of the individual finding:
+// each kin error type carries its own code, so the code determines the
+// severity. That makes this the single source of truth for both ends, the
+// runtime classification of a finding (severityForKinError) and the static
+// listing (`oasdiff checks validate`), which cannot then disagree.
+//
+// ERR is the default and is not listed: every kin Validate result is a spec
+// violation, so an unrecognised or newly added rule stays an error until
+// someone decides otherwise. Only the downgrades are recorded here.
+//
+// Deliberately left at ERR despite being downgrade candidates:
+// duplicate-operation-id violates the spec's uniqueness MUST and breaks code
+// generators that key method names off operationId.
+var ruleLevels = map[string]checker.Level{
+	// INFO: an example that doesn't match its schema is a documentation
+	// accuracy nit; the contract (the schema) is still valid.
+	"example-violates-schema": checker.INFO,
+
+	// WARN: structurally valid, but a portability or correctness risk.
+	//
+	// A default, unlike an example, is consumed at runtime by some tooling, so
+	// a mismatch there is a real risk.
+	"default-violates-schema": checker.WARN,
+	// Fields alongside a $ref are silently ignored in 3.0 rather than breaking
+	// the spec; the author's intent is lost, not the document.
+	"extra-sibling-fields": checker.WARN,
+	"conflicting-paths":    checker.WARN,
+	"duplicate-parameter":  checker.WARN,
+
+	// oasdiff's own SHOULD-level lints, which kin does not enforce. The spec
+	// still parses in every case; each is a correctness or portability risk.
+	DuplicateEnumValueID:              checker.WARN,
+	AmbiguousParameterSerializationID: checker.WARN,
+	RequiredWithDefaultID:             checker.WARN,
+	TypeFormatMismatchID:              checker.WARN,
+}
+
+// RuleLevel returns the severity of a validate rule.
+//
+// The version-gate rules (`<field>-field-for-3-1-plus` and friends) are WARN
+// as a family rather than one entry each, matched the same way
+// versionGateDescription describes them: a 3.1-only field in an older document
+// is a portability problem, not a structural break. Deriving them keeps a
+// newly gated field added upstream classified without a change here.
+//
+// An unknown id gets ERR, the same default an unrecognised error takes at
+// runtime.
+func RuleLevel(id string) checker.Level {
+	if level, ok := ruleLevels[id]; ok {
+		return level
+	}
+	if versionGateRe.MatchString(id) {
+		return checker.WARN
+	}
+	return checker.ERR
+}

--- a/validate/rule_levels_test.go
+++ b/validate/rule_levels_test.go
@@ -1,0 +1,138 @@
+package validate
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/oasdiff/oasdiff/formatters"
+
+	"github.com/oasdiff/oasdiff/checker"
+	"github.com/stretchr/testify/require"
+)
+
+// A downgrade keyed by an id no rule emits would never fire, and nothing else
+// would notice: RuleLevel would silently return ERR for the rule it was meant
+// to cover.
+func TestRuleLevels_KeysAreRegisteredRuleIDs(t *testing.T) {
+	for id := range ruleLevels {
+		require.True(t, slices.Contains(RuleIDs(), id),
+			"ruleLevels key %q is not a registered rule id", id)
+	}
+}
+
+func TestRuleLevel(t *testing.T) {
+	// Explicit downgrades.
+	require.Equal(t, checker.INFO, RuleLevel("example-violates-schema"))
+	require.Equal(t, checker.WARN, RuleLevel("default-violates-schema"))
+	require.Equal(t, checker.WARN, RuleLevel("conflicting-paths"))
+
+	// The version-gate family is derived from the id, not listed one by one,
+	// so a field gated upstream tomorrow is classified without a change here.
+	require.Equal(t, checker.WARN, RuleLevel("const-field-for-3-1-plus"))
+	require.Equal(t, checker.WARN, RuleLevel("webhooks-field-for-3-1-plus"))
+	require.NotContains(t, ruleLevels, "const-field-for-3-1-plus")
+
+	// Everything else is an error, including an id we've never seen: a spec
+	// violation stays an error until someone decides otherwise.
+	require.Equal(t, checker.ERR, RuleLevel("duplicate-operation-id"))
+	require.Equal(t, checker.ERR, RuleLevel("openapi-required"))
+	require.Equal(t, checker.ERR, RuleLevel("no-such-rule"))
+	require.Equal(t, checker.ERR, RuleLevel(""))
+}
+
+// The severity a finding carries has to be the one `oasdiff checks validate`
+// lists for its rule. These specs drive real kin errors through Validate, so
+// this pins the classification end to end rather than re-asserting the map.
+func TestValidate_FindingLevelsMatchTheRule(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		id   string
+		want checker.Level
+		spec string
+	}{
+		{
+			name: "example that violates its schema is a documentation nit",
+			id:   "example-violates-schema",
+			want: checker.INFO,
+			spec: `
+openapi: 3.0.0
+info: { title: t, version: "1" }
+paths: {}
+components:
+  schemas:
+    Age:
+      type: integer
+      example: "not-an-integer"
+`,
+		},
+		{
+			name: "default that violates its schema is consumed at runtime",
+			id:   "default-violates-schema",
+			want: checker.WARN,
+			spec: `
+openapi: 3.0.0
+info: { title: t, version: "1" }
+paths: {}
+components:
+  schemas:
+    Age:
+      type: integer
+      default: "not-an-integer"
+`,
+		},
+		{
+			name: "a 3.1-only field in a 3.0 document is a portability problem",
+			id:   "const-field-for-3-1-plus",
+			want: checker.WARN,
+			spec: `
+openapi: 3.0.0
+info: { title: t, version: "1" }
+paths: {}
+components:
+  schemas:
+    Fixed:
+      type: string
+      const: only-value
+`,
+		},
+		{
+			// oasdiff's own lints build findings directly rather than going
+			// through the kin error path, so they need their own guard: the
+			// listing showed "error" for these until they took their severity
+			// from the same map.
+			name: "an oasdiff-native lint carries the level the listing shows",
+			id:   DuplicateEnumValueID,
+			want: checker.WARN,
+			spec: `
+openapi: 3.0.0
+info: { title: t, version: "1" }
+paths: {}
+components:
+  schemas:
+    Color:
+      type: string
+      enum: [red, green, red]
+`,
+		},
+		{
+			name: "a missing title is a structural break",
+			id:   "info-title-required",
+			want: checker.ERR,
+			spec: `
+openapi: 3.0.0
+info: { version: "1" }
+paths: {}
+`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			findings := Validate(mustLoad(t, tc.spec), "spec.yaml")
+
+			idx := slices.IndexFunc(findings, func(f formatters.Finding) bool { return f.Id == tc.id })
+			require.GreaterOrEqual(t, idx, 0, "expected a %s finding, got %v", tc.id, findings)
+			require.Equal(t, tc.want, findings[idx].Level)
+			// The listing and the finding are the same classification.
+			require.Equal(t, RuleLevel(tc.id), findings[idx].Level)
+		})
+	}
+}

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -97,50 +97,11 @@ func flattenKinErrors(source string, err error) formatters.Findings {
 	return formatters.Findings{f}
 }
 
-// severityForKinError classifies a kin validation error into a severity.
-// The default is ERR: every kin Validate result is a spec violation, so
-// errors are the safe default and any kin cluster we don't recognise (or
-// a newly-typed one) stays an error. A few clusters are downgraded
-// because the spec still parses and the issue is a portability or
-// doc-accuracy concern rather than a structural break.
-//
-// The mapping is hardcoded for now. Per-rule severity customization (like
-// the changelog command's --severity-levels) can be layered on later, so
-// these classifications aren't engraved in stone.
-//
-// Deliberately kept as errors despite being downgrade candidates:
-// duplicate-operation-id violates the spec's uniqueness MUST and breaks
-// code generators that key method names off operationId.
+// severityForKinError classifies a kin validation error into a severity by
+// its rule id, so a finding carries exactly the severity `oasdiff checks
+// validate` lists for that rule. See ruleLevels for the classifications.
 func severityForKinError(err error) checker.Level {
-	// INFO: an example that doesn't match its schema is a documentation
-	// accuracy nit; the contract (the schema) is still valid. A default,
-	// by contrast, is consumed at runtime by some tooling, so a mismatch
-	// there is a real risk and stays a warning.
-	if sve, ok := errors.AsType[*openapi3.SchemaValueError](err); ok {
-		if sve.ValueKind == "example" {
-			return checker.INFO
-		}
-		return checker.WARN
-	}
-
-	// WARN: structurally valid but a portability or correctness risk.
-	if _, ok := errors.AsType[*openapi3.FieldVersionMismatchError](err); ok {
-		// e.g. a 3.1-only field in a doc that declares an older version.
-		return checker.WARN
-	}
-	if _, ok := errors.AsType[*openapi3.ExtraSiblingFieldsError](err); ok {
-		// Fields alongside a $ref are silently ignored in 3.0 rather than
-		// breaking the spec; the author's intent is lost, not the document.
-		return checker.WARN
-	}
-	if _, ok := errors.AsType[*openapi3.ConflictingPathsError](err); ok {
-		return checker.WARN
-	}
-	if _, ok := errors.AsType[*openapi3.DuplicateParameterError](err); ok {
-		return checker.WARN
-	}
-
-	return checker.ERR
+	return RuleLevel(knownRuleID(ruleIDForKinError(err)))
 }
 
 // dedupePreferringComponents groups findings by their underlying


### PR DESCRIPTION
The rule listing from #927. Split out of #1122, which now carries only the schema-constraint lints. The two are independent and can land in either order.

## The listings

`checks` is now one listing per rule set, and always names it:

- **`oasdiff checks changelog`** — the breaking-change and changelog rules.
- **`oasdiff checks validate`** — the rules `oasdiff validate` reports. New.

```
$ oasdiff checks validate
ID                                          DESCRIPTION                                                    LEVEL
additional-properties-both-forms-exclusive  additionalProperties is given as both a boolean and a schema   error
ambiguous-parameter-serialization           parameter type mixes a structured type with a scalar, so its
                                            serialization is ambiguous                                     warning
anchor-field-for-3-1-plus                   field is only valid in OpenAPI 3.1 or later                    warning
```

97 rules: 58 error, 38 warning, 1 info. Both listings render through the shared formatters (text / json / yaml), so `--format` validation and rendering stay consistent with the rest of the CLI.

## Bare `oasdiff checks` no longer lists anything

It named one rule set by omission, which stopped being tenable once a second one existed. It now prints the help, and `oasdiff checks --format json` fails with an unknown flag rather than quietly producing nothing.

**This is a breaking CLI change.** w3 generates the website's rule catalog with the bare command, and its deploy gate fails when the catalog is stale; oasdiff/w3#474 moves it to the subcommand and is held as a draft until this ships and `.oasdiff-version` is bumped.

## Flags differ per listing

Which they could not while one command served both:

| | `--format` | `--severity` | `--tags` | `--lang` |
|---|---|---|---|---|
| `checks changelog` | ✅ | ✅ | ✅ | ✅ |
| `checks validate` | ✅ | ✅ | ✗ | ✗ |

`--tags` is changelog-only because validate rules carry none, and `--lang` because their descriptions are plain English: a validate finding takes its message from the parser at runtime, so there is no localized message file to hang them off. They are oasdiff's own, since kin's `CodedError` carries only a code.

The severity filter is now one helper shared by both. It switches on the level rather than on `Level.String()`, because the flag takes the short forms and `warn` is not `warning`.

## Severity is a property of the rule

`--severity` works on the validate listing because a validate rule has a determinate severity, which I initially thought it did not.

`severityForKinError` switched on the error type, and each type carries its own code, so the code already determined the severity. The one branch that looked runtime-dependent, `SchemaValueError` splitting on `ValueKind`, is really two types with two codes: `ExampleViolatesSchema` and `DefaultViolatesSchema`. So `ruleLevels` is now the single source of truth for both the runtime classification and the listing, and `severityForKinError` is a lookup on the finding's own rule id, dropping the type switch that re-derived what the code lookup had already established.

The version-gate rules (`<field>-field-for-3-1-plus`) are matched by the same regex that describes them rather than listed one by one, so a field gated upstream tomorrow is classified without a change here. All 29 of kin's current gate codes match it.

**The listing found a real bug on its way in.** oasdiff's own lints built findings directly with `Level: checker.WARN` inline, bypassing the map, so the listing showed `ambiguous-parameter-serialization` as `error` while the lint emitted `warning`. All four now take their level from the map.

## Descriptions

Plain English, not localized, as above. The 30 version-gate rules are described from the ID rather than listed one by one, so a newly gated field added upstream is described without a change here. `TestRuleDescriptions_CoverEveryRuleID` requires a description for every ID, so a kin bump that adds a code cannot land undescribed (it already has to pass `TestRuleIDs_MatchKinCatalog` to be registered at all).

## An unknown subcommand fails

`oasdiff checks bogus` would have printed the help and exited **0**, while `oasdiff bogus` exits 100. Same mistake, different result by depth, and a script could not tell it from success.

Cobra returns `flag.ErrHelp` for a non-runnable command *before* validating `Args` (`command.go:956` vs `969` in v1.10.2), so `cobra.NoArgs` on a parent never runs. The parent therefore carries a `RunE` that only prints the help, which is what makes `Args` reachable, plus `DisableFlagsInUseLine` so the usage does not advertise flags that live on the subcommands. The message matches the top-level form exactly:

```
Error: unknown command "bogus" for "oasdiff checks"
Run 'oasdiff checks --help' for usage.
```

This is a documented workaround, not a design choice: reported upstream since 2020 (spf13/cobra#1156, also #706, #981, #2130), with spf13/cobra#2167 proposing `ErrorOnUnknownSubcommand` and awaiting review since 2024. Both threads upvoted rather than opening a fifth duplicate. `noSubcommandArgs` carries the removal recipe, at which point the usage block reads `oasdiff checks [command]` alone.

An unknown *flag* still prints the usage block, matching `flatten --bogus` and every other subcommand: different error, and the usage is what you want to see for it.

## Output surface

`formatters.Check`'s optional fields are `omitempty`, since the validate rules have an id, a description and a level but no direction, area, kind or action. **No change to the existing `checks` output**: all 506 changelog rules populate every field, verified byte-for-byte against the committed website catalog, and `TestChecks_AllRuleFieldsPopulated` pins that at the source so a future rule with a missing field fails there rather than silently dropping it from machine output.

`RenderChecks` is untouched.

## Docs

`CHECKS.md` opens with the two listings and gains a validate section; `BREAKING-CHANGES.md`, `CUSTOMIZING-CHECKS.md` and the command index in `docs/README.md` move to the explicit form.

## Verification

Full suite green, golangci-lint 0 issues. Six existing tests moved to `checks changelog`.

Every claim above was checked against a negative control where one applies: flipping `example-violates-schema` to WARN and removing the version-gate branch both fail the severity tests; the two unknown-command messages are asserted against each other rather than against a hardcoded string alone.