### PR TITLE
review: identify the uploading client in the request User-Agent

### DIFF
--- a/internal/open_review.go
+++ b/internal/open_review.go
@@ -198,6 +198,22 @@ func specSetDocsAndSources(specs []*load.SpecInfo) ([]*openapi3.T, map[string]st
 	return docs, texts
 }
 
+// uploadUserAgent identifies the uploading client to the server's request
+// logs: the CLI version, and the CI platform when one is declared. This is
+// the only server-visible attribution for an encrypted review; everything
+// else rides inside the ciphertext (see review.Payload), which is the point.
+func uploadUserAgent() string {
+	ua := "oasdiff-cli/" + build.Version
+	platform := os.Getenv("PLATFORM")
+	if platform == "" && os.Getenv("GITHUB_ACTIONS") == "true" {
+		platform = "github-actions"
+	}
+	if platform != "" {
+		ua += " (" + platform + ")"
+	}
+	return ua
+}
+
 // postEncryptedReview uploads the opaque ciphertext blob to the configured
 // server (see oasdiffSiteURL) and returns the assigned review id plus its TTL
 // expiry. The request is anonymous (no credentials): the server stores a blob
@@ -214,7 +230,7 @@ func postEncryptedReview(blob []byte) (string, time.Time, error) {
 		return "", time.Time{}, err
 	}
 	req.Header.Set("Content-Type", "application/octet-stream")
-	req.Header.Set("User-Agent", "oasdiff-cli")
+	req.Header.Set("User-Agent", uploadUserAgent())
 
 	client := &http.Client{Timeout: 5 * time.Minute}
 	resp, err := client.Do(req)
@@ -289,7 +305,7 @@ func uploadAuthenticatedReview(token string, metaEntries []string, blob, key []b
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", "oasdiff-cli")
+	req.Header.Set("User-Agent", uploadUserAgent())
 
 	client := &http.Client{Timeout: 5 * time.Minute}
 	resp, err := client.Do(req)

--- a/internal/open_review_useragent_test.go
+++ b/internal/open_review_useragent_test.go
@@ -1,0 +1,27 @@
+package internal
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/oasdiff/oasdiff/build"
+)
+
+func TestUploadUserAgent(t *testing.T) {
+	t.Setenv("PLATFORM", "")
+	t.Setenv("GITHUB_ACTIONS", "")
+	if got := uploadUserAgent(); got != "oasdiff-cli/"+build.Version {
+		t.Fatalf("plain CLI: %q", got)
+	}
+
+	t.Setenv("GITHUB_ACTIONS", "true")
+	if got := uploadUserAgent(); !strings.HasSuffix(got, " (github-actions)") {
+		t.Fatalf("runner: %q", got)
+	}
+
+	// An explicit platform (set by wrappers) wins over runner detection.
+	t.Setenv("PLATFORM", "github-action")
+	if got := uploadUserAgent(); !strings.HasSuffix(got, " (github-action)") {
+		t.Fatalf("explicit platform: %q", got)
+	}
+}


### PR DESCRIPTION
The upload sent User-Agent: oasdiff-cli with no version, so the server cannot tell client versions apart in its request logs. That matters for operating the service: diagnosing a version-specific upload problem, knowing when an old client has aged out, and understanding which versions are in use. The version/platform pair inside the review bundle (#1113) cannot serve this, because it is encrypted and the server rightly cannot read it.

The UA becomes oasdiff-cli/<version>, plus the CI platform when one is declared (the PLATFORM variable, or github-actions inferred from the standard GITHUB_ACTIONS env). Nothing identifying is added; this names the client software, not the user. Applies to all three upload paths. Unit test covers the three UA shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)