### PR TITLE
Guard the operations list against kin's fixed-field set

### DIFF
--- a/diff/operations_list_test.go
+++ b/diff/operations_list_test.go
@@ -1,0 +1,23 @@
+package diff
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/require"
+)
+
+// The operations list decides both what gets diffed and the order it is
+// reported in, so it has to stay a superset of the methods kin gives a
+// dedicated Path Item field.
+//
+// A method kin promotes to a fixed field and this list has not caught up with
+// is still diffed, since methodsToCompare falls back to treating it as custom,
+// but it lands in the sorted tail rather than in a position chosen here. This
+// fails when that happens so the position is picked deliberately.
+func TestOperations_CoverKinFixedFields(t *testing.T) {
+	for _, method := range openapi3.PathItemMethods() {
+		require.Contains(t, operations, method,
+			"kin has a dedicated Path Item field for %s; add it to `operations` in the position diff should report it", method)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -49,3 +49,9 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/wI2L/jsondiff v0.7.1
 )
+
+// TEMPORARY -- remove before merging.
+// Pins kin-openapi to the branch of getkin/kin-openapi#1241, which exports
+// PathItemMethods. Drop this and move the requirement to a release that
+// includes it.
+replace github.com/getkin/kin-openapi => github.com/oasdiff/kin-openapi v0.0.0-20260806105533-afc811ccf732

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,6 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
-github.com/getkin/kin-openapi v0.146.1-0.20260805064526-5d526a9e1f7e h1:xyQ9tUmmlERJ5EC/R+gSRphvejYcmvjpRwr4fNiscxU=
-github.com/getkin/kin-openapi v0.146.1-0.20260805064526-5d526a9e1f7e/go.mod h1:3BH9M9XDe/y9M5DSvEocVYAYq1w0qrhJHjC/vZi0AaY=
 github.com/go-openapi/jsonpointer v0.22.5 h1:8on/0Yp4uTb9f4XvTrM2+1CPrV05QPZXu+rvu2o9jcA=
 github.com/go-openapi/jsonpointer v0.22.5/go.mod h1:gyUR3sCvGSWchA2sUBJGluYMbe1zazrYWIkWPjjMUY0=
 github.com/go-openapi/swag/jsonname v0.25.5 h1:8p150i44rv/Drip4vWI3kGi9+4W9TdI3US3uUYSFhSo=
@@ -39,6 +37,8 @@ github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/oasdiff/kin-openapi v0.0.0-20260806105533-afc811ccf732 h1:jaV9BNivU6wqY2+RKv96AJKqVe0ecHvVGt/oZ4YzP/s=
+github.com/oasdiff/kin-openapi v0.0.0-20260806105533-afc811ccf732/go.mod h1:3BH9M9XDe/y9M5DSvEocVYAYq1w0qrhJHjC/vZi0AaY=
 github.com/oasdiff/yaml v0.1.1 h1:6nHx+pn9gBRM6YpBlFZFQGCCd1nuvqOBtTD3KKTgGxY=
 github.com/oasdiff/yaml v0.1.1/go.mod h1:EYJNoyktvWMJ0Hmhx+6qTaqMOsalUaRGT8Sj1hNcegU=
 github.com/oasdiff/yaml3 v0.0.14 h1:aLJee3hxBK2H5wdXd9iPcIXb93Nty1Ge0pT171eHtkw=


### PR DESCRIPTION
Follow-up to #1135, and companion to **getkin/kin-openapi#1241**.

**Draft: blocked on kin#1241.** It exports `PathItemMethods()`, which this test calls, so `go.mod` carries a temporary `replace` until #1241 merges and a release includes it. Nothing else here depends on it.

Stacked on #1135; retarget to `main` once that merges.

## What it guards

`operations` in `diff/operations_diff.go` decides two things: which methods get diffed, and the order they are reported in. kin owns which methods have a dedicated Path Item Object field, and until #1241 that set was unexported, so the only way to track it was to write the list out again and remember to update it. #1240 is what made that concrete: OpenAPI 3.2 promoted QUERY, and every consumer carrying its own list had to notice.

The failure is quiet rather than loud. A method kin promotes that this list has not caught up with is still diffed, because `methodsToCompare` treats anything it does not recognise as custom, so it is appended to the sorted tail. Nothing breaks; the method is simply reported in a position nobody chose. The test fails in that case so the position is picked deliberately.

```
kin has a dedicated Path Item field for QUERY; add it to `operations`
in the position diff should report it
```

That is the actual output, from deleting the QUERY entry.

## What it deliberately does not do

Classification still reads the local list:

```go
if !slices.Contains(operations, method) { /* custom */ }
```

Switching that to `PathItemMethods()` looks like the tidier change and is the wrong one. A method kin has promoted but this list has not caught up with would then be excluded from the custom set *and* absent from `operations`, so it would not be diffed at all. Today's mismatch costs an odd ordering; that version would cost a missed operation, which for a breaking-change tool means reporting a breaking change as safe.

So kin is the authority for the *check*, and the local list stays the authority for *what is compared*.
